### PR TITLE
build locally - signed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ r*.json
 r*.xml
 junit.xml
 .vscode/
+tools/

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+# echo "Running from directory ${BASEDIR}"
+export ORIGINAL_DIR=$(pwd)
+# cd "${BASEDIR}"
+
+
+#--------------------------------------------------------------------------
+#
+# Set Colors
+#
+#--------------------------------------------------------------------------
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#--------------------------------------------------------------------------
+#
+# Headers and Logging
+#
+#--------------------------------------------------------------------------
+underline() { printf "${underline}${bold}%s${reset}\n" "$@"
+}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@"
+}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@"
+}
+debug() { printf "${white}%s${reset}\n" "$@"
+}
+info() { printf "${white}➜ %s${reset}\n" "$@"
+}
+success() { printf "${green}✔ %s${reset}\n" "$@"
+}
+error() { printf "${red}✖ %s${reset}\n" "$@"
+}
+warn() { printf "${tan}➜ %s${reset}\n" "$@"
+}
+bold() { printf "${bold}%s${reset}\n" "$@"
+}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@"
+}
+
+
+#--------------------------------------------------------------------------
+# 
+# Main script logic
+#
+#--------------------------------------------------------------------------
+
+
+#--------------------------------------------------------------------------
+# Check that the ../framework is present.
+h2 "Making sure the openapi yaml file is available..."
+if [[ ! -e "../framework" ]]; then
+    error "../framework is not present. Clone the framework repository."
+    info "The openapi.yaml file from the framework repository is needed to generate a go client for the rest API"
+    exit 1
+fi
+
+if [[ ! -e "../framework/openapi.yaml" ]]; then 
+    error "File ../framework/openapi.yaml is not found."
+    info "The openapi.yaml file from the framework repository is needed to generate a go client for the rest API"
+    exit 1
+fi
+success "OK"
+
+#--------------------------------------------------------------------------
+# Create a temporary folder which is never checked in.
+h2 "Making sure the tools folder is present."
+mkdir -p tools
+rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to ensure the tools folder is present. rc=${rc}" ; exit 1 ; fi
+success "OK"
+
+#--------------------------------------------------------------------------
+# Download the open api generator tool if we've not got it already.
+export OPENAPI_GENERATOR_CLI_VERSION="6.2.0"
+export OPENAPI_GENERATOR_CLI_JAR=${BASEDIR}/tools/openapi-generator-cli-${OPENAPI_GENERATOR_CLI_VERSION}.jar
+if [[ ! -e ${OPENAPI_GENERATOR_CLI_JAR} ]]; then
+    info "The openapi generator tool is not available, so download it."
+
+    which wget 2>&1 > /dev/null
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then
+        info "The wget tool is not available. Install it and try again."
+        exit 1
+    fi
+
+    export OPENAPI_GENERATOR_CLI_SITE="https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli"
+    wget ${OPENAPI_GENERATOR_CLI_SITE}/${OPENAPI_GENERATOR_CLI_VERSION}/openapi-generator-cli-${OPENAPI_GENERATOR_CLI_VERSION}.jar \
+    -O ${OPENAPI_GENERATOR_CLI_JAR}
+    rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to download the open api generator tool. rc=${rc}" ; exit 1 ; fi
+    success "Downloaded OK"
+fi
+
+#--------------------------------------------------------------------------
+# Invoke the generator
+h2 "Generate the openapi client go code..."
+./genapi.sh 2>&1 > tools/generate-log.txt
+rc=$? ; if [[ "${rc}" != "0" ]]; then cat tools/generate-log.txt ; error "Failed to generate the code from the yaml file. rc=${rc}" ; exit 1 ; fi
+rm -f tools/generate-log.txt
+success "Code generation OK"
+
+#--------------------------------------------------------------------------
+# Invoke the generator again with different parameters
+h2 "Generate the openapi client go code... part II"
+./generate.sh 2>&1 > tools/generate-log.txt
+rc=$? ; if [[ "${rc}" != "0" ]]; then cat tools/generate-log.txt ; error "Failed to generate II the code from the yaml file. rc=${rc}" ; exit 1 ; fi
+rm -f tools/generate-log.txt
+success "Code generation part II - OK"
+
+#--------------------------------------------------------------------------
+# Build the executables
+h2 "Cleaning the binaries out..."
+make clean
+rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to build binary executable galasactl programs. rc=${rc}" ; exit 1 ; fi
+success "Binaries cleaned up - OK"
+
+h2 "Building new binaries..."
+make all
+rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to build binary executable galasactl programs. rc=${rc}" ; exit 1 ; fi
+success "New binaries built - OK"
+
+#--------------------------------------------------------------------------
+h2 "Use the results.."
+info "Binary executable programs are found in the 'bin' folder."
+ls bin

--- a/genapi.sh
+++ b/genapi.sh
@@ -1,1 +1,46 @@
-java -jar ~/openapi/openapi-generator-cli.jar generate -i ../framework/openapi.yaml -g go -o pkg/galasaapi --additional-properties=packageName=galasaapi --additional-properties=isGoSubmodule=true
+#!/usr/bin/env bash
+
+# Where is this script executing from ? Lets find out...
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+export ORIGINAL_DIR=$(pwd)
+cd "${BASEDIR}"
+
+# Allow an environment variable to over-ride the location of the openapi generator cli tool
+# otherwise set a default.
+if [[ -z $OPENAPI_GENERATOR_CLI_JAR ]]; then
+    export OPENAPI_GENERATOR_CLI_JAR=~/openapi/openapi-generator-cli.jar
+    echo "The location of the open generator jar is not specified. Defaulting it to ${OPENAPI_GENERATOR_CLI_JAR}"
+    echo "Set the OPENAPI_GENERATOR_CLI_JAR environment variable to over-ride this setting."
+    exit 1
+fi
+
+# Make sure that the openapi generator cli tool is present where we expect.
+if [[ ! -e ${OPENAPI_GENERATOR_CLI_JAR} ]]; then
+    echo "The openapi generator is not found at ${OPENAPI_GENERATOR_CLI_JAR}."
+    echo "Download it and set the OPENAPI_GENERATOR_CLI_JAR environment variable to point to it."
+    exit 1
+fi
+
+export OPENAPI_YAML_FILE="../framework/openapi.yaml"
+
+if [[ ! -e ${OPENAPI_YAML_FILE} ]]; then  
+    echo "This build requires that the galasa.dev/framework repository is checked-out to ${BASEDIR}"
+    exit 1
+fi
+
+# Use the tool to generate our api client code.
+java -jar ${OPENAPI_GENERATOR_CLI_JAR} generate \
+-i ${OPENAPI_YAML_FILE} \
+-g go \
+-o pkg/galasaapi \
+--additional-properties=packageName=galasaapi \
+--additional-properties=isGoSubmodule=true
+
+rc=$?
+if [[ "${rc}" != "0" ]]; then
+    echo "The openapi client code generator failed. rc=${rc}"
+    exit 1
+fi
+
+echo "Folder ${BASEDIR}/cli/pkg/galasaapi has been generated with content inside"
+echo "Note: This source code is never checked-in to github."

--- a/generate.sh
+++ b/generate.sh
@@ -1,4 +1,40 @@
-java -jar ~/openapi/openapi-generator-cli.jar generate -i ../framework/openapi.yaml -g go -o pkg/galasaapi --additional-properties=packageName=galasaapi
+#!/usr/bin/env bash
+
+# Where is this script executing from ? Lets find out...
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+export ORIGINAL_DIR=$(pwd)
+cd "${BASEDIR}"
+
+# Allow an environment variable to over-ride the location of the openapi generator cli tool
+# otherwise set a default.
+if [[ -z $OPENAPI_GENERATOR_CLI_JAR ]]; then
+    export OPENAPI_GENERATOR_CLI_JAR=~/openapi/openapi-generator-cli.jar
+    echo "The location of the open generator jar is not specified. Defaulting it to ${OPENAPI_GENERATOR_CLI_JAR}"
+    echo "Set the OPENAPI_GENERATOR_CLI_JAR environment variable to over-ride this setting."
+    exit 1
+fi
+
+# OpenAPigen should be 6.0.1
+
+# Make sure that the openapi generator cli tool is present where we expect.
+if [[ ! -e ${OPENAPI_GENERATOR_CLI_JAR} ]]; then
+    echo "The openapi generator is not found at ${OPENAPI_GENERATOR_CLI_JAR}."
+    echo "Download it and set the OPENAPI_GENERATOR_CLI_JAR environment variable to point to it."
+    exit 1
+fi
+
+export OPENAPI_YAML_FILE="../framework/openapi.yaml"
+
+if [[ ! -e ${OPENAPI_YAML_FILE} ]]; then  
+    echo "This build requires that the galasa.dev/framework repository is checked-out to ${BASEDIR}"
+    exit 1
+fi
+
+java -jar ${OPENAPI_GENERATOR_CLI_JAR} generate \
+-i ${OPENAPI_YAML_FILE} \
+-g go \
+-o pkg/galasaapi \
+--additional-properties=packageName=galasaapi
 
 rm pkg/galasaapi/go.mod
 rm pkg/galasaapi/go.sum


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>


This change is part of galasa-dev/projectmanagement#1149

- [x] Added `build-locally.sh`
- [x] Allowed the openapi generator jar to live anywhere, under control of an env var.
- [x] `build-locally` downloads the open api generator regardless.
- [x] Checks added to make sure ../framework exists before it is used.
- [x] Readme updated.   
- [x] Error if 'wget' isn't available.

----

## Example build output from the `build-locally.sh` script

```text
Making sure the openapi yaml file is available...
✔ OK

Making sure the tools folder is present.
✔ OK
➜ The openapi generator tool is not available, so download it.
--2022-10-28 16:11:11--  https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.2.0/openapi-generator-cli-6.2.0.jar
Resolving repo1.maven.org (repo1.maven.org)... 199.232.192.209, 199.232.196.209
Connecting to repo1.maven.org (repo1.maven.org)|199.232.192.209|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 25850195 (25M) [application/java-archive]
Saving to: ‘/Users/mcobbett/builds/galasa/code/external/galasa-dev/cli/tools/openapi-generator-cli.jar’

/Users/mcobbett/builds/galasa/code/e 100%[=====================================================================>]  24.65M  4.23MB/s    in 5.9s    

2022-10-28 16:11:18 (4.20 MB/s) - ‘/Users/mcobbett/builds/galasa/code/external/galasa-dev/cli/tools/openapi-generator-cli.jar’ saved [25850195/25850195]

✔ Downloaded OK

Generate the openapi client go code...
✔ Code generation OK

Generate the openapi client go code... part II
✔ Code generation part II - OK

Cleaning the binaries out...
rm -rf bin
✔ Binaries cleaned up - OK

Building new binaries...
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/galasactl-linux-amd64 ./cmd/galasactl
CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o bin/galasactl-windows-amd64.exe ./cmd/galasactl
CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o bin/galasactl-darwin-amd64 ./cmd/galasactl
CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o bin/galasactl-darwin-arm64 ./cmd/galasactl
CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -o bin/galasactl-linux-s390x ./cmd/galasactl
✔ New binaries built - OK

Use the results..
➜ Binary executable programs are found in the 'bin' folder.
galasactl-darwin-amd64          galasactl-linux-amd64           galasactl-windows-amd64.exe
galasactl-darwin-arm64          galasactl-linux-s390x
```

If you already have the tool downloaded, then it won't get it again.