### PR TITLE
Better error message + add 1st unit test 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ r*.xml
 junit.xml
 .vscode/
 tools/
+build/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,14 @@
 # (c) Copyright IBM Corp. 2021.
 #
 
-all: bin/galasactl-linux-amd64 bin/galasactl-windows-amd64.exe bin/galasactl-darwin-amd64 bin/galasactl-darwin-arm64 bin/galasactl-linux-s390x
+all: tests bin/galasactl-linux-amd64 bin/galasactl-windows-amd64.exe bin/galasactl-darwin-amd64 bin/galasactl-darwin-arm64 bin/galasactl-linux-s390x
+
+tests: ./cmd/galasactl/*.go ./pkg/api/*.go ./pkg/cmd/*.go ./pkg/utils/*.go
+	mkdir -p build
+	go test -v ./pkg/utils/* -cover -coverprofile=build/coverage.out
+	go tool cover -html=build/coverage.out -o build/coverage.html
+	go tool cover -func=build/coverage.out > build/coverage.txt
+	cat build/coverage.txt
 
 bin/galasactl-linux-amd64 : ./cmd/galasactl/*.go ./pkg/api/*.go ./pkg/cmd/*.go ./pkg/utils/*.go
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/galasactl-linux-amd64 ./cmd/galasactl

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -160,6 +160,10 @@ rm -f tools/generate-log.txt
 success "Code generation part II - OK"
 
 #--------------------------------------------------------------------------
+# Invoke unit tests
+
+
+#--------------------------------------------------------------------------
 # Build the executables
 if [[ "${build_type}" == "clean" ]]; then
     h2 "Cleaning the binaries out..."

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cobra v1.1.3
+	github.com/stretchr/testify v1.8.1 // indirect
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -132,6 +133,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -167,8 +169,14 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
@@ -302,8 +310,11 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/utils/testStream.go
+++ b/pkg/utils/testStream.go
@@ -35,14 +35,18 @@ func ValidateStream(streams []string, stream string) error {
 	// Build the error message.
 	var errorMsg = ""
 	if len(streams) < 1 {
-		template := "Stream \"%s\" is not found in the ecosystem. There are no streams set up."
+		template := "Stream \"%s\" is not found in the ecosystem. There are no streams set up. " +
+			"Ask your Galasa system administrator to add a new stream with the desired name."
 		errorMsg = fmt.Sprintf(template, stream)
 	} else {
-		template := "Stream \"%s\" is not found in the ecosystem. Valid streams are:%s"
+		template := "Stream \"%s\" is not found in the ecosystem. Valid streams are:%s. " +
+			"Try again using a valid stream, or ask your Galasa system administrator to " +
+			"add a new stream with the desired name."
 		var buffer strings.Builder
 		for _, s := range streams {
-			buffer.WriteString(" ")
+			buffer.WriteString(" '")
 			buffer.WriteString(s)
+			buffer.WriteString("'")
 		}
 		errorMsg = fmt.Sprintf(template, stream, buffer.String())
 	}

--- a/pkg/utils/testStream.go
+++ b/pkg/utils/testStream.go
@@ -1,13 +1,12 @@
 /*
-*  Licensed Materials - Property of IBM
-*
-* (c) Copyright IBM Corp. 2021.
-*/
+ * Copyright contributors to the Galasa project
+ */
 
 package utils
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/galasa.dev/cli/pkg/galasaapi"
@@ -15,7 +14,7 @@ import (
 
 func FetchTestStreams(apiClient *galasaapi.APIClient) []string {
 	cpsProperty, _, err := apiClient.ConfigurationPropertyStoreAPIApi.GetCpsNamespaceCascadeProperty(nil, "framework", "test", "streams").Execute()
-	if (err != nil) {
+	if err != nil {
 		panic(err)
 	}
 
@@ -26,12 +25,27 @@ func FetchTestStreams(apiClient *galasaapi.APIClient) []string {
 	return strings.Split(*cpsProperty.Value, ",")
 }
 
-func ValidateStream(streams []string, stream string) (error) {
-    for _, s := range streams {
-        if s == stream {
-            return nil
-        }
-    }
+func ValidateStream(streams []string, stream string) error {
+	for _, s := range streams {
+		if s == stream {
+			return nil
+		}
+	}
 
-    return errors.New("Stream \"" + stream + "\" is missing from ecosystem")
+	// Build the error message.
+	var errorMsg = ""
+	if len(streams) < 1 {
+		template := "Stream \"%s\" is not found in the ecosystem. There are no streams set up."
+		errorMsg = fmt.Sprintf(template, stream)
+	} else {
+		template := "Stream \"%s\" is not found in the ecosystem. Valid streams are:%s"
+		var buffer strings.Builder
+		for _, s := range streams {
+			buffer.WriteString(" ")
+			buffer.WriteString(s)
+		}
+		errorMsg = fmt.Sprintf(template, stream, buffer.String())
+	}
+
+	return errors.New(errorMsg)
 }

--- a/pkg/utils/testStream_test.go
+++ b/pkg/utils/testStream_test.go
@@ -18,7 +18,9 @@ func TestValidateStreamFound(t *testing.T) {
 
 func TestValidateStreamNotFoundNormal(t *testing.T) {
 	err := ValidateStream(streams, "apple")
-	expected := "Stream \"apple\" is not found in the ecosystem. Valid streams are: bsf prod"
+	expected := "Stream \"apple\" is not found in the ecosystem. Valid streams are: 'bsf' 'prod'. " +
+		"Try again using a valid stream, or ask your Galasa system administrator to " +
+		"add a new stream with the desired name."
 	if assert.NotNil(t, err, "ValidateStream found a stream where it should have returned an error message.") {
 		errorString := err.Error()
 		assert.Equal(t, expected, errorString, "Validate didn't fail with the correct response.")
@@ -28,7 +30,8 @@ func TestValidateStreamNotFoundNormal(t *testing.T) {
 func TestValidateStreamNotFoundNoStreamsToFind(t *testing.T) {
 	emptyStreams := []string{}
 	err := ValidateStream(emptyStreams, "orange")
-	expected := "Stream \"orange\" is not found in the ecosystem. There are no streams set up."
+	expected := "Stream \"orange\" is not found in the ecosystem. There are no streams set up. " +
+		"Ask your Galasa system administrator to add a new stream with the desired name."
 	if assert.NotNil(t, err) {
 		errorString := err.Error()
 		assert.Equal(t, expected, errorString, "Validate didn't fail with the correct response.")

--- a/pkg/utils/testStream_test.go
+++ b/pkg/utils/testStream_test.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var streams = []string{"bsf", "prod"}
+
+func TestValidateStreamFound(t *testing.T) {
+	actual := ValidateStream(streams, "prod")
+	assert.Nil(t, actual, "Validate didn't find the correct stream!")
+}
+
+func TestValidateStreamNotFoundNormal(t *testing.T) {
+	err := ValidateStream(streams, "apple")
+	expected := "Stream \"apple\" is not found in the ecosystem. Valid streams are: bsf prod"
+	if assert.NotNil(t, err, "ValidateStream found a stream where it should have returned an error message.") {
+		errorString := err.Error()
+		assert.Equal(t, expected, errorString, "Validate didn't fail with the correct response.")
+	}
+}
+
+func TestValidateStreamNotFoundNoStreamsToFind(t *testing.T) {
+	emptyStreams := []string{}
+	err := ValidateStream(emptyStreams, "orange")
+	expected := "Stream \"orange\" is not found in the ecosystem. There are no streams set up."
+	if assert.NotNil(t, err) {
+		errorString := err.Error()
+		assert.Equal(t, expected, errorString, "Validate didn't fail with the correct response.")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

This PR implements this story: https://github.com/galasa-dev/projectmanagement/issues/1236

----
Old output:
```
2022/11/07 12:37:07 Galasa CLI - Assemble tests
2022/11/07 12:37:07 Stream "XXXXX" is missing from ecosystem
```

New output:
```
2022/11/07 12:55:36 Galasa CLI - Assemble tests
2022/11/07 12:55:36 Stream "XXXXX" is not found in the ecosystem. Valid streams are: 'SIMBANK' 'DEVCAMP' 'EXAMPLE'. Try again using a valid stream, or ask your Galasa system administrator to add a new stream with the desired name.
```

- [x] Added unit test to check that ValidateStreams function does what it should
- [x] Added building of better error message when you don't specify a stream.
- [x] Added unit tests to check that the new error message is ok.
