### PR TITLE
CLI builds fail with error

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -5,7 +5,7 @@
 BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
 # echo "Running from directory ${BASEDIR}"
 export ORIGINAL_DIR=$(pwd)
-# cd "${BASEDIR}"
+cd "${BASEDIR}"
 
 
 #--------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

The script was not in the correct folder to do relative checking for a dependency.
Fixed.