### PR TITLE
Failing to resolve bootstrap URL better error message and doc limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,5 +127,10 @@ Full syntax, with descriptions of every parameter is available [here](./docs/gen
 ### Errors
 See [here](./docs/generated/errors-list.md) for a list of error messages the `galasactl` tool can output.
 
+### Known limitations
+- Go programs can sometimes struggle to resolve DNS names, especially when a working over a virtual private network (VPN). In such situations, you may notice that a bootstrap file cannot be found with `galasactl` but can be found by a desktop browser, or curl command.
+In such situations we recommend that you manually add the host detail to the `/etc/hosts` file, 
+to avoid DNS being involved in the resolution mechanism.
+
 ## Building locally
 To build the cli tools locally, use the `./build-locally.sh --help` script for instructions.

--- a/docs/generated/errors-list.md
+++ b/docs/generated/errors-list.md
@@ -4,7 +4,7 @@ The `galasactl` tool can generate the following errors:
 - GAL1001E: Unsupported bootstrap URL {}. Acceptable values start with 'http' or 'https'
 - GAL1002E: Bootstrap url does not end in '/bootstrap'. Bootstrap url is {}
 - GAL1003E: Bootstrap contents is badly formed. Bootstrap is at {}. Reason is: {}
-- GAL1004E: Failed to load the bootstrap from {}. Reason is {}
+- GAL1004E: Failed to load the bootstrap from {}. Reason is {}. If the URL is not resolving, try adding the hostname to your /etc/hosts file. This might especially be needed if communicating over a VPN connection.
 - GAL1005E: Failed to write to 'throttle' file {}. Reason is {}
 - GAL1006E: The submit command does not support mixing of the test selection flags and a portfolio
 - GAL1007E: Failed to create report yaml file {}. Reason is {}

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -57,11 +57,10 @@ var (
 	// A map of all the messages. Indexed by ordinal number.
 	GALASA_ALL_MESSAGES = make(map[int]*MessageType)
 
-	GALASA_ERROR_UNSUPPORTED_BOOTSTRAP_URL = NewMessageType("GAL1001E: Unsupported bootstrap URL %s. Acceptable values start with 'http' or 'https'", 1001)
-
+	GALASA_ERROR_UNSUPPORTED_BOOTSTRAP_URL      = NewMessageType("GAL1001E: Unsupported bootstrap URL %s. Acceptable values start with 'http' or 'https'", 1001)
 	GALASA_ERROR_BOOTSTRAP_URL_BAD_ENDING       = NewMessageType("GAL1002E: Bootstrap url does not end in '/bootstrap'. Bootstrap url is %s", 1002)
 	GALASA_ERROR_BAD_BOOTSTRAP_CONTENT          = NewMessageType("GAL1003E: Bootstrap contents is badly formed. Bootstrap is at %s. Reason is: %s", 1003)
-	GALASA_ERROR_FAILED_TO_GET_BOOTSTRAP        = NewMessageType("GAL1004E: Failed to load the bootstrap from %s. Reason is %s", 1004)
+	GALASA_ERROR_FAILED_TO_GET_BOOTSTRAP        = NewMessageType("GAL1004E: Failed to load the bootstrap from %s. Reason is %s. If the URL is not resolving, try adding the hostname to your /etc/hosts file. This might especially be needed if communicating over a VPN connection.", 1004)
 	GALASA_ERROR_THROTTLE_FILE_WRITE            = NewMessageType("GAL1005E: Failed to write to 'throttle' file %v. Reason is %s", 1005)
 	GALASA_ERROR_SUBMIT_MIX_FLAGS_AND_PORTFOLIO = NewMessageType("GAL1006E: The submit command does not support mixing of the test selection flags and a portfolio", 1006)
 	GALASA_ERROR_SUBMIT_CREATE_REPORT_YAML      = NewMessageType("GAL1007E: Failed to create report yaml file %s. Reason is %s", 1007)


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

This PR relates to story #projectmanagement/1235

It deals with the aspect that DNS resolution from within go programs always work over a VPN, and that the hostname needs adding to the `/etc/hosts` file.


## Tasks
- [x] Document the limitation in the readme
- [x] Better error message when bootstrap does not resolve. 
