### PR TITLE
techcobweb cli log option

### DIFF
--- a/pkg/utils/logRedirector.go
+++ b/pkg/utils/logRedirector.go
@@ -21,7 +21,9 @@ func CaptureLog(logFileName string) *os.File {
 	// Send the log to a file
 	if logFileName != "" && logFileName != "-" {
 		// The user has set the logFileName using the --log xxxx syntax
-		f, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		// Note: If the file exists, it gets truncated.
+		// Default permissions are 0666
+		f, err := os.Create(logFileName)
 		if err == nil {
 			log.SetOutput(f)
 		} else {


### PR DESCRIPTION
- --log option redirects logged output
- local build script to re-generate the reference documentation.
- copyright
- md files to have no date/time to limit delta changes
- generate some documention about errors which the tool can create.
- Errors should start with capital letters
- More complete list of errors documented.
- Failing to resolve bootstrap URL better error message and doc limitation
- galasactl log file should create anew and not append to existing
