### PR TITLE
galasactl log file should create anew and not append to existing

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -43,7 +43,7 @@ func Execute() {
 }
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&logFileName, "log", "l", "", "File to which log information will be sent")
+	RootCmd.PersistentFlags().StringVarP(&logFileName, "log", "l", "", "File to which log information will be sent. Any folder referred to must exist. An existing file will be over-written.")
 	RootCmd.PersistentFlags().StringVarP(&bootstrap, "bootstrap", "b", "", "Bootstrap URL")
 	RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 }

--- a/pkg/utils/logRedirector.go
+++ b/pkg/utils/logRedirector.go
@@ -21,7 +21,9 @@ func CaptureLog(logFileName string) *os.File {
 	// Send the log to a file
 	if logFileName != "" && logFileName != "-" {
 		// The user has set the logFileName using the --log xxxx syntax
-		f, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		// Note: If the file exists, it gets truncated.
+		// Default permissions are 0666
+		f, err := os.Create(logFileName)
 		if err == nil {
 			log.SetOutput(f)
 		} else {


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

When using --log option in `galasactl`, it appended to existing log files. Not that helpful.

- [x] Log files are over-written if they already exist.
