### PR TITLE
usage instructions for docker and download url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ To build the cli tools locally, use the `./build-locally.sh --help` script for i
 ## Built artifacts
 Download built artifacts:
 
+Built artifacts include:
+
+- galasactl-darwin-amd64 
+- galasactl-darwin-arm64
+- galasactl-linux-amd64 
+- galasactl-linux-s390x 
+- galasactl-windows-amd64.exe
+
 Browse the following web site and download whichever built binary files you wish:
 
 - Bleeding edge/Unstable : https://development.galasa.dev/main/binary/cli/

--- a/README.md
+++ b/README.md
@@ -134,3 +134,26 @@ to avoid DNS being involved in the resolution mechanism.
 
 ## Building locally
 To build the cli tools locally, use the `./build-locally.sh --help` script for instructions.
+
+## Built artifacts
+Download built artifacts:
+
+Browse the following web site and download whichever built binary files you wish:
+
+- Bleeding edge/Unstable : https://development.galasa.dev/main/binary/cli/
+
+## Docker images containing the command-line tools
+The build process builds some docker images with the command-line tools installed.
+This could be useful when wishing to embed a usage of the command-line within a build process which can use a docker image.
+
+- Bleeding edge/Unstable : `docker pull harbor.galasa.dev/galasadev/galasa-cli-amd64:main`
+
+### How to use the docker image
+The docker image has the `galasactl` tool on the path of the docker image when it starts up.
+So, invoke the `galasactl` without installing on your local machine, using the docker image like this:
+```
+docker run harbor.galasa.dev/galasadev/galasa-cli-amd64:main galasactl --version
+```
+
+
+


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- [x] Added some instructions into the readme about the bleeding-edge docker image.
- [x] Added some instructions into the readme about the download site for the bleeding-edge built artifacts.

@AaronJhaj Do we know the equivalent URLs for the officially-released/stable images/binaries ? 

@AaronJhaj Can we add similar comments to any of the other repositories, so it's easier for people to find built artifacts of the repo they are changing ?