### PR TITLE
mcobbett 1378 should use L prefix

### DIFF
--- a/pkg/launcher/jvmLauncher.go
+++ b/pkg/launcher/jvmLauncher.go
@@ -257,6 +257,12 @@ func addStandardProperties(fileSystem utils.FileSystem, overrides map[string]int
 			utils.FILE_SYSTEM_PATH_SEPARATOR + "ras"
 		overrides[OVERRIDE_PROPERTY_FRAMEWORK_RESULT_STORE] = rasPathUri
 	}
+
+	if err == nil {
+		// Force the launched runs to use the "L" prefix in their runids.
+		const OVERRIDE_PROPERTY_LOCAL_RUNID_PREFIX = "framework.request.type.LOCAL.prefix"
+		overrides[OVERRIDE_PROPERTY_LOCAL_RUNID_PREFIX] = "L"
+	}
 	return overrides, err
 }
 

--- a/pkg/launcher/jvmLauncher_test.go
+++ b/pkg/launcher/jvmLauncher_test.go
@@ -258,4 +258,5 @@ func TestCanCreateTempPropsFile(t *testing.T) {
 	overridesGotBack, err := utils.ReadPropertiesFile(fs, tempPropsFile)
 	assert.Nil(t, err)
 	assert.Contains(t, overridesGotBack, "framework.resultarchive.store")
+	assert.Contains(t, overridesGotBack, "framework.request.type.LOCAL.prefix")
 }


### PR DESCRIPTION
- local JVM runs have prefix L in their runid
