### PR TITLE
don't fail to launch if overrides file is not there

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -485,6 +485,9 @@ function launch_test_on_ecosystem {
         exit 1
     fi
 
+    rm -fr ~/galasa-old
+    mv ~/.galasa ~/galasa-old
+
     # hostname=$(echo -n "${GALASA_BOOTSTRAP}" | sed -e "s/http:\/\///g" | sed -e "s/https:\/\///g" | sed -e "s/.bootstrap//g")
     # info "Host name for boostrap is ${hostname}"
 
@@ -505,6 +508,8 @@ function launch_test_on_ecosystem {
         exit 1
     fi
     success "Submitting test to ecosystem worked OK"
+
+    mv ~/.galasa-old ~/.galasa
 }
 
 #--------------------------------------------------------------------------
@@ -593,7 +598,7 @@ function submit_local_test {
     # --noexitcodeontestfailures \
 
     # --remoteMaven https://development.galasa.dev/main/maven-repo/obr/ \
-    # --galasaVersion 0.25.0 \
+    # --galasaVersion 0.26.0 \
 
     rc=$?
     if [[ "${rc}" != "0" ]]; then 

--- a/docs/generated/errors-list.md
+++ b/docs/generated/errors-list.md
@@ -59,4 +59,5 @@ The `galasactl` tool can generate the following errors:
 - GAL1056E: The RAS folder path could not be detected in trace output for runId '{}'
 - GAL1057E: The run identifier could not be detected in trace output of the child process
 - GAL1058E: Failed to load bootstrap file '{}'. Reason is '{}'
+- GAL1059E: Failed to load overrides file '{}'. Reason is '{}'
 - GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '{}', and 'bleeding edge' repository is '{}'

--- a/docs/generated/galasactl_runs_submit.md
+++ b/docs/generated/galasactl_runs_submit.md
@@ -19,7 +19,7 @@ galasactl runs submit [flags]
   -h, --help                       help for submit
       --noexitcodeontestfailures   set to true if you don't want an exit code to be returned from galasactl if a test fails
       --override strings           overrides to be sent with the tests (overrides in the portfolio will take precedence). Each override is of the form 'name=value'. Multiple instances of this flag can be used. For example --override=prop1=val1 --override=prop2=val2
-      --overridefile string        path to a properties file containing override properties. Defaults to overrides.properties in galasa home folder. Overrides from --override options will take precedence over properties in this property file. A file path of '-' disables reading any properties file.
+      --overridefile string        path to a properties file containing override properties. Defaults to overrides.properties in galasa home folder if that file exists. Overrides from --override options will take precedence over properties in this property file. A file path of '-' disables reading any properties file.
       --package strings            packages of which tests will be selected from, packages are selected if the name contains this string, or if --regex is specified then matches the regex
       --poll int                   Optional. The interval time in seconds between successive polls of the test runs status. Defaults to 30 seconds. If less than 1, then default value is used. (default 30)
   -p, --portfolio string           portfolio containing the tests to run

--- a/docs/generated/galasactl_runs_submit_local.md
+++ b/docs/generated/galasactl_runs_submit_local.md
@@ -34,7 +34,7 @@ galasactl runs submit local [flags]
   -l, --log string                 File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
       --noexitcodeontestfailures   set to true if you don't want an exit code to be returned from galasactl if a test fails
       --override strings           overrides to be sent with the tests (overrides in the portfolio will take precedence). Each override is of the form 'name=value'. Multiple instances of this flag can be used. For example --override=prop1=val1 --override=prop2=val2
-      --overridefile string        path to a properties file containing override properties. Defaults to overrides.properties in galasa home folder. Overrides from --override options will take precedence over properties in this property file. A file path of '-' disables reading any properties file.
+      --overridefile string        path to a properties file containing override properties. Defaults to overrides.properties in galasa home folder if that file exists. Overrides from --override options will take precedence over properties in this property file. A file path of '-' disables reading any properties file.
       --poll int                   Optional. The interval time in seconds between successive polls of the test runs status. Defaults to 30 seconds. If less than 1, then default value is used. (default 30)
   -p, --portfolio string           portfolio containing the tests to run
       --progress int               in minutes, how often the cli will report the overall progress of the test runs. A value of 0 or less disables progress reporting. (default 5)

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -62,7 +62,7 @@ func init() {
 			strconv.Itoa(runs.DEFAULT_THROTTLE_TESTS_AT_ONCE))
 
 	runsSubmitCmd.PersistentFlags().StringVar(&runsSubmitCmdParams.OverrideFilePath, "overridefile", "",
-		"path to a properties file containing override properties. Defaults to overrides.properties in galasa home folder. "+
+		"path to a properties file containing override properties. Defaults to overrides.properties in galasa home folder if that file exists. "+
 			"Overrides from --override options will take precedence over properties in this property file. "+
 			"A file path of '-' disables reading any properties file.")
 

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -47,7 +47,6 @@ func NewGalasaError(msgType *MessageType, params ...interface{}) *GalasaError {
 	galasaError.msgType = msgType
 	galasaError.message = message
 
-
 	LogStackTrace()
 
 	return galasaError
@@ -121,6 +120,8 @@ var (
 	GALASA_ERROR_RAS_FOLDER_NOT_DETECTED        = NewMessageType("GAL1056E: The RAS folder path could not be detected in trace output for runId '%s'", 1056)
 	GALASA_ERROR_RUN_ID_NOT_DETECTED            = NewMessageType("GAL1057E: The run identifier could not be detected in trace output of the child process", 1057)
 	GALASA_ERROR_FAILED_TO_LOAD_BOOTSTRAP_FILE  = NewMessageType("GAL1058E: Failed to load bootstrap file '%s'. Reason is '%s'", 1058)
+	GALASA_ERROR_FAILED_TO_LOAD_OVERRIDES_FILE  = NewMessageType("GAL1059E: Failed to load overrides file '%s'. Reason is '%s'", 1059)
+
 	// Warnings...
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'bleeding edge' repository is '%s'", 2000)
 )

--- a/pkg/launcher/jvmLauncher.go
+++ b/pkg/launcher/jvmLauncher.go
@@ -373,7 +373,7 @@ func validateObrs(obrInputs []string) ([]utils.MavenCoordinates, error) {
 //	    --remotemaven https://development.galasa.dev/main/maven-repo/obr/ \
 //	    --bootstrap file:/Users/mcobbett/.galasa/bootstrap.properties \
 //	    --overrides file:/Users/mcobbett/.galasa/overrides.properties \
-//	    --obr mvn:dev.galasa/dev.galasa.uber.obr/0.25.0/obr \
+//	    --obr mvn:dev.galasa/dev.galasa.uber.obr/0.26.0/obr \
 //	    --obr mvn:dev.galasa.example.banking/dev.galasa.example.banking.obr/0.0.1-SNAPSHOT/obr \
 //	    --test dev.galasa.example.banking.payee/dev.galasa.example.banking.payee.TestPayee
 func getCommandSyntax(

--- a/pkg/runs/submitter.go
+++ b/pkg/runs/submitter.go
@@ -528,7 +528,18 @@ func loadOverrideFile(fileSystem utils.FileSystem, overrideFilePath string) (map
 		// Don't read properties from a file.
 		overrides = make(map[string]string)
 	} else {
-		overrides, err = utils.ReadPropertiesFile(fileSystem, overrideFilePath)
+		var isFileThere bool
+		isFileThere, err = fileSystem.Exists(overrideFilePath)
+		if err == nil {
+			if !isFileThere {
+				// The overrides file is not present in ~/.galasa, perhaps because the tool is launching a
+				// remote test, and in such cases ~/.galasa may not exist... which is OK.
+				// It just means we don't have properties from that location.
+				overrides = make(map[string]string)
+			} else {
+				overrides, err = utils.ReadPropertiesFile(fileSystem, overrideFilePath)
+			}
+		}
 	}
 
 	return overrides, err

--- a/pkg/runs/submitter.go
+++ b/pkg/runs/submitter.go
@@ -460,20 +460,37 @@ func validateAndCorrectParams(
 	}
 
 	if err == nil {
-		// Correct the default overrideFile path if it wasn't specified.
-		if params.OverrideFilePath == "" {
-			var home string
-			home, err = fs.GetUserHomeDir()
-			if err == nil {
-				params.OverrideFilePath = home + utils.FILE_SYSTEM_PATH_SEPARATOR +
-					".galasa" + utils.FILE_SYSTEM_PATH_SEPARATOR +
-					"overrides.properties"
-			}
-		}
+		err = correctOverrideFilePathParameter(fs, params)
 	}
 
 	tildaExpandAllPaths(fs, params)
 
+	return err
+}
+
+func correctOverrideFilePathParameter(fs utils.FileSystem, params *utils.RunsSubmitCmdParameters) error {
+	var err error
+	// Correct the default overrideFile path if it wasn't specified.
+	if params.OverrideFilePath == "" {
+		var home string
+		home, err = fs.GetUserHomeDir()
+		if err == nil {
+			params.OverrideFilePath = home + utils.FILE_SYSTEM_PATH_SEPARATOR +
+				".galasa" + utils.FILE_SYSTEM_PATH_SEPARATOR +
+				"overrides.properties"
+			var isFileThere bool
+			isFileThere, err = fs.Exists(params.OverrideFilePath)
+			if err == nil {
+				if !isFileThere {
+					// The flag wasn't specified.
+					// And we don't have an overrides file to read from the .galasa folder.
+					// So treat this the same as the user not wanting to use an override file.
+					// If the file existed, then we'd want to use it.
+					params.OverrideFilePath = "-"
+				}
+			}
+		}
+	}
 	return err
 }
 
@@ -508,9 +525,11 @@ func tildaExpandAllPaths(fs utils.FileSystem, params *utils.RunsSubmitCmdParamet
 
 func buildOverrideMap(fileSystem utils.FileSystem, commandParameters utils.RunsSubmitCmdParameters) (map[string]string, error) {
 
-	runOverrides, err := loadOverrideFile(fileSystem, commandParameters.OverrideFilePath)
-
-	if err == nil {
+	path := commandParameters.OverrideFilePath
+	runOverrides, err := loadOverrideFile(fileSystem, path)
+	if err != nil {
+		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_LOAD_OVERRIDES_FILE, path, err.Error())
+	} else {
 		runOverrides, err = addOverridesFromCmdLine(runOverrides, commandParameters.Overrides)
 	}
 
@@ -528,18 +547,7 @@ func loadOverrideFile(fileSystem utils.FileSystem, overrideFilePath string) (map
 		// Don't read properties from a file.
 		overrides = make(map[string]string)
 	} else {
-		var isFileThere bool
-		isFileThere, err = fileSystem.Exists(overrideFilePath)
-		if err == nil {
-			if !isFileThere {
-				// The overrides file is not present in ~/.galasa, perhaps because the tool is launching a
-				// remote test, and in such cases ~/.galasa may not exist... which is OK.
-				// It just means we don't have properties from that location.
-				overrides = make(map[string]string)
-			} else {
-				overrides, err = utils.ReadPropertiesFile(fileSystem, overrideFilePath)
-			}
-		}
+		overrides, err = utils.ReadPropertiesFile(fileSystem, overrideFilePath)
 	}
 
 	return overrides, err

--- a/pkg/runs/submitter_test.go
+++ b/pkg/runs/submitter_test.go
@@ -105,6 +105,22 @@ func TestOverridesReadFromOverridesFile(t *testing.T) {
 	assert.Equal(t, overrides["c"], "d", "file-based override value wasn't passed correctly.")
 }
 
+func TestOverridesWithoutOverridesFile(t *testing.T) {
+
+	fs := utils.NewMockFileSystem()
+
+	commandParameters := utils.RunsSubmitCmdParameters{
+		Overrides:        []string{"a=b"},
+		OverrideFilePath: "",
+	}
+
+	// Make sure it doesn't blow up if there is no .galasa folder
+	overrides, err := buildOverrideMap(fs, commandParameters)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, overrides)
+}
+
 func TestOverridesWithDashFileDontReadFromAnyFile(t *testing.T) {
 
 	fs := utils.NewMockFileSystem()

--- a/test-locally.sh
+++ b/test-locally.sh
@@ -99,7 +99,7 @@ public class TestLongRunningAccount {
 	 */
 	@Test
 	public void simpleSampleTest() throws Exception {
-        int secondsToSleep = 60;
+        int secondsToSleep = 20;
         Thread.sleep(secondsToSleep*1000);
 		assertThat(core).isNotNull();
 	}
@@ -182,18 +182,23 @@ echo "my.file.based.property = 23" > ${BASEDIR}/temp/extra-overrides.properties
 
 ${GALASACTL} runs submit local \
 --obr mvn:dev.galasa.example.banking/dev.galasa.example.banking.obr/0.0.1-SNAPSHOT/obr \
+--class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestLongRunningAccount \
 --class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestAccount \
+--class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestAccountExtended \
+--class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestFailingAccount \
+--class dev.galasa.example.banking.payee/dev.galasa.example.banking.payee.TestPayee \
+--class dev.galasa.example.banking.payee/dev.galasa.example.banking.payee.TestPayeeExtended \
+--log - 2>&1 | tee ${BASEDIR}/temp/log.txt
+
 # --override my.property=HELLO \
 # --overridefile ${BASEDIR}/temp/extra-overrides.properties 
-# --log - 2>&1 | tee ${BASEDIR}/temp/log.txt
 
-
-
+# --class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestAccount \
 # --class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestAccountExtended \
 # --class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestFailingAccount \
 # --class dev.galasa.example.banking.payee/dev.galasa.example.banking.payee.TestPayee \
 # --class dev.galasa.example.banking.payee/dev.galasa.example.banking.payee.TestPayeeExtended \
-# --class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestLongRunningAccount \
+
 # --throttle 7 \
 # --requesttype MikeCLI \
 # --poll 10 \
@@ -207,7 +212,7 @@ ${GALASACTL} runs submit local \
 # --noexitcodeontestfailures \
 
 # --remoteMaven https://development.galasa.dev/main/maven-repo/obr/ \
-# --galasaVersion 0.25.0 \
+# --galasaVersion 0.26.0 \
 
 rc=$?
 if [[ "${rc}" != "0" ]]; then 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Addresses issue [#1389](https://github.com/galasa-dev/projectmanagement/issues/1389)

- [x] If the `--overridesfile` is specified explicitly, but the file doesn't exist, then it should error.
- [x] If the `--overridesfile` is not specified, and `$HOME/.galasa/overrides.properties` exists, then it should be used.
- [x] If the `--overridesfile` is not specified, and `$HOME/.galasa/overrides.properties` does not exist, then it should not cause a failure, and should be treated as no overrides file being wanted (same as specifying `-`)
