### PR TITLE
Add --gradle and --maven flags to create Gradle and Maven test projects

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -233,6 +233,9 @@ function calculate_galasactl_executable {
     esac
 
     architecture=$(uname -m)
+    if [[ "${architecture}" == "x86_64" ]]; then
+        architecture="amd64"
+    fi
 
     export galasactl_command="galasactl-${os}-${architecture}"
     info "galasactl command is ${galasactl_command}"
@@ -535,6 +538,9 @@ function generate_galasactl_documentation {
                     exit 1
     esac
     architecture="$(uname -m)"
+    if [[ "${architecture}" == "x86_64" ]]; then
+        architecture="amd64"
+    fi
 
     # Call the documentation generator, which builds .md files
     info "Using program ${BASEDIR}/bin/gendocs-galasactl-${machine}-${architecture} to generate the documentation..."

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -250,7 +250,7 @@ function generate_sample_code {
     cd $BASEDIR/temp
 
     export PACKAGE_NAME="dev.galasa.example.banking"
-    ${BASEDIR}/bin/${galasactl_command} project create --package ${PACKAGE_NAME} --features payee,account --obr 
+    ${BASEDIR}/bin/${galasactl_command} project create --package ${PACKAGE_NAME} --features payee,account --obr --maven --gradle
     rc=$?
     if [[ "${rc}" != "0" ]]; then
         error " Failed to create the galasa test project using galasactl command. rc=${rc}"
@@ -260,8 +260,8 @@ function generate_sample_code {
 }
 
 #--------------------------------------------------------------------------
-# Now build the source it created.
-function build_generated_source {
+# Now build the source it created using maven
+function build_generated_source_maven {
     h2 "Building the sample project we just generated."
     cd ${BASEDIR}/temp/${PACKAGE_NAME}
     mvn clean test install 
@@ -273,7 +273,19 @@ function build_generated_source {
     success "OK"
 }
 
-
+#--------------------------------------------------------------------------
+# Now build the source it created using gradle
+function build_generated_source_gradle {
+    h2 "Building the sample project we just generated."
+    cd ${BASEDIR}/temp/${PACKAGE_NAME}
+    gradle build publishToMavenLocal
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then
+        error " Failed to build the generated source code which galasactl created."
+        exit 1
+    fi
+    success "OK"
+}
 
 #--------------------------------------------------------------------------
 # Execute the tests in Galasa
@@ -576,6 +588,7 @@ function submit_local_test {
     OBR_GROUP_ID=$3
     OBR_ARTIFACT_ID=$4
     OBR_VERSION=$5
+    LOG_FILE=$6
 
     # Could get this bootjar from https://development.galasa.dev/main/maven-repo/obr/dev/galasa/galasa-boot/0.26.0/
     export BOOT_JAR_VERSION="0.26.0"
@@ -601,7 +614,7 @@ function submit_local_test {
     --requesttype MikeCLI \
     --poll 10 \
     --progress 1 \
-    --log - 2>&1 | tee ${BASEDIR}/temp/local-run-log.txt
+    --log ${LOG_FILE}
 
     # --reportjson myreport.json \
     # --reportyaml myreport.yaml \
@@ -621,7 +634,8 @@ function submit_local_test {
 }
 
 function run_test_locally_using_galasactl {
-
+    export LOG_FILE=$1
+    
     # Run the Payee tests.
     export TEST_BUNDLE=dev.galasa.example.banking.payee
     export TEST_JAVA_CLASS=dev.galasa.example.banking.payee.TestPayee
@@ -629,9 +643,9 @@ function run_test_locally_using_galasactl {
     export TEST_OBR_ARTIFACT_ID=dev.galasa.example.banking.obr
     export TEST_OBR_VERSION=0.0.1-SNAPSHOT
 
-    submit_local_test $TEST_BUNDLE $TEST_JAVA_CLASS $TEST_OBR_GROUP_ID $TEST_OBR_ARTIFACT_ID $TEST_OBR_VERSION
-}
 
+    submit_local_test $TEST_BUNDLE $TEST_JAVA_CLASS $TEST_OBR_GROUP_ID $TEST_OBR_ARTIFACT_ID $TEST_OBR_VERSION $LOG_FILE
+}
 
 function test_on_windows {
     WINDOWS_HOST="cics-galasa-test"
@@ -639,18 +653,33 @@ function test_on_windows {
     ssh ${WINDOWS_HOST} ./galasactl.exe runs submit local  --obr mvn:dev.galasa.example.banking/dev.galasa.example.banking.obr/0.0.1-SNAPSHOT/obr  --class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestAccount --log -
 }
 
+function cleanup_local_maven_repo {
+    rm -fr ~/.m2/repository/dev/galasa/example
+}
+
 download_dependencies
 generate_rest_client
 build_executables
 calculate_galasactl_executable
 galasa_home_init
+
 generate_sample_code
-build_generated_source
-run_tests_java_minus_jar_method
-run_test_locally_using_galasactl
+
+# Gradle ...
+cleanup_local_maven_repo
+build_generated_source_gradle
+run_test_locally_using_galasactl ${BASEDIR}/temp/local-run-log-gradle.txt
+
+# Maven ...
+cleanup_local_maven_repo
+build_generated_source_maven
+run_test_locally_using_galasactl ${BASEDIR}/temp/local-run-log-maven.txt
+
+# run_tests_java_minus_jar_method
 # build_portfolio
 generate_galasactl_documentation
-launch_test_on_ecosystem
+
+# launch_test_on_ecosystem
 # test_on_windows
 
 #--------------------------------------------------------------------------

--- a/docs/generated/galasactl_project_create.md
+++ b/docs/generated/galasactl_project_create.md
@@ -15,9 +15,9 @@ galasactl project create [flags]
 ```
       --features string   A comma-separated list of features you are testing. These must be able to form parts of a java package name. For example: "payee,account" (default "feature1")
       --force             Force-overwrite files which already exist.
-      --gradle            Create a Galasa test project using Gradle.
+      --gradle            Generate gradle build artifacts. Can be used in addition to the --maven flag.
   -h, --help              help for create
-      --maven             Create a Galasa test project using Maven (default).
+      --maven             Generate maven build artifacts. Can be used in addition to the --gradle flag. If this flag is not used, and the gradle option is not used, then behaviour of this flag defaults to true.
       --obr               An OSGi Object Bundle Resource (OBR) project is needed.
       --package string    Java package name for tests we create. Forms part of the project name, maven/gradle group/artifact ID, and OSGi bundle name. It may reflect the name of your organisation or company, the department, function or application under test. For example: dev.galasa.banking.example
 ```

--- a/docs/generated/galasactl_project_create.md
+++ b/docs/generated/galasactl_project_create.md
@@ -15,7 +15,9 @@ galasactl project create [flags]
 ```
       --features string   A comma-separated list of features you are testing. These must be able to form parts of a java package name. For example: "payee,account" (default "feature1")
       --force             Force-overwrite files which already exist.
+      --gradle            Create a Galasa testproject using gradle
   -h, --help              help for create
+      --maven             Create a Galasa test project using maven (default)
       --obr               An OSGi Object Bundle Resource (OBR) project is needed.
       --package string    Java package name for tests we create. Forms part of the project name, maven/gradle group/artifact ID, and OSGi bundle name. It may reflect the name of your organisation or company, the department, function or application under test. For example: dev.galasa.banking.example
 ```

--- a/docs/generated/galasactl_project_create.md
+++ b/docs/generated/galasactl_project_create.md
@@ -15,9 +15,9 @@ galasactl project create [flags]
 ```
       --features string   A comma-separated list of features you are testing. These must be able to form parts of a java package name. For example: "payee,account" (default "feature1")
       --force             Force-overwrite files which already exist.
-      --gradle            Create a Galasa testproject using gradle
+      --gradle            Create a Galasa test project using Gradle.
   -h, --help              help for create
-      --maven             Create a Galasa test project using maven (default)
+      --maven             Create a Galasa test project using Maven (default).
       --obr               An OSGi Object Bundle Resource (OBR) project is needed.
       --package string    Java package name for tests we create. Forms part of the project name, maven/gradle group/artifact ID, and OSGi bundle name. It may reflect the name of your organisation or company, the department, function or application under test. For example: dev.galasa.banking.example
 ```

--- a/pkg/cmd/projectCreate_test.go
+++ b/pkg/cmd/projectCreate_test.go
@@ -18,10 +18,12 @@ func TestCanCreateProjectFailsIfPackageNameInvalid(t *testing.T) {
 	forceOverwrite := true
 	isObrProjectRequired := false
 	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := false
 
 	// When ...
 	err := createProject(mockFileSystem, "very.INVALID_PACKAGE_NAME.very",
-		featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite)
+		featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -35,9 +37,11 @@ func TestCanCreateProjectGoldenPathNoOBR(t *testing.T) {
 	forceOverwrite := true
 	isObrProjectRequired := false
 	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := false
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite)
+	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -133,6 +137,8 @@ func TestCreateProjectErrorsWhenMkAllDirsFails(t *testing.T) {
 	forceOverwrite := true
 	isObrProjectRequired := false
 	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := false
 
 	// Over-ride the default MkdirAll function so that it fails...
 	mockFileSystem.VirtualFunction_MkdirAll = func(targetFolderPath string) error {
@@ -140,7 +146,7 @@ func TestCreateProjectErrorsWhenMkAllDirsFails(t *testing.T) {
 	}
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite)
+	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
 
 	// Then...
 	assert.NotNil(t, err, "Sumulated error didn't bubble up to the top.")
@@ -154,6 +160,8 @@ func TestCreateProjectErrorsWhenWriteTextFileFails(t *testing.T) {
 	forceOverwrite := true
 	isObrProjectRequired := false
 	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := false
 
 	// Over-ride the default WriteTextFile function so that it fails...
 	mockFileSystem.VirtualFunction_WriteTextFile = func(targetFilePath string, desiredContents string) error {
@@ -161,7 +169,7 @@ func TestCreateProjectErrorsWhenWriteTextFileFails(t *testing.T) {
 	}
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite)
+	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
 
 	// Then...
 	assert.NotNil(t, err, "Sumulated error didn't bubble up to the top.")
@@ -175,13 +183,15 @@ func TestCreateProjectPomFileAlreadyExistsNoForceOverwrite(t *testing.T) {
 	isObrProjectRequired := false
 	testPackageName := "my.test.pkg"
 	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := false
 
 	// Create a pom.xml file already...
 	mockFileSystem.MkdirAll(testPackageName)
 	mockFileSystem.WriteTextFile(testPackageName+"/pom.xml", "dummy test pom.xml")
 
 	// When ...
-	err := createProject(mockFileSystem, testPackageName, featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite)
+	err := createProject(mockFileSystem, testPackageName, featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -196,13 +206,15 @@ func TestCreateProjectPomFileAlreadyExistsWithForceOverwrite(t *testing.T) {
 	forceOverwrite := true
 	testPackageName := "my.test.pkg"
 	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := false
 
 	// Create a pom.xml file already...
 	mockFileSystem.MkdirAll(testPackageName)
 	mockFileSystem.WriteTextFile(testPackageName+"/pom.xml", "dummy test pom.xml")
 
 	// When ...
-	err := createProject(mockFileSystem, testPackageName, featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite)
+	err := createProject(mockFileSystem, testPackageName, featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -229,9 +241,11 @@ func TestCanCreateProjectGoldenPathWithOBR(t *testing.T) {
 	forceOverwrite := true
 	isObrProjectRequired := true
 	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := false
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite)
+	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -267,10 +281,12 @@ func TestCreateProjectWithTwoFeaturesWorks(t *testing.T) {
 	isObrProjectRequired := false
 	testPackageName := "my.test.pkg"
 	featureNamesCommandSeparatedList := "account,payee"
+	maven := false
+	gradle := false
 
 	// When ...
 	err := createProject(mockFileSystem, testPackageName,
-		featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite)
+		featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -292,10 +308,12 @@ func TestCreateProjectWithInvalidFeaturesFails(t *testing.T) {
 	isObrProjectRequired := false
 	testPackageName := "my.test.pkg"
 	featureNamesCommandSeparatedList := "Account"
+	maven := false
+	gradle := false
 
 	// When ...
 	err := createProject(mockFileSystem, testPackageName,
-		featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite)
+		featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
 
 	// Then...
 	// Should have created a folder for the parent package.

--- a/pkg/cmd/projectCreate_test.go
+++ b/pkg/cmd/projectCreate_test.go
@@ -18,7 +18,7 @@ func TestCanCreateProjectFailsIfPackageNameInvalid(t *testing.T) {
 	forceOverwrite := true
 	isObrProjectRequired := false
 	featureNamesCommandSeparatedList := "test"
-	maven := false
+	maven := true
 	gradle := false
 
 	// When ...
@@ -37,7 +37,7 @@ func TestCanCreateProjectGoldenPathNoOBR(t *testing.T) {
 	forceOverwrite := true
 	isObrProjectRequired := false
 	featureNamesCommandSeparatedList := "test"
-	maven := false
+	maven := true
 	gradle := false
 
 	// When ...
@@ -49,56 +49,94 @@ func TestCanCreateProjectGoldenPathNoOBR(t *testing.T) {
 		assert.Fail(t, "Golden path should not return an error. %s", err.Error())
 	}
 
-	assertParentFolderAndContentsCreated(t, mockFileSystem, isObrProjectRequired)
-	assertTestFolderAndContentsCreatedOk(t, mockFileSystem, "test")
+	assertParentFolderAndContentsCreated(t, mockFileSystem, isObrProjectRequired, maven, gradle)
+	assertTestFolderAndContentsCreatedOk(t, mockFileSystem, "test", maven, gradle)
 }
 
-func assertParentFolderAndContentsCreated(t *testing.T, mockFileSystem utils.FileSystem, isObrProjectRequired bool) {
+func assertParentFolderAndContentsCreated(t *testing.T, mockFileSystem utils.FileSystem, isObrProjectRequired bool, isMaven bool, isGradle bool) {
 	parentFolderExists, err := mockFileSystem.DirExists("my.test.pkg")
 	assert.Nil(t, err)
 	assert.True(t, parentFolderExists, "Parent folder was not created.")
 
-	parentPomXmlFileExists, err := mockFileSystem.Exists("my.test.pkg/pom.xml")
-	assert.Nil(t, err)
-	assert.True(t, parentPomXmlFileExists, "Parent folder pom.xml was not created.")
+	if isMaven {
+		parentPomXmlFileExists, err := mockFileSystem.Exists("my.test.pkg/pom.xml")
+		assert.Nil(t, err)
+		assert.True(t, parentPomXmlFileExists, "Parent folder pom.xml was not created.")
+	
+		text, err := mockFileSystem.ReadTextFile("my.test.pkg/pom.xml")
+		assert.Nil(t, err)
+		assert.Contains(t, text, "<groupId>my.test.pkg</groupId>", "parent pom.xml didn't substitute the group id")
+		assert.Contains(t, text, "<artifactId>my.test.pkg</artifactId>", "parent pom.xml didn't substitute the artifact id")
+	
+		assert.Contains(t, text, "<module>my.test.pkg.test</module>", "parent pom.xml didn't have a test module included")
 
-	text, err := mockFileSystem.ReadTextFile("my.test.pkg/pom.xml")
-	assert.Nil(t, err)
-	assert.Contains(t, text, "<groupId>my.test.pkg</groupId>", "parent pom.xml didn't substitute the group id")
-	assert.Contains(t, text, "<artifactId>my.test.pkg</artifactId>", "parent pom.xml didn't substitute the artifact id")
+		if isObrProjectRequired {
+			assert.Contains(t, text, "<module>my.test.pkg.obr</module>", "parent pom.xml didn't have an obr module included")
+		} else {
+			assert.NotContains(t, text, "<module>my.test.pkg.obr</module>", "parent pom.xml should not have an obr module included")
+		}
+	}
 
-	assert.Contains(t, text, "<module>my.test.pkg.test</module>", "parent pom.xml didn't have a test module included")
+	if isGradle {
+		parentSettingsGradleFileExists, err := mockFileSystem.Exists("my.test.pkg/settings.gradle")
+		assert.Nil(t, err)
+		assert.True(t, parentSettingsGradleFileExists, "Parent folder settings.gradle was not created.")
+	
+		text, err := mockFileSystem.ReadTextFile("my.test.pkg/settings.gradle")
+		assert.Nil(t, err)
+		assert.Contains(t, text, "include 'my.test.pkg.test'", "parent settings.gradle didn't have a test module included")
+		
+		if isObrProjectRequired {
+			assert.Contains(t, text, "include 'my.test.pkg.obr'", "parent settings.gradle didn't have an obr module included")
+		} else {
+			assert.NotContains(t, text, "include 'my.test.pkg.obr'", "parent settings.gradle should not have an obr module included")
 
-	if isObrProjectRequired {
-		assert.Contains(t, text, "<module>my.test.pkg.obr</module>", "parent pom.xml didn't have an obr module included")
-	} else {
-		assert.NotContains(t, text, "<module>my.test.pkg.obr</module>", "parent pom.xml should not have an obr module included")
-
-		// Make sure the OBR folder does not exist.
-		expectedObrFolderPath := packageName + "/" + packageName + ".obr"
-		var obrFolderExists bool
-		obrFolderExists, _ = mockFileSystem.DirExists(expectedObrFolderPath)
-		assert.False(t, obrFolderExists, "OBR folder exists, when it should not!")
-
-		// OBR should not be mentioned in the parent pom.xml
+			// Make sure the OBR folder does not exist.
+			expectedObrFolderPath := packageName + "/" + packageName + ".obr"
+			var obrFolderExists bool
+			obrFolderExists, _ = mockFileSystem.DirExists(expectedObrFolderPath)
+			assert.False(t, obrFolderExists, "OBR folder exists, when it should not!")
+		}
 	}
 }
 
-func assertTestFolderAndContentsCreatedOk(t *testing.T, mockFileSystem utils.FileSystem, featureName string) {
+func assertTestFolderAndContentsCreatedOk(t *testing.T, mockFileSystem utils.FileSystem, featureName string, isMaven bool, isGradle bool) {
 
 	testFolderExists, err := mockFileSystem.DirExists("my.test.pkg/my.test.pkg." + featureName)
 	assert.Nil(t, err)
 	assert.True(t, testFolderExists, "Test"+featureName+" folder was not created.")
 
-	expectedPomFilePath := "my.test.pkg/my.test.pkg." + featureName + "/pom.xml"
-	testPomXmlFileExists, err := mockFileSystem.Exists(expectedPomFilePath)
-	assert.Nil(t, err)
-	assert.True(t, testPomXmlFileExists, "Test folder pom.xml was not created for feature."+featureName)
+	if isMaven {
+		expectedPomFilePath := "my.test.pkg/my.test.pkg." + featureName + "/pom.xml"
+		testPomXmlFileExists, err := mockFileSystem.Exists(expectedPomFilePath)
+		assert.Nil(t, err)
+		assert.True(t, testPomXmlFileExists, "Test folder pom.xml was not created for feature." + featureName)
 
-	text, err := mockFileSystem.ReadTextFile(expectedPomFilePath)
-	assert.Nil(t, err)
-	assert.Contains(t, text, "<groupId>my.test.pkg</groupId>", "Test folder pom.xml didn't substitute the group id")
-	assert.Contains(t, text, "<artifactId>my.test.pkg.test</artifactId>", "Test folder pom.xml didn't substitute the artifact id")
+		text, err := mockFileSystem.ReadTextFile(expectedPomFilePath)
+		assert.Nil(t, err)
+		assert.Contains(t, text, "<groupId>my.test.pkg</groupId>", "Test folder pom.xml didn't substitute the group id")
+		assert.Contains(t, text, "<artifactId>my.test.pkg.test</artifactId>", "Test folder pom.xml didn't substitute the artifact id")
+	}
+	
+	if isGradle {
+		expectedBuildGradleFilePath := "my.test.pkg/my.test.pkg." + featureName + "/build.gradle"
+		testBuildGradleFileExists, err := mockFileSystem.Exists(expectedBuildGradleFilePath)
+		assert.Nil(t, err)
+		assert.True(t, testBuildGradleFileExists, "Test folder build.gradle was not created for feature." + featureName)
+
+		expectedBndFilePath := "my.test.pkg/my.test.pkg." + featureName + "/bnd.bnd"
+		testBndFileExists, err := mockFileSystem.Exists(expectedBndFilePath)
+		assert.Nil(t, err)
+		assert.True(t, testBndFileExists, "Test folder bnd.bnd was not created for feature." + featureName)
+
+		buildGradleText, err := mockFileSystem.ReadTextFile(expectedBuildGradleFilePath)
+		assert.Nil(t, err)
+		assert.Contains(t, buildGradleText, "group = 'my.test.pkg'", "Test folder build.gradle didn't substitute the group id")
+
+		bndFileText, err := mockFileSystem.ReadTextFile(expectedBndFilePath)
+		assert.Nil(t, err)
+		assert.Contains(t, bndFileText, "Bundle-Name: my.test.pkg", "Test folder bnd.bnd didn't substitute the bundle name")
+	}
 
 	testSrcFolderExists, err := mockFileSystem.DirExists("my.test.pkg/my.test.pkg.test/src/main/java/my/test/pkg/test")
 	assert.Nil(t, err)
@@ -137,7 +175,7 @@ func TestCreateProjectErrorsWhenMkAllDirsFails(t *testing.T) {
 	forceOverwrite := true
 	isObrProjectRequired := false
 	featureNamesCommandSeparatedList := "test"
-	maven := false
+	maven := true
 	gradle := false
 
 	// Over-ride the default MkdirAll function so that it fails...
@@ -160,7 +198,7 @@ func TestCreateProjectErrorsWhenWriteTextFileFails(t *testing.T) {
 	forceOverwrite := true
 	isObrProjectRequired := false
 	featureNamesCommandSeparatedList := "test"
-	maven := false
+	maven := true
 	gradle := false
 
 	// Over-ride the default WriteTextFile function so that it fails...
@@ -183,7 +221,7 @@ func TestCreateProjectPomFileAlreadyExistsNoForceOverwrite(t *testing.T) {
 	isObrProjectRequired := false
 	testPackageName := "my.test.pkg"
 	featureNamesCommandSeparatedList := "test"
-	maven := false
+	maven := true
 	gradle := false
 
 	// Create a pom.xml file already...
@@ -206,7 +244,7 @@ func TestCreateProjectPomFileAlreadyExistsWithForceOverwrite(t *testing.T) {
 	forceOverwrite := true
 	testPackageName := "my.test.pkg"
 	featureNamesCommandSeparatedList := "test"
-	maven := false
+	maven := true
 	gradle := false
 
 	// Create a pom.xml file already...
@@ -241,7 +279,7 @@ func TestCanCreateProjectGoldenPathWithOBR(t *testing.T) {
 	forceOverwrite := true
 	isObrProjectRequired := true
 	featureNamesCommandSeparatedList := "test"
-	maven := false
+	maven := true
 	gradle := false
 
 	// When ...
@@ -253,25 +291,38 @@ func TestCanCreateProjectGoldenPathWithOBR(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 
-	assertParentFolderAndContentsCreated(t, mockFileSystem, isObrProjectRequired)
-	assertTestFolderAndContentsCreatedOk(t, mockFileSystem, "test")
-	assertOBRFOlderAndContentsCreatedOK(t, mockFileSystem)
+	assertParentFolderAndContentsCreated(t, mockFileSystem, isObrProjectRequired, maven, gradle)
+	assertTestFolderAndContentsCreatedOk(t, mockFileSystem, "test", maven, gradle)
+	assertOBRFOlderAndContentsCreatedOK(t, mockFileSystem, maven, gradle)
 }
 
-func assertOBRFOlderAndContentsCreatedOK(t *testing.T, mockFileSystem utils.FileSystem) {
+func assertOBRFOlderAndContentsCreatedOK(t *testing.T, mockFileSystem utils.FileSystem, isMaven bool, isGradle bool) {
 	testFolderExists, err := mockFileSystem.DirExists("my.test.pkg/my.test.pkg.obr")
 	assert.Nil(t, err)
 	assert.True(t, testFolderExists, "Test folder was not created.")
 
-	expectedPomFilePath := "my.test.pkg/my.test.pkg.obr/pom.xml"
-	testPomXmlFileExists, err := mockFileSystem.Exists(expectedPomFilePath)
-	assert.Nil(t, err)
-	assert.True(t, testPomXmlFileExists, "Test folder pom.xml was not created.")
+	if isMaven {
+		expectedPomFilePath := "my.test.pkg/my.test.pkg.obr/pom.xml"
+		testPomXmlFileExists, err := mockFileSystem.Exists(expectedPomFilePath)
+		assert.Nil(t, err)
+		assert.True(t, testPomXmlFileExists, "Test folder pom.xml was not created.")
+	
+		text, err := mockFileSystem.ReadTextFile(expectedPomFilePath)
+		assert.Nil(t, err)
+		assert.Contains(t, text, "<groupId>my.test.pkg</groupId>", "Test folder pom.xml didn't substitute the group id")
+		assert.Contains(t, text, "<artifactId>my.test.pkg.obr</artifactId>", "Test folder pom.xml didn't substitute the artifact id")
+	}
 
-	text, err := mockFileSystem.ReadTextFile(expectedPomFilePath)
-	assert.Nil(t, err)
-	assert.Contains(t, text, "<groupId>my.test.pkg</groupId>", "Test folder pom.xml didn't substitute the group id")
-	assert.Contains(t, text, "<artifactId>my.test.pkg.obr</artifactId>", "Test folder pom.xml didn't substitute the artifact id")
+	if isGradle {
+		expectedBuildGradleFilePath := "my.test.pkg/my.test.pkg.obr/build.gradle"
+		testBuildGradleFileExists, err := mockFileSystem.Exists(expectedBuildGradleFilePath)
+		assert.Nil(t, err)
+		assert.True(t, testBuildGradleFileExists, "Test folder build.gradle was not created.")
+	
+		text, err := mockFileSystem.ReadTextFile(expectedBuildGradleFilePath)
+		assert.Nil(t, err)
+		assert.Contains(t, text, "group = 'my.test.pkg'", "Test folder build.gradle didn't substitute the group id")
+	}
 }
 
 func TestCreateProjectWithTwoFeaturesWorks(t *testing.T) {
@@ -281,7 +332,7 @@ func TestCreateProjectWithTwoFeaturesWorks(t *testing.T) {
 	isObrProjectRequired := false
 	testPackageName := "my.test.pkg"
 	featureNamesCommandSeparatedList := "account,payee"
-	maven := false
+	maven := true
 	gradle := false
 
 	// When ...
@@ -308,7 +359,7 @@ func TestCreateProjectWithInvalidFeaturesFails(t *testing.T) {
 	isObrProjectRequired := false
 	testPackageName := "my.test.pkg"
 	featureNamesCommandSeparatedList := "Account"
-	maven := false
+	maven := true
 	gradle := false
 
 	// When ...
@@ -320,4 +371,94 @@ func TestCreateProjectWithInvalidFeaturesFails(t *testing.T) {
 	assert.NotNil(t, err, "err should have been set!")
 	assert.Contains(t, err.Error(), "GAL1045E")
 
+}
+
+func TestCanCreateGradleProjectWithNoOBR(t *testing.T) {
+	// Given...
+	mockFileSystem := utils.NewMockFileSystem()
+	forceOverwrite := true
+	isObrProjectRequired := false
+	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := true
+
+	// When ...
+	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+
+	// Then...
+	// Should have created a folder for the parent package.
+	if err != nil {
+		assert.Fail(t, "Creating a Maven project should not return an error. %s", err.Error())
+	}
+
+	assertParentFolderAndContentsCreated(t, mockFileSystem, isObrProjectRequired, maven, gradle)
+	assertTestFolderAndContentsCreatedOk(t, mockFileSystem, "test", maven, gradle)
+}
+
+func TestCanCreateGradleProjectWithOBR(t *testing.T) {
+	// Given...
+	mockFileSystem := utils.NewMockFileSystem()
+	forceOverwrite := true
+	isObrProjectRequired := true
+	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := true
+
+	// When ...
+	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+
+	// Then...
+	// Should have created a folder for the parent package.
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	assertParentFolderAndContentsCreated(t, mockFileSystem, isObrProjectRequired, maven, gradle)
+	assertTestFolderAndContentsCreatedOk(t, mockFileSystem, "test", maven, gradle)
+	assertOBRFOlderAndContentsCreatedOK(t, mockFileSystem, maven, gradle)
+}
+
+func TestCanCreateMavenAndGradleProject(t *testing.T) {
+	// Given...
+	mockFileSystem := utils.NewMockFileSystem()
+	forceOverwrite := true
+	isObrProjectRequired := false
+	featureNamesCommandSeparatedList := "test"
+	maven := true
+	gradle := true
+
+	// When ...
+	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+
+	// Then...
+	// Should have created a folder for the parent package.
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	assertParentFolderAndContentsCreated(t, mockFileSystem, isObrProjectRequired, maven, gradle)
+	assertTestFolderAndContentsCreatedOk(t, mockFileSystem, "test", maven, gradle)
+}
+
+func TestCreateProjectDefaultsToMavenProject(t *testing.T) {
+	// Given...
+	mockFileSystem := utils.NewMockFileSystem()
+	forceOverwrite := true
+	isObrProjectRequired := false
+	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := false
+	expectMaven := true
+
+	// When ...
+	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+
+	// Then...
+	// Should have created a folder for the parent package.
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	assertParentFolderAndContentsCreated(t, mockFileSystem, isObrProjectRequired, expectMaven, gradle)
+	assertTestFolderAndContentsCreatedOk(t, mockFileSystem, "test", expectMaven, gradle)
 }

--- a/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
@@ -1,5 +1,5 @@
 plugins {
-    id 'java'
+    id 'base'
     id 'maven-publish'
     id 'dev.galasa.obr' version '0.15.0'
 }
@@ -13,10 +13,15 @@ dependencies {
 {{- end }}
 }
 
+def obrFile = file('build/galasa.obr')
+artifacts {
+    archives obrFile
+}
+
 publishing {
     publications {
         maven(MavenPublication) {
-            from components.java
+            artifact obrFile
         }
     }
 }

--- a/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'maven-publish'
     id 'dev.galasa.obr' version '0.15.0'
 }
 
@@ -10,4 +11,12 @@ dependencies {
 {{- range $module := .Modules }}
     bundle project(':{{ $module.Name }}')
 {{- end }}
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
 }

--- a/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
@@ -1,0 +1,13 @@
+plugins {
+    id 'java'
+    id 'dev.galasa.obr' version '0.15.0'
+}
+
+group = '{{ .Parent.GroupId }}'
+version = '0.0.1-SNAPSHOT'
+
+dependencies {
+{{- range $module := .Modules }}
+    bundle project(':{{ $module.Name }}')
+{{- end }}
+}

--- a/pkg/embedded/templates/projectCreate/parent-project/settings.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/settings.gradle.template
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        // To use the bleeding edge version of galasa's obr plugin, use the development obr
+        // maven {
+        //    url = 'https://development.galasa.dev/main/maven-repo/obr'
+        // }
+        gradlePluginPortal()
+    }
+}
+
+{{- range $componentName := .ChildModuleNames }}
+include '{{ $componentName }}'
+{{- end }}
+{{- if .IsOBRRequired }}
+include '{{ .ObrName }}'
+{{- end }}

--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/bnd.bnd
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Version: 0.0.1-SNAPSHOT
+Bundle-Name: {{ .Coordinates.Name }}
+Import-Package: *

--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'maven-publish'
     id 'biz.aQute.bnd.builder' version '6.4.0'
 }
 
@@ -24,4 +25,12 @@ dependencies {
     implementation 'dev.galasa:dev.galasa.artifact.manager'
     implementation 'commons-logging:commons-logging'
     implementation 'org.assertj:assertj-core'
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
 }

--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'biz.aQute.bnd.builder' version '6.4.0'
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    // To use the bleeding edge version of galasa, use the development obr
+    // maven {
+    //   url = 'https://development.galasa.dev/main/maven-repo/obr'
+    // }
+}
+
+group = '{{ .Parent.GroupId }}'
+version = '0.0.1-SNAPSHOT'
+
+dependencies {
+    implementation platform('dev.galasa:galasa-bom:{{.GalasaVersion}}')
+
+    implementation 'dev.galasa:dev.galasa'
+    implementation 'dev.galasa:dev.galasa.framework'
+    implementation 'dev.galasa:dev.galasa.core.manager'
+    implementation 'dev.galasa:dev.galasa.artifact.manager'
+    implementation 'commons-logging:commons-logging'
+    implementation 'org.assertj:assertj-core'
+}

--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/src/main/build.gradle
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/src/main/build.gradle
@@ -1,5 +1,0 @@
-plugins {
-    id '{{ProjectName}}.java-conventions'
-}
-
-description = '{{ProjectName}}.main'

--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/src/main/build.gradle
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/src/main/build.gradle
@@ -1,0 +1,5 @@
+plugins {
+    id '{{ProjectName}}.java-conventions'
+}
+
+description = '{{ProjectName}}.main'

--- a/test-locally.sh
+++ b/test-locally.sh
@@ -61,10 +61,35 @@ mkdir -p temp
 # rm -fr ~/.galasa/*
 
 #-------------------------------------------------------------------------
+# Set galasactl version to use
+#-------------------------------------------------------------------------
+raw_os=$(uname -s) # eg: "Darwin"
+os=""
+
+case $raw_os in
+    Darwin*) 
+        os="darwin" 
+        ;;
+	Linux*)
+    	os="linux"
+        ;;
+    *) 
+        error "Failed to recognise which operating system is in use. $raw_os"
+        exit 1
+esac
+
+architecture=$(uname -m)
+if [[ "${architecture}" == "x86_64" ]]; then
+    architecture="amd64"
+fi
+
+export GALASACTL="${BASEDIR}/bin/galasactl-${os}-${architecture}"
+
+#-------------------------------------------------------------------------
 # Run tool, generate source
 #-------------------------------------------------------------------------
 cd temp
-../bin/galasactl-darwin-arm64 project create --package dev.galasa.example.banking --features payee,account --obr --log -
+${GALASACTL} project create --package dev.galasa.example.banking --features payee,account --obr --log -
 rc=$?
 if [[ "${rc}" != "0" ]]; then 
     error "Failed. rc=${rc}"
@@ -176,7 +201,6 @@ export REMOTE_MAVEN=https://development.galasa.dev/main/maven-repo/obr/
 # else go to maven central
 #export REMOTE_MAVEN=https://repo.maven.apache.org/maven2
 
-export GALASACTL="${BASEDIR}/bin/galasactl-darwin-arm64"
 
 echo "my.file.based.property = 23" > ${BASEDIR}/temp/extra-overrides.properties
 

--- a/test-locally.sh
+++ b/test-locally.sh
@@ -213,8 +213,12 @@ ${GALASACTL} runs submit local \
 --class dev.galasa.example.banking.payee/dev.galasa.example.banking.payee.TestPayee \
 --class dev.galasa.example.banking.payee/dev.galasa.example.banking.payee.TestPayeeExtended \
 --remoteMaven https://development.galasa.dev/main/maven-repo/obr/ \
---galasaVersion 0.26.0 \
---log - 2>&1 | tee ${BASEDIR}/temp/log.txt
+--galasaVersion 0.27.0 
+# --log - 2>&1 | tee ${BASEDIR}/temp/log.txt
+
+# --class dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestLongRunningAccount \
+# \
+# --log - 2>&1 | tee ${BASEDIR}/temp/log.txt
 
 # --override my.property=HELLO \
 # --overridefile ${BASEDIR}/temp/extra-overrides.properties 
@@ -240,6 +244,7 @@ ${GALASACTL} runs submit local \
 
 
 rc=$?
+echo "Exit code detected by calling script is ${rc}"
 if [[ "${rc}" != "0" ]]; then 
     echo "Failed to run the test"
     exit 1


### PR DESCRIPTION
(In progress)
For https://github.com/galasa-dev/projectmanagement/issues/1333

Main changes:
- Added `--maven` flag to allow Maven test projects to be created when running `galasactl project create` (this is the default option, so it does not need to be specified).
- Added `--gradle` flag to allow Gradle test projects to be created when running `galasactl project create`.
- Can specify both `--maven` and `--gradle` to create Maven and Gradle files in a test project.
- Added unit tests to cover both flags