### PR TITLE
galasactl project create adds a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 bin/
 vendor/
-pkg/galasaapi/
+
+
+
 p*.yaml
 r*.yaml
 r*.json
@@ -10,15 +12,25 @@ junit.xml
 tools/
 build/
 .idea/
-temp*/
+
+# The temporary file we use for build-FV tests locally.
+temp/
 run.sh
+
+# Mac metadata files on a desktop.
 **/.DS_Store
 .DS_Store
+
 # Ignore Gradle project-specific cache directory
 .gradle
 .dependencies
+
 # Ignore Gradle build output directory
 build
+
+# Don't check-in the boot jar which is embedded in local builds.
 pkg/embedded/templates/lib/
 **/*.jar
 
+# The galasaapi package is generated.
+pkg/galasaapi/

--- a/pkg/cmd/projectCreate.go
+++ b/pkg/cmd/projectCreate.go
@@ -214,7 +214,7 @@ func createParentFolderContents(
 	}
 
 	if err == nil {
-		err = createGitIgnoreFile(packageName, fileGenerator, forceOverwrite)
+		err = createGitIgnoreFile(packageName, fileGenerator, forceOverwrite, useMaven, useGradle)
 	}
 
 	return err
@@ -224,13 +224,26 @@ func createGitIgnoreFile(
 	packageName string,
 	fileGenerator *utils.FileGenerator,
 	forceOverwrite bool,
+	useMaven bool,
+	useGradle bool,
 ) error {
+
+	type GitIgnoreParameters struct {
+		IsMavenUsed  bool
+		IsGradleUsed bool
+	}
+
+	templateParameters := GitIgnoreParameters{
+		IsMavenUsed:  useMaven,
+		IsGradleUsed: useGradle,
+	}
 
 	targetFile := utils.GeneratedFileDef{
 		FileType:                 ".gitignore",
 		TargetFilePath:           packageName + "/.gitignore",
 		EmbeddedTemplateFilePath: "templates/projectCreate/parent-project/gitignore-template",
-		TemplateParameters:       nil}
+		TemplateParameters:       templateParameters,
+	}
 
 	err := fileGenerator.CreateFile(targetFile, forceOverwrite, true)
 	return err

--- a/pkg/cmd/projectCreate.go
+++ b/pkg/cmd/projectCreate.go
@@ -161,34 +161,60 @@ func createProject(
 	if err == nil {
 		err = utils.ValidateJavaPackageName(packageName)
 		if err == nil {
+
 			// Create the parent folder
 			parentProjectFolder := packageName
 			err = fileGenerator.CreateFolder(parentProjectFolder)
+
 			if err == nil {
-				if useMaven {
-					err = createParentFolderPom(fileGenerator, packageName, featureNames, isOBRProjectRequired, forceOverwrite)
-				}
+				err = createParentFolderContents(
+					fileGenerator, packageName, featureNames, isOBRProjectRequired,
+					forceOverwrite, useMaven, useGradle)
 			}
 
 			if err == nil {
-				if useGradle {
-					err = createParentFolderSettingsGradle(fileGenerator, packageName, featureNames, isOBRProjectRequired, forceOverwrite)
-				}
-			}
-
-			if err == nil {
-				err = createGitIgnoreFile(packageName, fileGenerator, forceOverwrite)
-			}
-
-			if err == nil {
-				err = createTestProjects(fileGenerator, packageName, featureNames, forceOverwrite, useMaven, useGradle)
+				err = createTestProjects(fileGenerator, packageName, featureNames, forceOverwrite,
+					useMaven, useGradle)
 				if err == nil {
 					if isOBRProjectRequired {
-						err = createOBRProject(fileGenerator, packageName, featureNames, forceOverwrite, useMaven, useGradle)
+						err = createOBRProject(fileGenerator, packageName, featureNames,
+							forceOverwrite, useMaven, useGradle)
 					}
 				}
 			}
 		}
+	}
+
+	return err
+}
+
+func createParentFolderContents(
+	fileGenerator *utils.FileGenerator,
+	packageName string,
+	featureNames []string,
+	isOBRProjectRequired bool,
+	forceOverwrite bool,
+	useMaven bool,
+	useGradle bool,
+) error {
+	var err error = nil
+
+	if err == nil {
+		if useMaven {
+			err = createParentFolderPom(fileGenerator, packageName, featureNames,
+				isOBRProjectRequired, forceOverwrite)
+		}
+	}
+
+	if err == nil {
+		if useGradle {
+			err = createParentFolderSettingsGradle(fileGenerator, packageName,
+				featureNames, isOBRProjectRequired, forceOverwrite)
+		}
+	}
+
+	if err == nil {
+		err = createGitIgnoreFile(packageName, fileGenerator, forceOverwrite)
 	}
 
 	return err

--- a/pkg/cmd/projectCreate.go
+++ b/pkg/cmd/projectCreate.go
@@ -241,7 +241,7 @@ func createGitIgnoreFile(
 	targetFile := utils.GeneratedFileDef{
 		FileType:                 ".gitignore",
 		TargetFilePath:           packageName + "/.gitignore",
-		EmbeddedTemplateFilePath: "templates/projectCreate/parent-project/gitignore-template",
+		EmbeddedTemplateFilePath: "templates/projectCreate/parent-project/git-ignore.template",
 		TemplateParameters:       templateParameters,
 	}
 

--- a/pkg/cmd/projectCreate_test.go
+++ b/pkg/cmd/projectCreate_test.go
@@ -62,12 +62,16 @@ func assertParentFolderAndContentsCreated(t *testing.T, mockFileSystem utils.Fil
 		parentPomXmlFileExists, err := mockFileSystem.Exists("my.test.pkg/pom.xml")
 		assert.Nil(t, err)
 		assert.True(t, parentPomXmlFileExists, "Parent folder pom.xml was not created.")
-	
+
+		gitIgnoreFileExists, err := mockFileSystem.Exists("my.test.pkg/.gitignore")
+		assert.Nil(t, err)
+		assert.True(t, gitIgnoreFileExists, "Parent folder .gitignore was not created.")
+
 		text, err := mockFileSystem.ReadTextFile("my.test.pkg/pom.xml")
 		assert.Nil(t, err)
 		assert.Contains(t, text, "<groupId>my.test.pkg</groupId>", "parent pom.xml didn't substitute the group id")
 		assert.Contains(t, text, "<artifactId>my.test.pkg</artifactId>", "parent pom.xml didn't substitute the artifact id")
-	
+
 		assert.Contains(t, text, "<module>my.test.pkg.test</module>", "parent pom.xml didn't have a test module included")
 
 		if isObrProjectRequired {
@@ -81,11 +85,11 @@ func assertParentFolderAndContentsCreated(t *testing.T, mockFileSystem utils.Fil
 		parentSettingsGradleFileExists, err := mockFileSystem.Exists("my.test.pkg/settings.gradle")
 		assert.Nil(t, err)
 		assert.True(t, parentSettingsGradleFileExists, "Parent folder settings.gradle was not created.")
-	
+
 		text, err := mockFileSystem.ReadTextFile("my.test.pkg/settings.gradle")
 		assert.Nil(t, err)
 		assert.Contains(t, text, "include 'my.test.pkg.test'", "parent settings.gradle didn't have a test module included")
-		
+
 		if isObrProjectRequired {
 			assert.Contains(t, text, "include 'my.test.pkg.obr'", "parent settings.gradle didn't have an obr module included")
 		} else {
@@ -110,24 +114,24 @@ func assertTestFolderAndContentsCreatedOk(t *testing.T, mockFileSystem utils.Fil
 		expectedPomFilePath := "my.test.pkg/my.test.pkg." + featureName + "/pom.xml"
 		testPomXmlFileExists, err := mockFileSystem.Exists(expectedPomFilePath)
 		assert.Nil(t, err)
-		assert.True(t, testPomXmlFileExists, "Test folder pom.xml was not created for feature." + featureName)
+		assert.True(t, testPomXmlFileExists, "Test folder pom.xml was not created for feature."+featureName)
 
 		text, err := mockFileSystem.ReadTextFile(expectedPomFilePath)
 		assert.Nil(t, err)
 		assert.Contains(t, text, "<groupId>my.test.pkg</groupId>", "Test folder pom.xml didn't substitute the group id")
 		assert.Contains(t, text, "<artifactId>my.test.pkg.test</artifactId>", "Test folder pom.xml didn't substitute the artifact id")
 	}
-	
+
 	if isGradle {
 		expectedBuildGradleFilePath := "my.test.pkg/my.test.pkg." + featureName + "/build.gradle"
 		testBuildGradleFileExists, err := mockFileSystem.Exists(expectedBuildGradleFilePath)
 		assert.Nil(t, err)
-		assert.True(t, testBuildGradleFileExists, "Test folder build.gradle was not created for feature." + featureName)
+		assert.True(t, testBuildGradleFileExists, "Test folder build.gradle was not created for feature."+featureName)
 
 		expectedBndFilePath := "my.test.pkg/my.test.pkg." + featureName + "/bnd.bnd"
 		testBndFileExists, err := mockFileSystem.Exists(expectedBndFilePath)
 		assert.Nil(t, err)
-		assert.True(t, testBndFileExists, "Test folder bnd.bnd was not created for feature." + featureName)
+		assert.True(t, testBndFileExists, "Test folder bnd.bnd was not created for feature."+featureName)
 
 		buildGradleText, err := mockFileSystem.ReadTextFile(expectedBuildGradleFilePath)
 		assert.Nil(t, err)
@@ -306,7 +310,7 @@ func assertOBRFOlderAndContentsCreatedOK(t *testing.T, mockFileSystem utils.File
 		testPomXmlFileExists, err := mockFileSystem.Exists(expectedPomFilePath)
 		assert.Nil(t, err)
 		assert.True(t, testPomXmlFileExists, "Test folder pom.xml was not created.")
-	
+
 		text, err := mockFileSystem.ReadTextFile(expectedPomFilePath)
 		assert.Nil(t, err)
 		assert.Contains(t, text, "<groupId>my.test.pkg</groupId>", "Test folder pom.xml didn't substitute the group id")
@@ -318,7 +322,7 @@ func assertOBRFOlderAndContentsCreatedOK(t *testing.T, mockFileSystem utils.File
 		testBuildGradleFileExists, err := mockFileSystem.Exists(expectedBuildGradleFilePath)
 		assert.Nil(t, err)
 		assert.True(t, testBuildGradleFileExists, "Test folder build.gradle was not created.")
-	
+
 		text, err := mockFileSystem.ReadTextFile(expectedBuildGradleFilePath)
 		assert.Nil(t, err)
 		assert.Contains(t, text, "group = 'my.test.pkg'", "Test folder build.gradle didn't substitute the group id")

--- a/pkg/embedded/templates/projectCreate/parent-project/git-ignore.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/git-ignore.template
@@ -1,0 +1,19 @@
+
+# Ignore Mac metadata files.
+**/.DS_Store
+
+{{- if .IsGradleUsed }}
+# Ignore anything built by gradle
+**/build/
+**/.gradle/
+**/target/
+{{- end }}
+
+{{- if .IsMavenUsed }}
+# Ignore anything built by maven
+**/target/
+{{- end }}
+
+# Ignore any built java artifacts
+**/*.class
+**/*.jar

--- a/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
@@ -1,12 +1,16 @@
+// This section tells gradle which gradle plugins to use to build this project.
 plugins {
     id 'base'
     id 'maven-publish'
     id 'dev.galasa.obr' version '0.15.0'
 }
 
+// Set the variables which will control what the built OSGi bundle will be called
+// and the name it will be published under in the maven repository.
 group = '{{ .Parent.GroupId }}'
 version = '0.0.1-SNAPSHOT'
 
+// What are the dependencies of the obr ? 
 dependencies {
 {{- range $module := .Modules }}
     bundle project(':{{ $module.Name }}')
@@ -18,6 +22,8 @@ artifacts {
     archives obrFile
 }
 
+// Tell gradle to publish the built OBR as a maven artifact on the 
+// local maven repository.
 publishing {
     publications {
         maven(MavenPublication) {

--- a/pkg/embedded/templates/projectCreate/parent-project/settings.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/settings.gradle.template
@@ -1,3 +1,5 @@
+
+// Tell gradle where it should look to find the plugins and dependencies it needs to build.
 pluginManagement {
     repositories {
         mavenLocal()
@@ -10,6 +12,7 @@ pluginManagement {
     }
 }
 
+// Tell gradle to build the sub-projects in child folders
 {{- range $componentName := .ChildModuleNames }}
 include '{{ $componentName }}'
 {{- end }}

--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
@@ -1,9 +1,12 @@
+
+// This section tells gradle which gradle plugins to use to build this project.
 plugins {
     id 'java'
     id 'maven-publish'
     id 'biz.aQute.bnd.builder' version '6.4.0'
 }
 
+// This section tells gradle where it should look for any dependencies
 repositories {
     mavenLocal()
     mavenCentral()
@@ -13,9 +16,13 @@ repositories {
     // }
 }
 
+// Set the variables which will control what the built OSGi bundle will be called
+// and the name it will be published under in the maven repository.
 group = '{{ .Parent.GroupId }}'
 version = '0.0.1-SNAPSHOT'
 
+// What are the dependencies of the test code ? 
+// When more managers and dependencies are added, this list will need to grow.
 dependencies {
     implementation platform('dev.galasa:galasa-bom:{{.GalasaVersion}}')
 
@@ -27,6 +34,8 @@ dependencies {
     implementation 'org.assertj:assertj-core'
 }
 
+// Tell gradle to publish the built OSGi bundles as maven artifacts on the 
+// local maven repository.
 publishing {
     publications {
         maven(MavenPublication) {

--- a/pkg/utils/fileGenerator.go
+++ b/pkg/utils/fileGenerator.go
@@ -121,10 +121,20 @@ func (generator *FileGenerator) checkAllowedToWrite(targetFilePath string, force
 	return isAllowed, err
 }
 
+type BlankTemplateParameters struct{}
+
+// substituteParametersIntoTemplate renders the golang template into a string
 func (generator *FileGenerator) substituteParametersIntoTemplate(template *template.Template, templateParameters interface{}) (string, error) {
-	// Render the golang template into a string
 	var buffer bytes.Buffer
 	fileContents := ""
+
+	if templateParameters == nil {
+		// Template substitution blows up if there are no template
+		// parameters. So create a blank set of template parameters
+		// to keep the substitution engine happy.
+		templateParameters = BlankTemplateParameters{}
+	}
+
 	err := template.Execute(&buffer, templateParameters)
 	if err == nil {
 		fileContents = buffer.String()


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- [x] When you use `galasactl project create` you also get a `.gitignore` file generated to make sure the user doesn't check-in built artifacts.
