### PR TITLE
Update gradle file dependencies to work with later versions of Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,11 @@ repositories {
 apply plugin: 'java'
 dependencies {
     // We need the galasa-boot jar so we can launch tests in a local JVM
-    compileClasspath group: 'dev.galasa', name: 'galasa-boot', version: galasaBootJarVersion
+    implementation 'dev.galasa:galasa-boot:' + galasaBootJarVersion
     // We need the openapi generator to turn a yaml file into go client stubs, 
     // so we can call the api server REST services
     // https://mvnrepository.com/artifact/org.openapitools/openapi-generator
-    compileClasspath group: 'org.openapitools', name: 'openapi-generator-cli', version: '6.0.1'
+    implementation 'org.openapitools:openapi-generator-cli:6.0.1'
 }
 task downloadDependencies(type: Copy) {
     // Download the dependencies onto the local disk.


### PR DESCRIPTION
Declaring compileClasspath inside the dependencies clause is not supported in versions of Gradle later than 7. Using implementation instead is supported in various levels of Gradle, I have tested this with 6.9.2, 7.1 and 8.0.1 and all worked.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>