### PR TITLE
Bump openapi-generator-cli to 6.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     // We need the openapi generator to turn a yaml file into go client stubs, 
     // so we can call the api server REST services
     // https://mvnrepository.com/artifact/org.openapitools/openapi-generator
-    implementation 'org.openapitools:openapi-generator-cli:6.0.1'
+    implementation 'org.openapitools:openapi-generator-cli:6.1.0'
 }
 task downloadDependencies(type: Copy) {
     // Download the dependencies onto the local disk.


### PR DESCRIPTION
Bumping to keep consistency between the version used in this repo and the build pipelines. Tested openapi client generation with this version and found no issues.

Signed-off-by: Eamonn Mansour <47121388+eamansour@users.noreply.github.com>