### PR TITLE
--development flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ you will have to create and re-initialise the folder using the `galasactl local 
 The syntax is documented in generated documentation [here](docs/generated/galasactl.md)
 
 
+## Setting up your environment
+Run this command to set up your environment for future calls to the galasactl tooling.
+```
+galasactl local init
+```
+
+If you wish to build content which depends on the very latest/bleeding-edge of galasa code, 
+add the `--development` flag. This will set things up to include the maven repositories 
+in any new {HOME}/.m2/settings.xml file, if that doesn't already exist.
+
+This command respects the GALASA_HOME environment variable, and will set up a number of files
+there, or in {HOME}/.galasa otherwise.
+
+
 ## Creating an example project
 
 `galasactl` can be used to create near-empty test projects to lay-down an initial structure 
@@ -56,7 +70,6 @@ galasactl project create --package dev.galasa.example.banking --features payee,a
 ```
 
 
-
 ### Building the example project
 
 Maven and Gradle are both build tools, which read metadata from files which guide how the code within a module should be built. Maven and Gradle use different formats for these build files.
@@ -76,6 +89,7 @@ To build a project with Maven artifacts, use `mvn clean install`
 
 To build a project with Gradle artifacts, use `gradle build publishToMavenLocal`
 
+If you wish the generated code to depend upon the very latest/bleeding-edge of galasa code, then add the `--development` flag. This will add extra settings to the `settings.gradle` file.
 
 ## runs prepare
 

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -248,7 +248,7 @@ function generate_sample_code {
     cd $BASEDIR/temp
 
     export PACKAGE_NAME="dev.galasa.example.banking"
-    ${BASEDIR}/bin/${galasactl_command} project create --package ${PACKAGE_NAME} --features payee,account --obr ${BUILD_SYSTEM_FLAGS}
+    ${BASEDIR}/bin/${galasactl_command} project create --development --package ${PACKAGE_NAME} --features payee,account --obr ${BUILD_SYSTEM_FLAGS}
     rc=$?
     if [[ "${rc}" != "0" ]]; then
         error " Failed to create the galasa test project using galasactl command. rc=${rc}"

--- a/docs/generated/galasactl_local_init.md
+++ b/docs/generated/galasactl_local_init.md
@@ -13,7 +13,8 @@ galasactl local init [flags]
 ### Options
 
 ```
-  -h, --help   help for init
+      --development   Use bleeding-edge galasa versions and repositories.
+  -h, --help          help for init
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_project_create.md
+++ b/docs/generated/galasactl_project_create.md
@@ -13,6 +13,7 @@ galasactl project create [flags]
 ### Options
 
 ```
+      --development       Use bleeding-edge galasa versions and repositories.
       --features string   A comma-separated list of features you are testing. These must be able to form parts of a java package name. For example: "payee,account" (default "feature1")
       --force             Force-overwrite files which already exist.
       --gradle            Generate gradle build artifacts. Can be used in addition to the --maven flag.

--- a/pkg/cmd/localInit.go
+++ b/pkg/cmd/localInit.go
@@ -17,9 +17,13 @@ var (
 		Args:  cobra.NoArgs,
 		Run:   executeEnvInit,
 	}
+
+	isDevelopmentLocalInit bool
 )
 
 func init() {
+	localInitCmd.Flags().BoolVar(&isDevelopmentLocalInit, "development", false, "Use bleeding-edge galasa versions and repositories.")
+
 	parentCommand := localCmd
 	parentCommand.AddCommand(localInitCmd)
 }
@@ -31,20 +35,25 @@ func executeEnvInit(cmd *cobra.Command, args []string) {
 	fileSystem := utils.NewOSFileSystem()
 	env := utils.NewEnvironment()
 
-	err := localEnvInit(fileSystem, env, CmdParamGalasaHomePath)
+	err := localEnvInit(fileSystem, env, CmdParamGalasaHomePath, isDevelopmentLocalInit)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func localEnvInit(fileSystem utils.FileSystem, env utils.Environment, cmdFlagGalasaHome string) error {
+func localEnvInit(
+	fileSystem utils.FileSystem,
+	env utils.Environment,
+	cmdFlagGalasaHome string,
+	isDevelopment bool,
+) error {
 
 	galasaHome, err := utils.NewGalasaHome(fileSystem, env, cmdFlagGalasaHome)
 	if err == nil {
 		embeddedFileSystem := embedded.GetEmbeddedFileSystem()
 		err = utils.InitialiseGalasaHomeFolder(galasaHome, fileSystem, embeddedFileSystem)
 		if err == nil {
-			err = utils.InitialiseM2Folder(fileSystem, embeddedFileSystem)
+			err = utils.InitialiseM2Folder(fileSystem, embeddedFileSystem, isDevelopment)
 		}
 	}
 	return err

--- a/pkg/cmd/localInit_test.go
+++ b/pkg/cmd/localInit_test.go
@@ -10,13 +10,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCanCreateGalasaHomeFolderWhenNotAlreadyInitialised(t *testing.T) {
+func TestCanCreateGalasaHomeFolderWhenNotAlreadyInitialisedNonDevelopmentMode(t *testing.T) {
 	mockFileSystem := utils.NewMockFileSystem()
 	mockEnv := utils.NewMockEnv()
 	homeDir, _ := mockFileSystem.GetUserHomeDirPath()
 	galasaDir := homeDir + "/.galasa/"
 	m2Dir := homeDir + "/.m2/"
-	err := localEnvInit(mockFileSystem, mockEnv, "")
+	isDevelopment := false
+	cmdFlagGalasaHome := ""
+
+	err := localEnvInit(mockFileSystem, mockEnv, cmdFlagGalasaHome, isDevelopment)
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
@@ -25,7 +28,28 @@ func TestCanCreateGalasaHomeFolderWhenNotAlreadyInitialised(t *testing.T) {
 	assertCredentialsPropertiesCreated(t, mockFileSystem, galasaDir)
 	assertDSSPropertiesCreated(t, mockFileSystem, galasaDir)
 	assertOverridesPropertiesCreated(t, mockFileSystem, galasaDir)
-	assertSettingsXMLCreatedAndContentOk(t, mockFileSystem, m2Dir)
+	assertSettingsXMLCreatedAndContentOk(t, mockFileSystem, m2Dir, isDevelopment)
+}
+
+func TestCanCreateGalasaHomeFolderWhenNotAlreadyInitialisedWithDevelopmentMode(t *testing.T) {
+	mockFileSystem := utils.NewMockFileSystem()
+	mockEnv := utils.NewMockEnv()
+	homeDir, _ := mockFileSystem.GetUserHomeDirPath()
+	galasaDir := homeDir + "/.galasa/"
+	m2Dir := homeDir + "/.m2/"
+	isDevelopment := true
+	cmdFlagGalasaHome := ""
+
+	err := localEnvInit(mockFileSystem, mockEnv, cmdFlagGalasaHome, isDevelopment)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+	assertBootstrapPropertiesCreated(t, mockFileSystem, galasaDir)
+	assertCPSPropertiesCreated(t, mockFileSystem, galasaDir)
+	assertCredentialsPropertiesCreated(t, mockFileSystem, galasaDir)
+	assertDSSPropertiesCreated(t, mockFileSystem, galasaDir)
+	assertOverridesPropertiesCreated(t, mockFileSystem, galasaDir)
+	assertSettingsXMLCreatedAndContentOk(t, mockFileSystem, m2Dir, isDevelopment)
 }
 
 func TestCanCreateGalasaHomeFolderWhenAlreadyInitialised(t *testing.T) {
@@ -33,6 +57,9 @@ func TestCanCreateGalasaHomeFolderWhenAlreadyInitialised(t *testing.T) {
 	homeDir, _ := mockFileSystem.GetUserHomeDirPath()
 	galasaDir := homeDir + "/.galasa/"
 	m2Dir := homeDir + "/.m2/"
+	cmdFlagGalasaHome := ""
+	isDevelopment := false
+
 	mockFileSystem.WriteTextFile(galasaDir+"bootstrap.properties", "")
 	mockFileSystem.WriteTextFile(galasaDir+"dss.properties", "")
 	mockFileSystem.WriteTextFile(galasaDir+"cps.properties", "")
@@ -41,7 +68,7 @@ func TestCanCreateGalasaHomeFolderWhenAlreadyInitialised(t *testing.T) {
 	mockFileSystem.WriteTextFile(m2Dir+"settings.xml", "")
 
 	mockEnv := utils.NewMockEnv()
-	err := localEnvInit(mockFileSystem, mockEnv, "")
+	err := localEnvInit(mockFileSystem, mockEnv, cmdFlagGalasaHome, isDevelopment)
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
@@ -78,11 +105,17 @@ func assertOverridesPropertiesCreated(t *testing.T, mockFileSystem utils.FileSys
 	assert.True(t, testOverridesPropertiesExists, "Overrides properties was not created")
 }
 
-func assertSettingsXMLCreatedAndContentOk(t *testing.T, mockFileSystem utils.FileSystem, m2Dir string) {
+func assertSettingsXMLCreatedAndContentOk(t *testing.T, mockFileSystem utils.FileSystem, m2Dir string, isDevelopment bool) {
 	testSettingsXMLExists, err := mockFileSystem.Exists(m2Dir + "settings.xml")
 	assert.Nil(t, err)
 	assert.True(t, testSettingsXMLExists, "Settings.xml was not created")
 	settingsContent, err := mockFileSystem.ReadTextFile(m2Dir + "settings.xml")
 	assert.Nil(t, err)
 	assert.Contains(t, settingsContent, "<url>https://development.galasa.dev/main/maven-repo/obr</url>")
+
+	if isDevelopment {
+		assert.Contains(t, settingsContent, "<!-- Using the bleeding edge version of galasa. Comment out if not needed. -->")
+	} else {
+		assert.Contains(t, settingsContent, "<!-- To use the bleeding edge version of galasa, use the development obr")
+	}
 }

--- a/pkg/cmd/projectCreate_test.go
+++ b/pkg/cmd/projectCreate_test.go
@@ -20,10 +20,11 @@ func TestCanCreateProjectFailsIfPackageNameInvalid(t *testing.T) {
 	featureNamesCommandSeparatedList := "test"
 	maven := true
 	gradle := false
+	isDevelopment := false
 
 	// When ...
 	err := createProject(mockFileSystem, "very.INVALID_PACKAGE_NAME.very",
-		featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+		featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -39,9 +40,12 @@ func TestCanCreateProjectGoldenPathNoOBR(t *testing.T) {
 	featureNamesCommandSeparatedList := "test"
 	maven := true
 	gradle := false
+	isDevelopment := false
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(
+		mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -181,6 +185,7 @@ func TestCreateProjectErrorsWhenMkAllDirsFails(t *testing.T) {
 	featureNamesCommandSeparatedList := "test"
 	maven := true
 	gradle := false
+	isDevelopment := false
 
 	// Over-ride the default MkdirAll function so that it fails...
 	mockFileSystem.VirtualFunction_MkdirAll = func(targetFolderPath string) error {
@@ -188,7 +193,9 @@ func TestCreateProjectErrorsWhenMkAllDirsFails(t *testing.T) {
 	}
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(
+		mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	assert.NotNil(t, err, "Sumulated error didn't bubble up to the top.")
@@ -204,6 +211,7 @@ func TestCreateProjectErrorsWhenWriteTextFileFails(t *testing.T) {
 	featureNamesCommandSeparatedList := "test"
 	maven := true
 	gradle := false
+	isDevelopment := false
 
 	// Over-ride the default WriteTextFile function so that it fails...
 	mockFileSystem.VirtualFunction_WriteTextFile = func(targetFilePath string, desiredContents string) error {
@@ -211,7 +219,9 @@ func TestCreateProjectErrorsWhenWriteTextFileFails(t *testing.T) {
 	}
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(
+		mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	assert.NotNil(t, err, "Sumulated error didn't bubble up to the top.")
@@ -227,13 +237,16 @@ func TestCreateProjectPomFileAlreadyExistsNoForceOverwrite(t *testing.T) {
 	featureNamesCommandSeparatedList := "test"
 	maven := true
 	gradle := false
+	isDevelopment := false
 
 	// Create a pom.xml file already...
 	mockFileSystem.MkdirAll(testPackageName)
 	mockFileSystem.WriteTextFile(testPackageName+"/pom.xml", "dummy test pom.xml")
 
 	// When ...
-	err := createProject(mockFileSystem, testPackageName, featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(
+		mockFileSystem, testPackageName, featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -250,13 +263,16 @@ func TestCreateProjectPomFileAlreadyExistsWithForceOverwrite(t *testing.T) {
 	featureNamesCommandSeparatedList := "test"
 	maven := true
 	gradle := false
+	isDevelopment := false
 
 	// Create a pom.xml file already...
 	mockFileSystem.MkdirAll(testPackageName)
 	mockFileSystem.WriteTextFile(testPackageName+"/pom.xml", "dummy test pom.xml")
 
 	// When ...
-	err := createProject(mockFileSystem, testPackageName, featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(
+		mockFileSystem, testPackageName, featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -285,9 +301,12 @@ func TestCanCreateProjectGoldenPathWithOBR(t *testing.T) {
 	featureNamesCommandSeparatedList := "test"
 	maven := true
 	gradle := false
+	isDevelopment := false
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(
+		mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -338,10 +357,13 @@ func TestCreateProjectWithTwoFeaturesWorks(t *testing.T) {
 	featureNamesCommandSeparatedList := "account,payee"
 	maven := true
 	gradle := false
+	isDevelopment := false
 
 	// When ...
-	err := createProject(mockFileSystem, testPackageName,
-		featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(
+		mockFileSystem, testPackageName,
+		featureNamesCommandSeparatedList, isObrProjectRequired,
+		forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -365,10 +387,12 @@ func TestCreateProjectWithInvalidFeaturesFails(t *testing.T) {
 	featureNamesCommandSeparatedList := "Account"
 	maven := true
 	gradle := false
+	isDevelopment := false
 
 	// When ...
 	err := createProject(mockFileSystem, testPackageName,
-		featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+		featureNamesCommandSeparatedList, isObrProjectRequired,
+		forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -385,9 +409,11 @@ func TestCanCreateGradleProjectWithNoOBR(t *testing.T) {
 	featureNamesCommandSeparatedList := "test"
 	maven := false
 	gradle := true
+	isDevelopment := false
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -407,9 +433,12 @@ func TestCanCreateGradleProjectWithOBR(t *testing.T) {
 	featureNamesCommandSeparatedList := "test"
 	maven := false
 	gradle := true
+	isDevelopment := false
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(
+		mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -430,9 +459,12 @@ func TestCanCreateMavenAndGradleProject(t *testing.T) {
 	featureNamesCommandSeparatedList := "test"
 	maven := true
 	gradle := true
+	isDevelopment := false
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(
+		mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -453,9 +485,12 @@ func TestCreateProjectDefaultsToMavenProject(t *testing.T) {
 	maven := false
 	gradle := false
 	expectMaven := true
+	isDevelopment := false
 
 	// When ...
-	err := createProject(mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList, isObrProjectRequired, forceOverwrite, maven, gradle)
+	err := createProject(
+		mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -465,4 +500,56 @@ func TestCreateProjectDefaultsToMavenProject(t *testing.T) {
 
 	assertParentFolderAndContentsCreated(t, mockFileSystem, isObrProjectRequired, expectMaven, gradle)
 	assertTestFolderAndContentsCreatedOk(t, mockFileSystem, "test", expectMaven, gradle)
+}
+
+func TestCanCreateGradleProjectNonDevelopmentModeGeneratesCommentedOutMavenRepoReference(t *testing.T) {
+	// Given...
+	mockFileSystem := utils.NewMockFileSystem()
+	forceOverwrite := true
+	isObrProjectRequired := true
+	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := true
+	isDevelopment := false
+
+	// When ...
+	err := createProject(
+		mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
+
+	// Then...
+	// Should have created a folder for the parent package.
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	text, err := mockFileSystem.ReadTextFile("my.test.pkg/settings.gradle")
+	assert.Nil(t, err)
+	assert.Contains(t, text, "//    url 'https://development.galasa.dev/main/maven-repo/obr'", "parent settings.gradle didn't have a commented-out bleeding edge repo ref.")
+}
+
+func TestCanCreateGradleProjectDevelopmentModeGeneratesMavenRepoReference(t *testing.T) {
+	// Given...
+	mockFileSystem := utils.NewMockFileSystem()
+	forceOverwrite := true
+	isObrProjectRequired := true
+	featureNamesCommandSeparatedList := "test"
+	maven := false
+	gradle := true
+	isDevelopment := true
+
+	// When ...
+	err := createProject(
+		mockFileSystem, "my.test.pkg", featureNamesCommandSeparatedList,
+		isObrProjectRequired, forceOverwrite, maven, gradle, isDevelopment)
+
+	// Then...
+	// Should have created a folder for the parent package.
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	text, err := mockFileSystem.ReadTextFile("my.test.pkg/settings.gradle")
+	assert.Nil(t, err)
+	assert.Contains(t, text, "           url 'https://development.galasa.dev/main/maven-repo/obr'", "parent settings.gradle didn't have a commented-out bleeding edge repo ref.")
 }

--- a/pkg/embedded/templates/m2/settings.xml
+++ b/pkg/embedded/templates/m2/settings.xml
@@ -1,31 +1,51 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-     <pluginGroups>
-         <pluginGroup>dev.galasa</pluginGroup>
-     </pluginGroups>
+    <pluginGroups>
+        <pluginGroup>dev.galasa</pluginGroup>
+    </pluginGroups>
      
-     <profiles>
-         <profile>
-             <id>galasa</id>
-             <activation>
-                 <activeByDefault>true</activeByDefault>
-             </activation>
-             <repositories>
-                 <repository>
-                     <id>galasa.repo</id>
-                     <url>https://repo.maven.apache.org/maven2/</url>
-                     <!-- To use the bleeding edge version of galasa, use the development obr
-                     <url>https://development.galasa.dev/main/maven-repo/obr</url> -->
-                 </repository>
-             </repositories>
-             <pluginRepositories>
-                 <pluginRepository>
-                     <id>galasa.repo</id>
-                     <url>https://repo.maven.apache.org/maven2/</url>
-                     <!-- To use the bleeding edge version of galasa, use the development obr
-                     <url>https://development.galasa.dev/main/maven-repo/obr</url> -->
-                 </pluginRepository>
+    <profiles>
+        <profile>
+            <id>galasa</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>maven.central</id>
+                    <url>https://repo.maven.apache.org/maven2/</url>
+                </repository>
+                {{- if .IsDevelopment }}
+                <!-- Using the bleeding edge version of galasa. Comment out if not needed. -->
+                {{- else }}
+                <!-- To use the bleeding edge version of galasa, use the development obr
+                {{- end }}
+                <repository>
+                    <id>galasa.repo</id>
+                    <url>https://development.galasa.dev/main/maven-repo/obr</url> 
+                </repository>
+                {{- if not .IsDevelopment }}
+                -->
+                {{- end }}
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>maven.central</id>
+                    <url>https://repo.maven.apache.org/maven2/</url>
+                </pluginRepository>
+                {{- if .IsDevelopment }}
+                <!-- Using the bleeding edge version of galasa. Comment out if not needed. -->
+                {{- else }}
+                <!-- To use the bleeding edge version of galasa, use the development obr
+                {{- end }}
+                <pluginRepository>
+                    <id>galasa.repo</id>    
+                    <url>https://development.galasa.dev/main/maven-repo/obr</url> 
+                </pluginRepository>
+                {{- if not .IsDevelopment }}
+                -->
+                {{- end }}
              </pluginRepositories>
          </profile>
      </profiles>

--- a/pkg/embedded/templates/projectCreate/parent-project/settings.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/settings.gradle.template
@@ -4,10 +4,19 @@ pluginManagement {
     repositories {
         mavenLocal()
         mavenCentral()
+
+        {{- if .IsDevelopment }}
+        // To use the bleeding edge version of galasa's obr plugin, use the development obr
+        maven {
+            url 'https://development.galasa.dev/main/maven-repo/obr'
+        }
+        {{- else }}
         // To use the bleeding edge version of galasa's obr plugin, use the development obr
         // maven {
-        //    url = 'https://development.galasa.dev/main/maven-repo/obr'
+        //    url 'https://development.galasa.dev/main/maven-repo/obr'
         // }
+        {{- end }}
+
         gradlePluginPortal()
     }
 }

--- a/pkg/utils/m2FolderCreator.go
+++ b/pkg/utils/m2FolderCreator.go
@@ -16,7 +16,7 @@ const (
 	MAVEN_REPO_URL_MAVEN_CENTRAL        = "https://repo.maven.apache.org/maven2"
 )
 
-func InitialiseM2Folder(fileSystem FileSystem, embeddedFileSystem embed.FS) error {
+func InitialiseM2Folder(fileSystem FileSystem, embeddedFileSystem embed.FS, isDevelopment bool) error {
 
 	var err error
 	var userHomeDir string
@@ -29,22 +29,35 @@ func InitialiseM2Folder(fileSystem FileSystem, embeddedFileSystem embed.FS) erro
 		err = fileGenerator.CreateFolder(m2Dir)
 
 		if err == nil {
-			err = createSettingsXMLFile(fileGenerator, fileSystem, m2Dir)
+			err = createSettingsXMLFile(fileGenerator, fileSystem, m2Dir, isDevelopment)
 		}
 	}
 
 	return err
 }
 
-func createSettingsXMLFile(fileGenerator *FileGenerator, fileSystem FileSystem, m2Dir string) error {
+func createSettingsXMLFile(
+	fileGenerator *FileGenerator,
+	fileSystem FileSystem,
+	m2Dir string,
+	isDevelopment bool,
+) error {
 
 	targetPath := m2Dir + fileSystem.GetFilePathSeparator() + "settings.xml"
+
+	type M2SettingsXmlTemplateParams struct {
+		IsDevelopment bool
+	}
+
+	templateParameters := M2SettingsXmlTemplateParams{
+		IsDevelopment: isDevelopment,
+	}
 
 	xmlFile := GeneratedFileDef{
 		FileType:                 "xml",
 		TargetFilePath:           targetPath,
 		EmbeddedTemplateFilePath: "templates/m2/settings.xml",
-		TemplateParameters:       nil,
+		TemplateParameters:       templateParameters,
 	}
 
 	settingsFileExists, err := fileSystem.Exists(targetPath)

--- a/pkg/utils/m2FolderCreator_test.go
+++ b/pkg/utils/m2FolderCreator_test.go
@@ -17,9 +17,10 @@ func TestCanCreateM2FolderAndSettingsXML(t *testing.T) {
 	// Given...
 	mockFileSystem := NewMockFileSystem()
 	embeddedFileSystem := embedded.GetEmbeddedFileSystem()
+	isDevelopment := false
 
 	// When ...
-	err := InitialiseM2Folder(mockFileSystem, embeddedFileSystem)
+	err := InitialiseM2Folder(mockFileSystem, embeddedFileSystem, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -46,8 +47,10 @@ func TestWhenM2SettingsExistButReposNotPresentYouGetAWarningAboutRequiredReposYo
 	mockFileSystem := newMockFSContainingSettingsXml(settingsXmlContents)
 
 	embeddedFileSystem := embedded.GetEmbeddedFileSystem()
+	isDevelopment := false
+
 	// When ...
-	err := InitialiseM2Folder(mockFileSystem, embeddedFileSystem)
+	err := InitialiseM2Folder(mockFileSystem, embeddedFileSystem, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -80,8 +83,10 @@ func checkThatDifferentSettingsXmlFileContentsCauseFailure(t *testing.T, setting
 	mockFileSystem := newMockFSContainingSettingsXml(settingsXmlContents)
 
 	embeddedFileSystem := embedded.GetEmbeddedFileSystem()
+	isDevelopment := false
+
 	// When ...
-	err := InitialiseM2Folder(mockFileSystem, embeddedFileSystem)
+	err := InitialiseM2Folder(mockFileSystem, embeddedFileSystem, isDevelopment)
 
 	// Then...
 	// Should have created a folder for the parent package.
@@ -108,13 +113,14 @@ func TestWhenM2SettingsExistCheckFailsErrorGetsReturned(t *testing.T) {
 	mockFileSystem := newMockFSContainingSettingsXml(settingsXmlContents)
 
 	embeddedFileSystem := embedded.GetEmbeddedFileSystem()
+	isDevelopment := false
 
 	mockFileSystem.VirtualFunction_Exists = func(targetFolderPath string) (bool, error) {
 		return false, errors.New("Simulated Exists() method failure")
 	}
 
 	// When ...
-	err := InitialiseM2Folder(mockFileSystem, embeddedFileSystem)
+	err := InitialiseM2Folder(mockFileSystem, embeddedFileSystem, isDevelopment)
 
 	// Then...
 
@@ -132,13 +138,14 @@ func TestWhenM2SettingsReadTextFileFailsErrorGetsReturned(t *testing.T) {
 	mockFileSystem := newMockFSContainingSettingsXml(settingsXmlContents)
 
 	embeddedFileSystem := embedded.GetEmbeddedFileSystem()
+	isDevelopment := false
 
 	mockFileSystem.VirtualFunction_ReadTextFile = func(targetFolderPath string) (string, error) {
 		return "", errors.New("Simulated Exists() method failure")
 	}
 
 	// When ...
-	err := InitialiseM2Folder(mockFileSystem, embeddedFileSystem)
+	err := InitialiseM2Folder(mockFileSystem, embeddedFileSystem, isDevelopment)
 
 	// Then...
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- [x] `--development` flag to use in `galasactl local init --development`
- [x] `--development` flag to use in `galasactl project create --development ...`
- [x] docs updated in the README.

this PR relates to story https://github.com/galasa-dev/projectmanagement/issues/1434
