### PR TITLE
--development flag - continued

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To build a project with Maven artifacts, use `mvn clean install`
 
 To build a project with Gradle artifacts, use `gradle build publishToMavenLocal`
 
-If you wish the generated code to depend upon the very latest/bleeding-edge of galasa code, then add the `--development` flag. This will add extra settings to the `settings.gradle` file of the parent and the `build.gradle` file of the child test project.
+If you wish the generated code to depend upon the very latest/bleeding-edge of galasa code, then add the `--development` flag. This will add extra settings to the `settings.gradle` file of the parent and the `build.gradle` file of any of the child test projects.
 
 ## runs prepare
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To build a project with Maven artifacts, use `mvn clean install`
 
 To build a project with Gradle artifacts, use `gradle build publishToMavenLocal`
 
-If you wish the generated code to depend upon the very latest/bleeding-edge of galasa code, then add the `--development` flag. This will add extra settings to the `settings.gradle` file.
+If you wish the generated code to depend upon the very latest/bleeding-edge of galasa code, then add the `--development` flag. This will add extra settings to the `settings.gradle` file of the parent and the `build.gradle` file of the child test project.
 
 ## runs prepare
 

--- a/pkg/cmd/projectCreate.go
+++ b/pkg/cmd/projectCreate.go
@@ -180,7 +180,7 @@ func createProject(
 
 			if err == nil {
 				err = createTestProjects(fileGenerator, packageName, featureNames, forceOverwrite,
-					useMaven, useGradle)
+					useMaven, useGradle, isDevelopment)
 				if err == nil {
 					if isOBRProjectRequired {
 						err = createOBRProject(fileGenerator, packageName, featureNames,
@@ -366,11 +366,13 @@ func createTestProjects(
 	featureNames []string,
 	forceOverwrite bool,
 	useMaven bool,
-	useGradle bool) error {
+	useGradle bool,
+	isDevelopment bool,
+) error {
 
 	var err error = nil
 	for _, featureName := range featureNames {
-		err = createTestProject(fileGenerator, packageName, featureName, forceOverwrite, useMaven, useGradle)
+		err = createTestProject(fileGenerator, packageName, featureName, forceOverwrite, useMaven, useGradle, isDevelopment)
 		if err != nil {
 			break
 		}
@@ -385,7 +387,9 @@ func createTestProject(
 	featureName string,
 	forceOverwrite bool,
 	useMaven bool,
-	useGradle bool) error {
+	useGradle bool,
+	isDevelopment bool,
+) error {
 
 	targetFolderPath := packageName + "/" + packageName + "." + featureName
 	log.Printf("Creating tests project %s\n", targetFolderPath)
@@ -398,7 +402,7 @@ func createTestProject(
 		}
 
 		if useGradle {
-			err = createTestFolderGradle(fileGenerator, targetFolderPath, packageName, featureName, forceOverwrite)
+			err = createTestFolderGradle(fileGenerator, targetFolderPath, packageName, featureName, forceOverwrite, isDevelopment)
 		}
 	}
 
@@ -547,19 +551,21 @@ func createTestFolderPom(fileGenerator *utils.FileGenerator, targetTestFolderPat
 
 // Creates a build.gradle and a bnd.bnd file in a Gradle test project directory.
 func createTestFolderGradle(fileGenerator *utils.FileGenerator, targetTestFolderPath string,
-	packageName string, featureName string, forceOverwrite bool) error {
+	packageName string, featureName string, forceOverwrite bool, isDevelopment bool) error {
 
 	type TestGradleParameters struct {
 		Parent      GradleCoordinates
 		Coordinates GradleCoordinates
 		// Version of Galasa we are targetting
 		GalasaVersion string
+		IsDevelopment bool
 	}
 
 	gradleProjectTemplateParameters := TestGradleParameters{
 		Parent:        GradleCoordinates{GroupId: packageName, Name: packageName},
 		Coordinates:   GradleCoordinates{GroupId: packageName, Name: packageName + "." + featureName},
-		GalasaVersion: embedded.GetGalasaVersion()}
+		GalasaVersion: embedded.GetGalasaVersion(),
+		IsDevelopment: isDevelopment}
 
 	buildGradleFile := utils.GeneratedFileDef{
 		FileType:                 "gradle",

--- a/pkg/cmd/projectCreate_test.go
+++ b/pkg/cmd/projectCreate_test.go
@@ -523,9 +523,14 @@ func TestCanCreateGradleProjectNonDevelopmentModeGeneratesCommentedOutMavenRepoR
 		assert.Fail(t, err.Error())
 	}
 
-	text, err := mockFileSystem.ReadTextFile("my.test.pkg/settings.gradle")
+	settingsGradleText, err := mockFileSystem.ReadTextFile("my.test.pkg/settings.gradle")
 	assert.Nil(t, err)
-	assert.Contains(t, text, "//    url 'https://development.galasa.dev/main/maven-repo/obr'", "parent settings.gradle didn't have a commented-out bleeding edge repo ref.")
+	assert.Contains(t, settingsGradleText, "//    url 'https://development.galasa.dev/main/maven-repo/obr'", "parent settings.gradle didn't have a commented-out bleeding edge repo ref.")
+
+	buildGradleText, err := mockFileSystem.ReadTextFile("my.test.pkg/my.test.pkg.test/build.gradle")
+	assert.Nil(t, err)
+	assert.Contains(t, buildGradleText, "//    url 'https://development.galasa.dev/main/maven-repo/obr'", "child build.gradle didn't have a commented-out bleeding edge repo ref.")
+
 }
 
 func TestCanCreateGradleProjectDevelopmentModeGeneratesMavenRepoReference(t *testing.T) {
@@ -549,7 +554,11 @@ func TestCanCreateGradleProjectDevelopmentModeGeneratesMavenRepoReference(t *tes
 		assert.Fail(t, err.Error())
 	}
 
-	text, err := mockFileSystem.ReadTextFile("my.test.pkg/settings.gradle")
+	settingsGradleText, err := mockFileSystem.ReadTextFile("my.test.pkg/settings.gradle")
 	assert.Nil(t, err)
-	assert.Contains(t, text, "           url 'https://development.galasa.dev/main/maven-repo/obr'", "parent settings.gradle didn't have a commented-out bleeding edge repo ref.")
+	assert.Contains(t, settingsGradleText, "           url 'https://development.galasa.dev/main/maven-repo/obr'", "parent settings.gradle didn't have an uncommented bleeding edge repo ref.")
+
+	buildGradleText, err := mockFileSystem.ReadTextFile("my.test.pkg/my.test.pkg.test/build.gradle")
+	assert.Nil(t, err)
+	assert.Contains(t, buildGradleText, "       url 'https://development.galasa.dev/main/maven-repo/obr'", "child build.gradle didn't have an uncommented bleeding edge repo ref.")
 }

--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
@@ -10,10 +10,19 @@ plugins {
 repositories {
     mavenLocal()
     mavenCentral()
-    // To use the bleeding edge version of galasa, use the development obr
+
+    {{- if .IsDevelopment }}
+    // To use the bleeding edge version of galasa's obr plugin, use the development obr
+    maven {
+        url 'https://development.galasa.dev/main/maven-repo/obr'
+    }
+    {{- else }}
+    // To use the bleeding edge version of galasa's obr plugin, use the development obr
     // maven {
-    //   url = 'https://development.galasa.dev/main/maven-repo/obr'
+    //    url 'https://development.galasa.dev/main/maven-repo/obr'
     // }
+    {{- end }}
+
 }
 
 // Set the variables which will control what the built OSGi bundle will be called


### PR DESCRIPTION
I forgot to spec in the work item that the child test project's build.gradle would also need to be affected by the --development flag and include or not include the development.galasa.dev repository.

- Updates made to project create
- Updates to the build.gradle.template
- Updates to the tests
- Update to README.md

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>