### PR TITLE
make log redirector testable. log can't be a folder.

### DIFF
--- a/docs/generated/errors-list.md
+++ b/docs/generated/errors-list.md
@@ -69,4 +69,5 @@ The `galasactl` tool can generate the following errors:
 - GAL1066E: Badly formed Class parameter '{}'. Expected it to be of the form <OSGiBundleId>/<FullyQualifiedJavaClass> with no .class suffix. Unwanted .class suffix detected.
 - GAL1067E: Unsupported value '{}' for parameter --output. Supported values are: 'summary'.
 - GAL1068E: Could not query run results. Reason: '{}'
+- GAL1069E: Could not open log file for writing. '{}' is a directory, the --log parameter should refer to a file path (existing or not), or '-' (the console)
 - GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '{}', and 'pre-release' repository is '{}'

--- a/pkg/cmd/localInit.go
+++ b/pkg/cmd/localInit.go
@@ -29,13 +29,21 @@ func init() {
 }
 
 func executeEnvInit(cmd *cobra.Command, args []string) {
-	utils.CaptureLog(logFileName)
+
+	var err error = nil
+
+	// Operations on the file system will all be relative to the current folder.
+	fileSystem := utils.NewOSFileSystem()
+
+	err = utils.CaptureLog(fileSystem, logFileName)
+	if err != nil {
+		panic(err)
+	}
 	isCapturingLogs = true
 
-	fileSystem := utils.NewOSFileSystem()
 	env := utils.NewEnvironment()
 
-	err := localEnvInit(fileSystem, env, CmdParamGalasaHomePath, isDevelopmentLocalInit)
+	err = localEnvInit(fileSystem, env, CmdParamGalasaHomePath, isDevelopmentLocalInit)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cmd/projectCreate.go
+++ b/pkg/cmd/projectCreate.go
@@ -78,15 +78,20 @@ func init() {
 
 func executeCreateProject(cmd *cobra.Command, args []string) {
 
-	utils.CaptureLog(logFileName)
-	isCapturingLogs = true
-
-	log.Println("Galasa CLI - Create project")
+	var err error = nil
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := utils.NewOSFileSystem()
 
-	err := createProject(fileSystem, packageName, featureNamesCommaSeparated,
+	err = utils.CaptureLog(fileSystem, logFileName)
+	if err != nil {
+		panic(err)
+	}
+	isCapturingLogs = true
+
+	log.Println("Galasa CLI - Create project")
+
+	err = createProject(fileSystem, packageName, featureNamesCommaSeparated,
 		isOBRProjectRequired, force, useMaven, useGradle, isDevelopmentProjectCreate)
 
 	// Convey the error to the top level.

--- a/pkg/cmd/runsGet.go
+++ b/pkg/cmd/runsGet.go
@@ -43,13 +43,16 @@ func executeRunsGet(cmd *cobra.Command, args []string) {
 
 	var err error
 
-	utils.CaptureLog(logFileName)
+	// Operations on the file system will all be relative to the current folder.
+	fileSystem := utils.NewOSFileSystem()
+
+	err = utils.CaptureLog(fileSystem, logFileName)
+	if err != nil {
+		panic(err)
+	}
 	isCapturingLogs = true
 
 	log.Println("Galasa CLI - Get info about a run")
-
-	// Operations on the file system will all be relative to the current folder.
-	fileSystem := utils.NewOSFileSystem()
 
 	// Get the ability to query environment variables.
 	env := utils.NewEnvironment()

--- a/pkg/cmd/runsPrepare.go
+++ b/pkg/cmd/runsPrepare.go
@@ -42,14 +42,18 @@ func init() {
 }
 
 func executeAssemble(cmd *cobra.Command, args []string) {
-
-	utils.CaptureLog(logFileName)
-	isCapturingLogs = true
-
-	log.Println("Galasa CLI - Assemble tests")
+	var err error = nil
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := utils.NewOSFileSystem()
+
+	err = utils.CaptureLog(fileSystem, logFileName)
+	if err != nil {
+		panic(err)
+	}
+	isCapturingLogs = true
+
+	log.Println("Galasa CLI - Assemble tests")
 
 	// Get the ability to query environment variables.
 	env := utils.NewEnvironment()

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -87,13 +87,16 @@ func executeSubmit(cmd *cobra.Command, args []string) {
 
 	var err error
 
-	utils.CaptureLog(logFileName)
+	// Operations on the file system will all be relative to the current folder.
+	fileSystem := utils.NewOSFileSystem()
+
+	err = utils.CaptureLog(fileSystem, logFileName)
+	if err != nil {
+		panic(err)
+	}
 	isCapturingLogs = true
 
 	log.Println("Galasa CLI - Submit tests (Remote)")
-
-	// Operations on the file system will all be relative to the current folder.
-	fileSystem := utils.NewOSFileSystem()
 
 	// Get the ability to query environment variables.
 	env := utils.NewEnvironment()
@@ -111,11 +114,11 @@ func executeSubmit(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
-		timeService := utils.NewRealTimeService()
-		var launcherInstance launcher.Launcher = nil
+	timeService := utils.NewRealTimeService()
+	var launcherInstance launcher.Launcher = nil
 
-		// The launcher we are going to use to start/monitor tests.
-		launcherInstance = launcher.NewRemoteLauncher(bootstrapData.ApiServerURL)
+	// The launcher we are going to use to start/monitor tests.
+	launcherInstance = launcher.NewRemoteLauncher(bootstrapData.ApiServerURL)
 
 	if err == nil {
 		err = runs.ExecuteSubmitRuns(galasaHome, fileSystem, runsSubmitCmdParams, launcherInstance, timeService, &submitSelectionFlags)

--- a/pkg/cmd/runsSubmitLocal.go
+++ b/pkg/cmd/runsSubmitLocal.go
@@ -56,15 +56,18 @@ func init() {
 
 func executeSubmitLocal(cmd *cobra.Command, args []string) {
 
-	var err error
-
-	utils.CaptureLog(logFileName)
-	isCapturingLogs = true
-
-	log.Println("Galasa CLI - Submit tests (Local)")
+	var err error = nil
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := utils.NewOSFileSystem()
+
+	err = utils.CaptureLog(fileSystem, logFileName)
+	if err != nil {
+		panic(err)
+	}
+	isCapturingLogs = true
+
+	log.Println("Galasa CLI - Submit tests (Local)")
 
 	// Get the ability to query environment variables.
 	env := utils.NewEnvironment()

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -90,7 +90,7 @@ var (
 	GALASA_ERROR_TESTS_FAILED                   = NewMessageType("GAL1017E: Not all runs passed. %v failed.", 1017, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_NO_TESTS_SELECTED              = NewMessageType("GAL1018E: No tests were selected.", 1018, STACK_TRACE_WANTED)
 	GALASA_ERROR_PREPARE_INVALID_OVERRIDE       = NewMessageType("GAL1019E: Invalid override '%v'", 1019, STACK_TRACE_WANTED)
-	GALASA_ERROR_OPEN_LOG_FILE_FAILED           = NewMessageType("GAL1020E: Failed to open log file '%s' for writing. Reason is %s", 1020, STACK_TRACE_WANTED)
+	GALASA_ERROR_OPEN_LOG_FILE_FAILED           = NewMessageType("GAL1020E: Failed to open log file '%s' for writing. Reason is %s", 1020, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_OPEN_PORTFOLIO_FILE_FAILED     = NewMessageType("GAL1021E: Failed to open portfolio file '%s' for reading. Reason is %s", 1021, STACK_TRACE_WANTED)
 	GALASA_ERROR_PORTFOLIO_BAD_FORMAT           = NewMessageType("GAL1022E: Failed to read portfolio file '%s' because the content is in the wrong format. Reason is %s", 1022, STACK_TRACE_WANTED)
 	GALASA_ERROR_PORTFOLIO_BAD_FORMAT_VERSION   = NewMessageType("GAL1023E: Failed to read portfolio file '%s' because the content are not using format '%s'.", 1023, STACK_TRACE_WANTED)
@@ -139,6 +139,7 @@ var (
 	GALASA_ERROR_INVALID_CLASS_SUFFIX_FOUND     = NewMessageType("GAL1066E: Badly formed Class parameter '%s'. Expected it to be of the form <OSGiBundleId>/<FullyQualifiedJavaClass> with no .class suffix. Unwanted .class suffix detected.", 1066, STACK_TRACE_WANTED)
 	GALASA_ERROR_INVALID_OUTPUT_FORMAT          = NewMessageType("GAL1067E: Unsupported value '%s' for parameter --output. Supported values are: 'summary'.", 1067, STACK_TRACE_WANTED)
 	GALASA_ERROR_QUERY_RUNS_FAILED              = NewMessageType("GAL1068E: Could not query run results. Reason: '%s'", 1068, STACK_TRACE_WANTED)
+	GALASA_ERROR_LOG_FILE_IS_A_FOLDER           = NewMessageType("GAL1069E: Could not open log file for writing. '%s' is a directory, the --log parameter should refer to a file path (existing or not), or '-' (the console)", 1069, STACK_TRACE_NOT_WANTED)
 
 	// Warnings...
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'pre-release' repository is '%s'", 2000, STACK_TRACE_WANTED)

--- a/pkg/utils/fileSystem.go
+++ b/pkg/utils/fileSystem.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"errors"
+	"io"
 	"os"
 	pathUtils "path"
 	"runtime"
@@ -25,6 +26,9 @@ type FileSystem interface {
 	OutputWarningMessage(string) error
 	MkTempDir() (string, error)
 	DeleteDir(path string)
+
+	// Creates a file in the file system if it can.
+	Create(path string) (io.Writer, error)
 
 	// Returns the normal extension used for executable files.
 	// ie: The .exe suffix in windows, or "" in unix-like systems.
@@ -65,6 +69,11 @@ func NewOSFileSystem() FileSystem {
 // ------------------------------------------------------------------------------------
 // Interface methods...
 // ------------------------------------------------------------------------------------
+
+func (osFS *OSFileSystem) Create(path string) (io.Writer, error) {
+	fileWriter, err := os.Create(path)
+	return fileWriter, err
+}
 
 func (osFS *OSFileSystem) GetFilePathSeparator() string {
 	return string(os.PathSeparator)

--- a/pkg/utils/fileSystemMock.go
+++ b/pkg/utils/fileSystemMock.go
@@ -5,6 +5,8 @@ package utils
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"log"
 	"math"
 	"math/rand"
@@ -47,6 +49,7 @@ type MockFileSystem struct {
 	VirtualFunction_OutputWarningMessage func(string) error
 	VirtualFunction_MkTempDir            func() (string, error)
 	VirtualFunction_DeleteDir            func(path string)
+	VirtualFunction_Create               func(path string) (io.Writer, error)
 }
 
 // NewMockFileSystem creates an implementation of the thin file system layer which delegates
@@ -74,6 +77,11 @@ func NewOverridableMockFileSystem() *MockFileSystem {
 
 	// Set up functions inside the structure to call the basic/default mock versions...
 	// These can later be over-ridden on a test-by-test basis.
+
+	mockFileSystem.VirtualFunction_Create = func(path string) (io.Writer, error) {
+		return mockFSCreate(mockFileSystem, path)
+	}
+
 	mockFileSystem.VirtualFunction_MkdirAll = func(targetFolderPath string) error {
 		return mockFSMkdirAll(mockFileSystem, targetFolderPath)
 	}
@@ -124,6 +132,10 @@ func (fs *MockFileSystem) SetExecutableExtension(newExtension string) {
 //------------------------------------------------------------------------------------
 // Interface methods...
 //------------------------------------------------------------------------------------
+
+func (fs *MockFileSystem) Create(path string) (io.Writer, error) {
+	return fs.Create(path)
+}
 
 func (fs *MockFileSystem) GetFilePathSeparator() string {
 	return fs.filePathSeparator
@@ -184,6 +196,13 @@ func (fs MockFileSystem) OutputWarningMessage(message string) error {
 // ------------------------------------------------------------------------------------
 // Default implementations of the methods...
 // ------------------------------------------------------------------------------------
+
+func mockFSCreate(fs MockFileSystem, path string) (io.Writer, error) {
+	var writer io.Writer = nil
+	err := errors.New("Not implemented")
+	return writer, err
+}
+
 func mockFSDeleteDir(fs MockFileSystem, pathToDelete string) {
 
 	// Figure out which entries we are going to delete.

--- a/pkg/utils/logRedirector_test.go
+++ b/pkg/utils/logRedirector_test.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogRedirectorFailsWhenLogFileIsAFolder(t *testing.T) {
+
+	var err error = nil
+
+	fileSystem := NewOverridableMockFileSystem()
+
+	// Create a fake folder '.'
+	logFileName := "."
+	fileSystem.MkdirAll(logFileName)
+
+	err = CaptureLog(fileSystem, logFileName)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "GAL1069")
+}


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

This PR is created to address the issue raised in this bug report: https://github.com/galasa-dev/projectmanagement/issues/1451

- [x] logRedirector is now testable
- [x] unit test that checks logRedirector delivers decent error if the log file is a folder.
