### PR TITLE
Extended testcase now writes a file to the artifacts root in RAS

### DIFF
--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/pom.xml
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/pom.xml
@@ -28,6 +28,12 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>dev.galasa</groupId>
+            <artifactId>dev.galasa.core.manager</artifactId>
+        </dependency>
+        
     </dependencies>
   
 </project>

--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/src/main/java/TestExtended.java.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/src/main/java/TestExtended.java.template
@@ -15,6 +15,8 @@ import dev.galasa.artifact.*;
 import dev.galasa.core.manager.*;
 import dev.galasa.Test;
 
+import java.nio.file.*;
+
 /**
  * A sample galasa test class, which does slightly more than the simple test class
  */
@@ -32,6 +34,10 @@ public class {{.ClassName}} {
 	// The run id of this test will be injected, so we can name things using it as a prefix.
 	@RunName
     public String runName;
+	
+	// Where we can save files relating to this test if they help with diagnosing a problem.
+	@StoredArtifactRoot
+	public Path archivedArtifactRoot ;
 
 	/**
 	 * Test which demonstrates that the managers have been injected ok.
@@ -57,4 +63,14 @@ public class {{.ClassName}} {
         assertThat(textContent.trim()).isEqualTo("This content is read from a bundle resource file.");
     }
 	
+	@Test
+	public void testStoreFileInResultsArchiveStore() throws Exception {
+
+		String testMessageEmbedIntoArtifact = "Hello Galasa !";
+
+		// Now store the artifact in the test repository.
+		Path artifactFilePath = archivedArtifactRoot.resolve(runName+"-{{.ClassName}}-Artifact.txt");
+
+	    Files.write(artifactFilePath, testMessageEmbedIntoArtifact.getBytes());
+	}
 }


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

The generated testcase (Extended version) now creates a file within the RAS store.

This code relates to the following issue: https://github.com/galasa-dev/projectmanagement/issues/1336
