### PR TITLE
fix download ivt test

### DIFF
--- a/test-galasactl-ecosystem.sh
+++ b/test-galasactl-ecosystem.sh
@@ -103,6 +103,7 @@ export GALASA_TEST_NAME_LONG="dev.galasa.inttests.core.${GALASA_TEST_NAME_SHORT}
 export GALASA_TEST_RUN_GET_EXPECTED_SUMMARY_LINE_COUNT="4"
 export GALASA_TEST_RUN_GET_EXPECTED_DETAILS_LINE_COUNT="13"
 export GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT="10"
+export GALASA_TEST_RUN_GET_EXPECTED_NUMBER_ARTIFACT_RUNNING_COUNT="3"
 
 
 #--------------------------------------------------------------------------
@@ -311,11 +312,15 @@ function runs_download_check_folder_names_during_test_run {
                 if [[ "${rc}" != "0" ]]; then
                     # Check to see of the folder created has a ":" in the folder name... indicating that the test is running.
                     folder_name=$(cat $output_file| cut -d' ' -f 7)
+                    no_artifacts=$(cat $output_file| cut -d' ' -f 3)
+                    expected_artifact_count=$GALASA_TEST_RUN_GET_EXPECTED_NUMBER_ARTIFACT_RUNNING_COUNT
                     echo $folder_name | grep ":" 
                     rc=$?
                     if [[ "${rc}" != "0" ]]; then 
-                        error "Folder named incorrectly. Has no timestamp when it should, because downloading from running tests should create a folder with a time in, such as U456-16:50:32."
-                        exit 1
+                        if [[ "${no_artifacts}" != "${expected_artifact_count}" ]]; then
+                            error "Folder named incorrectly. Has no timestamp when it should, because downloading from running tests should create a folder with a time in, such as U456-16:50:32."
+                            exit 1
+                        fi
                     fi
                 fi    
             fi

--- a/test-galasactl-ecosystem.sh
+++ b/test-galasactl-ecosystem.sh
@@ -306,9 +306,8 @@ function runs_download_check_folder_names_during_test_run {
             
             test_building_line=$(cat ${log_file} | grep "now 'building'")
             if [[ "$test_building_line" != "" ]]; then
-                cat ${log_file} | grep "now 'running'" -q
-                rc=$?
-                if [[ "${rc}" != "0" ]]; then
+                test_running_line=$(cat ${log_file} | grep "running") 
+                if [[ "$test_running_line" == "" ]]; then
                     # Check to see of the folder created has a ":" in the folder name... indicating that the test is running.
                     folder_name=$(cat $output_file| cut -d' ' -f 7)
                     echo $folder_name | grep ":" 
@@ -760,32 +759,32 @@ function launch_test_from_unknown_portfolio {
 calculate_galasactl_executable
 
 # Launch test on ecosystem from a portfolio ...
-launch_test_on_ecosystem_with_portfolio
+# launch_test_on_ecosystem_with_portfolio
 
-# Query the result ... setting RUN_NAME to hold the one which galasa allocated
-get_result_with_runname 
-runs_get_check_summary_format_output  $RUN_NAME
-runs_get_check_details_format_output  $RUN_NAME
-runs_get_check_raw_format_output  $RUN_NAME
+# # Query the result ... setting RUN_NAME to hold the one which galasa allocated
+# get_result_with_runname 
+# runs_get_check_summary_format_output  $RUN_NAME
+# runs_get_check_details_format_output  $RUN_NAME
+# runs_get_check_raw_format_output  $RUN_NAME
 
-# Query the result with the age parameter 
-runs_get_check_raw_format_output_with_from_and_to $RUN_NAME
-runs_get_check_raw_format_output_with_just_from $RUN_NAME
+# # Query the result with the age parameter 
+# runs_get_check_raw_format_output_with_from_and_to $RUN_NAME
+# runs_get_check_raw_format_output_with_just_from $RUN_NAME
 
-# Check that the age parameter throws correct errors with invalid values
-runs_get_check_raw_format_output_with_no_runname_and_no_age_param
-runs_get_check_raw_format_output_with_invalid_age_param
-runs_get_check_raw_format_output_with_older_to_than_from_age
-# Unable to test 'to' age because the smallest time unit we support is Hours so would have to query a test that happened over an hour ago
+# # Check that the age parameter throws correct errors with invalid values
+# runs_get_check_raw_format_output_with_no_runname_and_no_age_param
+# runs_get_check_raw_format_output_with_invalid_age_param
+# runs_get_check_raw_format_output_with_older_to_than_from_age
+# # Unable to test 'to' age because the smallest time unit we support is Hours so would have to query a test that happened over an hour ago
 
-# Launch test on ecosystem without a portfolio ...
-# NOTE - Bug found with this command so commenting out for now see issue xxx
-# launch_test_on_ecosystem_without_portfolio
+# # Launch test on ecosystem without a portfolio ...
+# # NOTE - Bug found with this command so commenting out for now see issue xxx
+# # launch_test_on_ecosystem_without_portfolio
 
-# Attempt to create a test portfolio with an unknown test ...
-create_portfolio_with_unknown_test
+# # Attempt to create a test portfolio with an unknown test ...
+# create_portfolio_with_unknown_test
 
-# Attempt to launch a test from an unknown portfolio ...
-launch_test_from_unknown_portfolio
+# # Attempt to launch a test from an unknown portfolio ...
+# launch_test_from_unknown_portfolio
 
 runs_download_check_folder_names_during_test_run

--- a/test-galasactl-ecosystem.sh
+++ b/test-galasactl-ecosystem.sh
@@ -103,7 +103,7 @@ export GALASA_TEST_NAME_LONG="dev.galasa.inttests.core.${GALASA_TEST_NAME_SHORT}
 export GALASA_TEST_RUN_GET_EXPECTED_SUMMARY_LINE_COUNT="4"
 export GALASA_TEST_RUN_GET_EXPECTED_DETAILS_LINE_COUNT="13"
 export GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT="10"
-export GALASA_TEST_RUN_GET_EXPECTED_NUMBER_ARTIFACT_RUNNING_COUNT="3"
+export GALASA_TEST_RUN_GET_EXPECTED_NUMBER_ARTIFACT_RUNNING_COUNT="10"
 
 
 #--------------------------------------------------------------------------
@@ -313,11 +313,13 @@ function runs_download_check_folder_names_during_test_run {
                     # Check to see of the folder created has a ":" in the folder name... indicating that the test is running.
                     folder_name=$(cat $output_file| cut -d' ' -f 7)
                     no_artifacts=$(cat $output_file| cut -d' ' -f 3)
+                    no_artifacts=$(($no_artifacts+0))
                     expected_artifact_count=$GALASA_TEST_RUN_GET_EXPECTED_NUMBER_ARTIFACT_RUNNING_COUNT
+                    expected_artifact_count=$(($expected_artifact_count+0))
                     echo $folder_name | grep ":" 
                     rc=$?
                     if [[ "${rc}" != "0" ]]; then 
-                        if [[ "${no_artifacts}" == "${expected_artifact_count}" ]]; then
+                        if [[ "${no_artifacts}" < "${expected_artifact_count}" ]]; then
                             error "Folder named incorrectly. Has no timestamp when it should, because downloading from running tests should create a folder with a time in, such as U456-16:50:32."
                             exit 1
                         fi

--- a/test-galasactl-ecosystem.sh
+++ b/test-galasactl-ecosystem.sh
@@ -317,7 +317,7 @@ function runs_download_check_folder_names_during_test_run {
                     echo $folder_name | grep ":" 
                     rc=$?
                     if [[ "${rc}" != "0" ]]; then 
-                        if [[ "${no_artifacts}" != "${expected_artifact_count}" ]]; then
+                        if [[ "${no_artifacts}" == "${expected_artifact_count}" ]]; then
                             error "Folder named incorrectly. Has no timestamp when it should, because downloading from running tests should create a folder with a time in, such as U456-16:50:32."
                             exit 1
                         fi

--- a/test-galasactl-ecosystem.sh
+++ b/test-galasactl-ecosystem.sh
@@ -306,8 +306,9 @@ function runs_download_check_folder_names_during_test_run {
             
             test_building_line=$(cat ${log_file} | grep "now 'building'")
             if [[ "$test_building_line" != "" ]]; then
-                test_running_line=$(cat ${log_file} | grep "running") 
-                if [[ "$test_running_line" == "" ]]; then
+                cat ${log_file} | grep "now 'running'" -q #if now running is there, dont look further -
+                rc=$?
+                if [[ "${rc}" != "0" ]]; then
                     # Check to see of the folder created has a ":" in the folder name... indicating that the test is running.
                     folder_name=$(cat $output_file| cut -d' ' -f 7)
                     echo $folder_name | grep ":" 
@@ -759,32 +760,32 @@ function launch_test_from_unknown_portfolio {
 calculate_galasactl_executable
 
 # Launch test on ecosystem from a portfolio ...
-# launch_test_on_ecosystem_with_portfolio
+launch_test_on_ecosystem_with_portfolio
 
-# # Query the result ... setting RUN_NAME to hold the one which galasa allocated
-# get_result_with_runname 
-# runs_get_check_summary_format_output  $RUN_NAME
-# runs_get_check_details_format_output  $RUN_NAME
-# runs_get_check_raw_format_output  $RUN_NAME
+# Query the result ... setting RUN_NAME to hold the one which galasa allocated
+get_result_with_runname 
+runs_get_check_summary_format_output  $RUN_NAME
+runs_get_check_details_format_output  $RUN_NAME
+runs_get_check_raw_format_output  $RUN_NAME
 
-# # Query the result with the age parameter 
-# runs_get_check_raw_format_output_with_from_and_to $RUN_NAME
-# runs_get_check_raw_format_output_with_just_from $RUN_NAME
+# Query the result with the age parameter 
+runs_get_check_raw_format_output_with_from_and_to $RUN_NAME
+runs_get_check_raw_format_output_with_just_from $RUN_NAME
 
-# # Check that the age parameter throws correct errors with invalid values
-# runs_get_check_raw_format_output_with_no_runname_and_no_age_param
-# runs_get_check_raw_format_output_with_invalid_age_param
-# runs_get_check_raw_format_output_with_older_to_than_from_age
-# # Unable to test 'to' age because the smallest time unit we support is Hours so would have to query a test that happened over an hour ago
+# Check that the age parameter throws correct errors with invalid values
+runs_get_check_raw_format_output_with_no_runname_and_no_age_param
+runs_get_check_raw_format_output_with_invalid_age_param
+runs_get_check_raw_format_output_with_older_to_than_from_age
+# Unable to test 'to' age because the smallest time unit we support is Hours so would have to query a test that happened over an hour ago
 
-# # Launch test on ecosystem without a portfolio ...
-# # NOTE - Bug found with this command so commenting out for now see issue xxx
-# # launch_test_on_ecosystem_without_portfolio
+# Launch test on ecosystem without a portfolio ...
+# NOTE - Bug found with this command so commenting out for now see issue xxx
+# launch_test_on_ecosystem_without_portfolio
 
-# # Attempt to create a test portfolio with an unknown test ...
-# create_portfolio_with_unknown_test
+# Attempt to create a test portfolio with an unknown test ...
+create_portfolio_with_unknown_test
 
-# # Attempt to launch a test from an unknown portfolio ...
-# launch_test_from_unknown_portfolio
+# Attempt to launch a test from an unknown portfolio ...
+launch_test_from_unknown_portfolio
 
 runs_download_check_folder_names_during_test_run


### PR DESCRIPTION
download test was failing as the log wa inconsistent so sometimes has "now running" and sometimes didn't. I have added a check to the number of artifacts so if the folder name has a timestamp, we check there are less than 10 artifacts downloaded as this is the minimum number of artifacts the finished test has