### PR TITLE
remove rogue log statement.

### DIFF
--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -5,7 +5,6 @@ package embedded
 
 import (
 	"embed"
-	"log"
 
 	"github.com/galasa.dev/cli/pkg/props"
 )

--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -90,10 +90,9 @@ func readVersionsFromEmbeddedFile(fs ReadOnlyFileSystem, versionDataAlreadyKnown
 	)
 	if versionDataAlreadyKnown == nil {
 
-		log.Printf("Loading the properties file '%s'...", PropsFileName)
 		bytes, err = fs.ReadFile(PropsFileName)
 		if err != nil {
-			log.Printf("Failure. %s", err.Error())
+			log.Printf("Failure to load contents from an embedded property file %s. reason:%s", PropsFileName, err.Error())
 		} else {
 			propsFileContent := string(bytes)
 			properties := props.ReadProperties(propsFileContent)

--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -91,9 +91,7 @@ func readVersionsFromEmbeddedFile(fs ReadOnlyFileSystem, versionDataAlreadyKnown
 	if versionDataAlreadyKnown == nil {
 
 		bytes, err = fs.ReadFile(PropsFileName)
-		if err != nil {
-			log.Printf("Failure to load contents from an embedded property file %s. reason:%s", PropsFileName, err.Error())
-		} else {
+		if err == nil {
 			propsFileContent := string(bytes)
 			properties := props.ReadProperties(propsFileContent)
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- Remove the offending log statement.
- Remove log which occurs if readTextFile fails. That error will already have been logged and a stack trace made available.

See [issue projectManagement#](https://github.com/galasa-dev/projectmanagement/issues/1530)