### PR TITLE
fiona 1556 tests order

### DIFF
--- a/pkg/runs/humanReporter.go
+++ b/pkg/runs/humanReporter.go
@@ -228,9 +228,9 @@ func orderResultKeys(resultCounts map[string]int) []string {
 	orderedkeys = append(orderedkeys, RESULT_LOST)
 	orderedkeys = append(orderedkeys, RESULT_ENVFAIL)
 
-	var keyMap = make(map[string]string)
+	var keyMap = make(map[string]struct{})
 	for _, key := range orderedkeys {
-		keyMap[key] = ""
+		keyMap[key] = struct{}{}
 	}
 
 	var customLabels []string

--- a/pkg/runs/humanReporter.go
+++ b/pkg/runs/humanReporter.go
@@ -145,8 +145,8 @@ func FinalHumanReadableReportAsString(finishedRuns map[string]*TestRun, lostRuns
 	//Total, Passed, Passed With Defects, Failed, Failed With Defects, Lost, EnvFail, Custom Keys...
 	orderedKeys := orderResultKeys(resultCounts)
 
-	for i := range orderedKeys {
-		resultsSoFar = resultsSoFar + fmt.Sprintf(", %v=%v", orderedKeys[i], resultCounts[orderedKeys[i]])
+	for _, key := range orderedKeys {
+		resultsSoFar = resultsSoFar + fmt.Sprintf(", %v=%v", key, resultCounts[key])
 	}
 
 	fmt.Fprintln(&buff, resultsSoFar)
@@ -208,8 +208,8 @@ func InterrimProgressReportAsString(
 		resultsSoFar := fmt.Sprintf("*** Results so far:\n*** Total=%v", totalResults)
 
 		orderedKeys := orderResultKeys(resultCounts)
-		for i := range orderedKeys {
-			resultsSoFar = resultsSoFar + fmt.Sprintf(", %v=%v", orderedKeys[i], resultCounts[orderedKeys[i]])
+		for _, key := range orderedKeys {
+			resultsSoFar = resultsSoFar + fmt.Sprintf(", %v=%v", key, resultCounts[key])
 		}
 		fmt.Fprintln(&buff, resultsSoFar)
 	}
@@ -220,23 +220,28 @@ func InterrimProgressReportAsString(
 
 func orderResultKeys(resultCounts map[string]int) []string {
 
-	var keys []string
-	keys = append(keys, RESULT_PASSED)
-	keys = append(keys, RESULT_PASSED_WITH_DEFECTS)
-	keys = append(keys, RESULT_FAILED)
-	keys = append(keys, RESULT_FAILED_WITH_DEFECTS)
-	keys = append(keys, RESULT_LOST)
-	keys = append(keys, RESULT_ENVFAIL)
+	var orderedkeys []string
+	orderedkeys = append(orderedkeys, RESULT_PASSED)
+	orderedkeys = append(orderedkeys, RESULT_PASSED_WITH_DEFECTS)
+	orderedkeys = append(orderedkeys, RESULT_FAILED)
+	orderedkeys = append(orderedkeys, RESULT_FAILED_WITH_DEFECTS)
+	orderedkeys = append(orderedkeys, RESULT_LOST)
+	orderedkeys = append(orderedkeys, RESULT_ENVFAIL)
+
+	var keyMap = make(map[string]string)
+	for _, key := range orderedkeys {
+		keyMap[key] = ""
+	}
 
 	var customLabels []string
 	for keyLabel := range resultCounts {
-		if keyLabel != RESULT_PASSED && keyLabel != RESULT_PASSED_WITH_DEFECTS && keyLabel != RESULT_FAILED && keyLabel != RESULT_FAILED_WITH_DEFECTS && keyLabel != RESULT_ENVFAIL && keyLabel != RESULT_LOST {
+		if _, ok := keyMap[keyLabel]; !ok {
 			customLabels = append(customLabels, keyLabel)
 		}
 	}
 
 	sort.Strings(customLabels)
-	keys = append(keys, customLabels...)
+	orderedkeys = append(orderedkeys, customLabels...)
 
-	return keys
+	return orderedkeys
 }

--- a/pkg/runs/humanReporter_test.go
+++ b/pkg/runs/humanReporter_test.go
@@ -65,7 +65,7 @@ func TestCanCountFailuresOneLostOneFailed(t *testing.T) {
 	// When
 	count := CountTotalFailedRuns(finishedRunsMap, lostRunsMap)
 
-	assert.Equal(t, 2, count, "Failed to count failde test cases.")
+	assert.Equal(t, 2, count, "Failed to count failed test cases.")
 }
 
 func TestCanCallHumanReportNoErrors(t *testing.T) {
@@ -102,7 +102,7 @@ func TestCanCallHumanReportNoErrors(t *testing.T) {
 	assert.Contains(t, reportText, "Final report")
 }
 
-func TestCanCallHumanInterrimReportNoErrors(t *testing.T) {
+func TestHumanReportResultsPrintsInOrder(t *testing.T) {
 	// Given...
 	lostRun1 := TestRun{
 		Name:      "myTestRun",
@@ -120,12 +120,192 @@ func TestCanCallHumanInterrimReportNoErrors(t *testing.T) {
 		Class:     "com.myco.MyClass",
 		Stream:    "myStream",
 		Status:    "myStatus",
+		Result:    "Passed",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finished2 := TestRun{
+		Name:      "myTestRun2",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
 		Result:    "Failed",
 		Overrides: make(map[string]string, 1),
 		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
 
-	finishedRunsMap := make(map[string]*TestRun, 1)
-	finishedRunsMap["myTestRun"] = &finished1
+	finishedRunsMap := make(map[string]*TestRun, 2)
+	finishedRunsMap["myTestRun1"] = &finished1
+	finishedRunsMap["myTestRun2"] = &finished2
+
+	lostRunsMap := make(map[string]*TestRun, 1)
+	lostRunsMap["myTestRun"] = &lostRun1
+
+	// When
+	reportText := FinalHumanReadableReportAsString(finishedRunsMap, lostRunsMap)
+	//Then
+	assert.Contains(t, reportText, "Total=3, Passed=1, Passed With Defects=0, Failed=1, Failed With Defects=0, Lost=1")
+}
+
+func TestHumanReportResultsPrintsInOrderWithCustomResult(t *testing.T) {
+	// Given...
+	lostRun1 := TestRun{
+		Name:      "myTestRun",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "Failed",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finished1 := TestRun{
+		Name:      "myTestRun1",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "Passed",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finished2 := TestRun{
+		Name:      "myTestRun2",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "Custom",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finished3 := TestRun{
+		Name:      "myTestRun3",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "Custard",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finishedRunsMap := make(map[string]*TestRun, 3)
+	finishedRunsMap["myTestRun1"] = &finished1
+	finishedRunsMap["myTestRun2"] = &finished2
+	finishedRunsMap["myTestRun3"] = &finished3
+
+	lostRunsMap := make(map[string]*TestRun, 1)
+	lostRunsMap["myTestRun"] = &lostRun1
+
+	// When
+	reportText := FinalHumanReadableReportAsString(finishedRunsMap, lostRunsMap)
+	//Then
+	assert.Contains(t, reportText, "Total=4, Passed=1, Passed With Defects=0, Failed=0, Failed With Defects=0, Lost=1, EnvFail=0, Custard=1, Custom=1")
+}
+
+func TestHumanReportResultsPrintsInOrderWhenAllResultsAreCustomResults(t *testing.T) {
+	// Given...
+	lostRun1 := TestRun{
+		Name:      "myTestRun",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "CustomLost",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finished1 := TestRun{
+		Name:      "myTestRun1",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "Doughnuts",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finished2 := TestRun{
+		Name:      "myTestRun2",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "Cookies",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finished3 := TestRun{
+		Name:      "myTestRun3",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "Jam",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finishedRunsMap := make(map[string]*TestRun, 3)
+	finishedRunsMap["myTestRun1"] = &finished1
+	finishedRunsMap["myTestRun2"] = &finished2
+	finishedRunsMap["myTestRun3"] = &finished3
+
+	lostRunsMap := make(map[string]*TestRun, 1)
+	lostRunsMap["myTestRun"] = &lostRun1
+
+	// When
+	reportText := FinalHumanReadableReportAsString(finishedRunsMap, lostRunsMap)
+	//Then
+	print(reportText)
+	assert.Contains(t, reportText, "Total=4, Passed=0, Passed With Defects=0, Failed=0, Failed With Defects=0, Lost=1, EnvFail=0, Cookies=1, Doughnuts=1, Jam=1")
+}
+
+func TestHumanReportResultsWithNoDataPrintsInOrder(t *testing.T) {
+	// Given...
+	var lostRunsMap map[string]*TestRun = make(map[string]*TestRun, 0)
+	var finishedRunsMap map[string]*TestRun = make(map[string]*TestRun, 0)
+
+	// When
+	reportText := FinalHumanReadableReportAsString(finishedRunsMap, lostRunsMap)
+	//Then
+	assert.Contains(t, reportText, "Total=0, Passed=0, Passed With Defects=0, Failed=0, Failed With Defects=0, Lost=0, EnvFail=0")
+}
+
+func TestCanCallHumanInterrimReportNoErrors(t *testing.T) {
+	// Given...
+	lostRun1 := TestRun{
+		Name:      "myTestRun",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "Failed",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finished1 := TestRun{
+		Name:      "myTestRun1",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "Passed",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finished2 := TestRun{
+		Name:      "myTestRun2",
+		Bundle:    "myBundle",
+		Class:     "com.myco.MyClass",
+		Stream:    "myStream",
+		Status:    "myStatus",
+		Result:    "Failed With Defects",
+		Overrides: make(map[string]string, 1),
+		Tests:     []TestMethod{{Method: "method1", Result: "passed"}, {Method: "method2", Result: "passed"}}}
+
+	finishedRunsMap := make(map[string]*TestRun, 2)
+	finishedRunsMap["myTestRun1"] = &finished1
+	finishedRunsMap["myTestRun2"] = &finished2
 
 	lostRunsMap := make(map[string]*TestRun, 1)
 	lostRunsMap["myTestRun"] = &lostRun1
@@ -134,4 +314,5 @@ func TestCanCallHumanInterrimReportNoErrors(t *testing.T) {
 	reportText := InterrimProgressReportAsString(make([]TestRun, 0), finishedRunsMap, finishedRunsMap, lostRunsMap, 5)
 
 	assert.Contains(t, reportText, "Progress report")
+	assert.Contains(t, reportText, "Total=3, Passed=1, Passed With Defects=0, Failed=0, Failed With Defects=1, Lost=1, EnvFail=0")
 }

--- a/pkg/runs/humanReporter_test.go
+++ b/pkg/runs/humanReporter_test.go
@@ -256,7 +256,6 @@ func TestHumanReportResultsPrintsInOrderWhenAllResultsAreCustomResults(t *testin
 	// When
 	reportText := FinalHumanReadableReportAsString(finishedRunsMap, lostRunsMap)
 	//Then
-	print(reportText)
 	assert.Contains(t, reportText, "Total=4, Passed=0, Passed With Defects=0, Failed=0, Failed With Defects=0, Lost=1, EnvFail=0, Cookies=1, Doughnuts=1, Jam=1")
 }
 


### PR DESCRIPTION
Story: [CLI test results summay is in random order.#1556](https://github.com/galasa-dev/projectmanagement/issues/1556)
- fixed the order in which tests show for human readable reports
- provided constant variables for results
