### PR TITLE
Fix --bootstrap flag for properties commands

### DIFF
--- a/pkg/cmd/propertiesDelete.go
+++ b/pkg/cmd/propertiesDelete.go
@@ -63,7 +63,7 @@ func executePropertiesDelete(cmd *cobra.Command, args []string) {
 	// Read the bootstrap properties.
 	var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 	var bootstrapData *api.BootstrapData
-	bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, bootstrap, urlService)
+	bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, ecosystemBootstrap, urlService)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cmd/propertiesGet.go
+++ b/pkg/cmd/propertiesGet.go
@@ -79,7 +79,7 @@ func executePropertiesGet(cmd *cobra.Command, args []string) {
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, ecosystemBootstrap, urlService)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/cmd/propertiesSet.go
+++ b/pkg/cmd/propertiesSet.go
@@ -67,7 +67,7 @@ func executePropertiesSet(cmd *cobra.Command, args []string) {
 	// Read the bootstrap properties.
 	var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 	var bootstrapData *api.BootstrapData
-	bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, bootstrap, urlService)
+	bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, ecosystemBootstrap, urlService)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Related to https://github.com/galasa-dev/projectmanagement/issues/1566

The `--bootstrap` flag was not working correctly for properties commands since the correct bootstrap variable was not being used.