### PR TITLE
separate consoles to collect output for stdout/stderr

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -67,6 +67,13 @@ EOF
 }
 
 #--------------------------------------------------------------------------
+function read_boot_jar_version {
+    export BOOT_JAR_VERSION=$(cat ${BASEDIR}/build.gradle | grep "galasaBootJarVersion[ ]*=" | cut -f2 -d"'" )
+    info "Boot jar version is $BOOT_JAR_VERSION"
+}
+
+
+#--------------------------------------------------------------------------
 # 
 # Main script logic
 #
@@ -118,6 +125,7 @@ if [[ ! -e "../framework/openapi.yaml" ]]; then
     exit 1
 fi
 success "OK"
+
 
 
 #--------------------------------------------------------------------------
@@ -480,11 +488,7 @@ function generate_galasactl_documentation {
     success "Documentation generated - OK"
 }
 
-#--------------------------------------------------------------------------
-function read_boot_jar_version {
-    export BOOT_JAR_VERSION=$(cat ${BASEDIR}/build.gradle | grep "galasaBootJarVersion[ ]*=" | cut -f2 -d"'" )
-    info "Boot jar version is $BOOT_JAR_VERSION"
-}
+
 
 #--------------------------------------------------------------------------
 # Run test using the galasactl locally in a JVM

--- a/pkg/cmd/factory.go
+++ b/pkg/cmd/factory.go
@@ -19,14 +19,16 @@ type Factory interface {
 	GetFileSystem() files.FileSystem
 	GetEnvironment() utils.Environment
 	GetFinalWordHandler() FinalWordHandler
-	GetConsole() utils.Console
+	GetStdOutConsole() utils.Console
+	GetStdErrConsole() utils.Console
 }
 
 // Allocates real objects with real implementations,
 // none of which are generally great for unit testing.
 // eg: A real file system can leave debris behind when a test runs.
 type RealFactory struct {
-	console utils.Console
+	stdOutConsole utils.Console
+	stdErrConsole utils.Console
 }
 
 func NewRealFactory() Factory {
@@ -47,9 +49,16 @@ func (*RealFactory) GetFinalWordHandler() FinalWordHandler {
 
 // We only ever expect there to be a single console object, which collects all the
 // command output.
-func (this *RealFactory) GetConsole() utils.Console {
-	if this.console == nil {
-		this.console = utils.NewRealConsole()
+func (this *RealFactory) GetStdOutConsole() utils.Console {
+	if this.stdOutConsole == nil {
+		this.stdOutConsole = utils.NewRealConsole()
 	}
-	return this.console
+	return this.stdOutConsole
+}
+
+func (this *RealFactory) GetStdErrConsole() utils.Console {
+	if this.stdErrConsole == nil {
+		this.stdErrConsole = utils.NewRealConsole()
+	}
+	return this.stdErrConsole
 }

--- a/pkg/cmd/factoryMock.go
+++ b/pkg/cmd/factoryMock.go
@@ -14,7 +14,8 @@ type MockFactory struct {
 	finalWordHandler FinalWordHandler
 	fileSystem       files.FileSystem
 	env              utils.Environment
-	console          utils.Console
+	stdOutConsole    utils.Console
+	stdErrConsole    utils.Console
 }
 
 func NewMockFactory() Factory {
@@ -42,9 +43,16 @@ func (this *MockFactory) GetFinalWordHandler() FinalWordHandler {
 	return this.finalWordHandler
 }
 
-func (this *MockFactory) GetConsole() utils.Console {
-	if this.console == nil {
-		this.console = utils.NewMockConsole()
+func (this *MockFactory) GetStdOutConsole() utils.Console {
+	if this.stdOutConsole == nil {
+		this.stdOutConsole = utils.NewMockConsole()
 	}
-	return this.console
+	return this.stdOutConsole
+}
+
+func (this *MockFactory) GetStdErrConsole() utils.Console {
+	if this.stdErrConsole == nil {
+		this.stdErrConsole = utils.NewMockConsole()
+	}
+	return this.stdErrConsole
 }

--- a/pkg/cmd/projectCreate_test.go
+++ b/pkg/cmd/projectCreate_test.go
@@ -577,9 +577,13 @@ func TestCreateProjectUsingCommandLineNoPackageSet(t *testing.T) {
 	// Then...
 
 	// Check what the user saw is reasonable.
-	console := factory.GetConsole().(*utils.MockConsole)
-	text := console.ReadText()
-	assert.Contains(t, text, "Error: required flag(s) \"package\" not set")
+	stdOutConsole := factory.GetStdOutConsole().(*utils.MockConsole)
+	outText := stdOutConsole.ReadText()
+	assert.Contains(t, outText, "Usage:")
+
+	stdErrConsole := factory.GetStdErrConsole().(*utils.MockConsole)
+	errText := stdErrConsole.ReadText()
+	assert.Contains(t, errText, "Error: required flag(s) \"package\" not set")
 
 	// We expect an exit code of 0 for this command.
 	finalWordHandler := factory.GetFinalWordHandler().(*MockFinalWordHandler)
@@ -600,9 +604,13 @@ func TestCreateProjectUsingCommandLineNoFeaturesSetWorks(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Check what the user saw no output
-	console := factory.GetConsole().(*utils.MockConsole)
-	text := console.ReadText()
-	assert.Equal(t, text, "")
+	stdOutConsole := factory.GetStdOutConsole().(*utils.MockConsole)
+	outText := stdOutConsole.ReadText()
+	assert.Empty(t, outText)
+
+	stdErrConsole := factory.GetStdErrConsole().(*utils.MockConsole)
+	errText := stdErrConsole.ReadText()
+	assert.Empty(t, errText)
 
 	// We expect an exit code of 0.
 	finalWordHandler := factory.GetFinalWordHandler().(*MockFinalWordHandler)
@@ -629,9 +637,13 @@ func TestCreateProjectUsingCommandLineNoMavenNorGradleFails(t *testing.T) {
 	// Then...
 
 	// Check what the user saw is reasonable.
-	console := factory.GetConsole().(*utils.MockConsole)
-	text := console.ReadText()
-	assert.Contains(t, text, "Error: GAL1089E: Need to use --maven and/or --gradle parameter")
+	stdOutConsole := factory.GetStdOutConsole().(*utils.MockConsole)
+	outText := stdOutConsole.ReadText()
+	assert.Contains(t, outText, "Usage:")
+
+	stdErrConsole := factory.GetStdErrConsole().(*utils.MockConsole)
+	errText := stdErrConsole.ReadText()
+	assert.Contains(t, errText, "Error: GAL1089E: Need to use --maven and/or --gradle parameter")
 
 	// We expect an exit code of 1 for this command. But it seems that syntax errors caught by cobra still return no error.
 	finalWordHandler := factory.GetFinalWordHandler().(*MockFinalWordHandler)

--- a/pkg/cmd/propertiesGet.go
+++ b/pkg/cmd/propertiesGet.go
@@ -109,7 +109,7 @@ func executePropertiesGet(
 			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, propertiesCmdValues.ecosystemBootstrap, urlService)
 			if err == nil {
 
-				var console = factory.GetConsole()
+				var console = factory.GetStdOutConsole()
 
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)

--- a/pkg/cmd/propertiesNamespaceGet.go
+++ b/pkg/cmd/propertiesNamespaceGet.go
@@ -87,7 +87,7 @@ func executePropertiesNamespaceGet(
 			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, propertiesCmdValues.ecosystemBootstrap, urlService)
 			if err == nil {
 
-				var console = factory.GetConsole()
+				var console = factory.GetStdOutConsole()
 
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -44,9 +44,8 @@ func CreateRootCmd(factory Factory) (*cobra.Command, error) {
 			Version: version,
 		}
 
-		console := factory.GetConsole()
-		rootCmd.SetErr(console)
-		rootCmd.SetOut(console)
+		rootCmd.SetErr(factory.GetStdErrConsole())
+		rootCmd.SetOut(factory.GetStdOutConsole())
 
 		var galasaCtlVersion string
 		galasaCtlVersion, err = embedded.GetGalasaCtlVersion()

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -36,7 +36,7 @@ func TestVersionFromCommandLine(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Lets check that the version came out.
-	console := factory.GetConsole().(*utils.MockConsole)
+	console := factory.GetStdOutConsole().(*utils.MockConsole)
 	text := console.ReadText()
 	assert.Contains(t, text, "galasactl version")
 	versionString, _ := embedded.GetGalasaCtlVersion()
@@ -60,7 +60,7 @@ func TestNoParamsFromCommandLine(t *testing.T) {
 	// Then...
 
 	// Check what the user saw is reasonable.
-	console := factory.GetConsole().(*utils.MockConsole)
+	console := factory.GetStdOutConsole().(*utils.MockConsole)
 	text := console.ReadText()
 	assert.Contains(t, text, "A tool for controlling Galasa resources")
 

--- a/pkg/cmd/runsDownload.go
+++ b/pkg/cmd/runsDownload.go
@@ -89,7 +89,7 @@ func executeRunsDownload(
 			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, runsCmdValues.bootstrap, urlService)
 			if err == nil {
 
-				var console = factory.GetConsole()
+				var console = factory.GetStdOutConsole()
 
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)

--- a/pkg/cmd/runsGet.go
+++ b/pkg/cmd/runsGet.go
@@ -94,7 +94,7 @@ func executeRunsGet(
 			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, runsCmdValues.bootstrap, urlService)
 			if err == nil {
 
-				var console = factory.GetConsole()
+				var console = factory.GetStdOutConsole()
 
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -142,7 +142,7 @@ func executeSubmit(
 				err = validator.Validate(runsSubmitCmdValues.TestSelectionFlagValues)
 				if err == nil {
 
-					var console = factory.GetConsole()
+					var console = factory.GetStdOutConsole()
 
 					submitter := runs.NewSubmitter(galasaHome, fileSystem, launcherInstance, timeService, env, console)
 

--- a/pkg/cmd/runsSubmitLocal.go
+++ b/pkg/cmd/runsSubmitLocal.go
@@ -162,7 +162,7 @@ func executeSubmitLocal(
 						processFactory, galasaHome)
 
 					if err == nil {
-						var console = factory.GetConsole()
+						var console = factory.GetStdOutConsole()
 
 						// Do the launching of the tests.
 						submitter := runs.NewSubmitter(


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- Separate consoles to collect output from cobra and the rest of the tools when running within unit tests.
- Unit tests can now get the mock console attached to stdout, separately to the one attached to stderr.