### PR TITLE
CLI downloads the openapi.yaml rather than referring to ../framework/openapi.yaml

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -33,26 +33,16 @@ blue=$(tput setaf 25)
 # Headers and Logging
 #
 #--------------------------------------------------------------------------
-underline() { printf "${underline}${bold}%s${reset}\n" "$@"
-}
-h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@"
-}
-h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@"
-}
-debug() { printf "${white}%s${reset}\n" "$@"
-}
-info() { printf "${white}➜ %s${reset}\n" "$@"
-}
-success() { printf "${green}✔ %s${reset}\n" "$@"
-}
-error() { printf "${red}✖ %s${reset}\n" "$@"
-}
-warn() { printf "${tan}➜ %s${reset}\n" "$@"
-}
-bold() { printf "${bold}%s${reset}\n" "$@"
-}
-note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@"
-}
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ;}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ;}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ;}
+debug() { printf "${white}%s${reset}\n" "$@" ;}
+info() { printf "${white}➜ %s${reset}\n" "$@" ;}
+success() { printf "${green}✔ %s${reset}\n" "$@" ;}
+error() { printf "${red}✖ %s${reset}\n" "$@" ;}
+warn() { printf "${tan}➜ %s${reset}\n" "$@" ;}
+bold() { printf "${bold}%s${reset}\n" "$@" ;}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
 
 #-----------------------------------------------------------------------------------------
 # Functions
@@ -111,24 +101,6 @@ h1 "Building the CLI component"
 #--------------------------------------------------------------------------
 
 #--------------------------------------------------------------------------
-# Check that the ../framework is present.
-h2 "Making sure the openapi yaml file is available..."
-if [[ ! -e "../framework" ]]; then
-    error "../framework is not present. Clone the framework repository."
-    info "The openapi.yaml file from the framework repository is needed to generate a go client for the rest API"
-    exit 1
-fi
-
-if [[ ! -e "../framework/openapi.yaml" ]]; then
-    error "File ../framework/openapi.yaml is not found."
-    info "The openapi.yaml file from the framework repository is needed to generate a go client for the rest API"
-    exit 1
-fi
-success "OK"
-
-
-
-#--------------------------------------------------------------------------
 h2 "Setting versions of things."
 # Could get this bootjar from https://development.galasa.dev/main/maven-repo/obr/dev/galasa/galasa-boot/
 read_boot_jar_version
@@ -159,8 +131,6 @@ function go_mod_tidy {
     h2 "Tidying up go.mod..."
 
     if [[ "${build_type}" == "clean" ]]; then
-        h2 "Cleaning the dependencies out..."
-        rm -fr build/dependencies
         h2 "Tidying go mod file..."
         go mod tidy
         rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to tidy go mod. rc=${rc}" ; exit 1 ; fi
@@ -201,6 +171,19 @@ function generate_rest_client {
     success "Code generation part II - OK"
 }
 
+#--------------------------------------------------------------------------
+#
+# Clean out old things if the clean option was specified.
+#
+#--------------------------------------------------------------------------
+function clean {
+    if [[ "${build_type}" == "clean" ]]; then
+        h2 "Cleaning the binaries out..."
+        make clean
+        rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to build binary executable galasactl programs. rc=${rc}" ; exit 1 ; fi
+        success "Binaries cleaned up - OK"
+    fi
+}
 
 #--------------------------------------------------------------------------
 #
@@ -208,13 +191,6 @@ function generate_rest_client {
 #
 #--------------------------------------------------------------------------
 function build_executables {
-    if [[ "${build_type}" == "clean" ]]; then
-        h2 "Cleaning the binaries out..."
-        make clean
-        rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to build binary executable galasactl programs. rc=${rc}" ; exit 1 ; fi
-        success "Binaries cleaned up - OK"
-    fi
-
     h2 "Building new binaries..."
     set -o pipefail # Fail everything if anything in the pipeline fails. Else we are just checking the 'tee' return code.
     make all | tee ${BASEDIR}/build/compile-log.txt
@@ -602,6 +578,7 @@ function cleanup_temp {
 }
 
 # The steps to build the CLI
+clean
 download_dependencies
 generate_rest_client
 go_mod_tidy

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@
 def galasaBootJarVersion = '0.31.0'
 def galasaFrameworkVersion = '0.31.0'
 
+// Right now, the REST interface spec is always the same version as the galasa framework bundles.
+def galasaOpenApiYamlVersion = galasaFrameworkVersion
+
 repositories {
     gradlePluginPortal()
     mavenCentral()
@@ -33,13 +36,29 @@ dependencies {
     // so we can call the api server REST services
     // https://mvnrepository.com/artifact/org.openapitools/openapi-generator
     implementation 'org.openapitools:openapi-generator-cli:6.6.0'
+
+    // Download the openapi.yaml specification for the REST APIs.
+    compileOnly group: "dev.galasa", name: "dev.galasa.framework.api.openapi", version: "$galasaOpenApiYamlVersion", ext: "yaml"
 }
-task downloadDependencies(type: Copy) {
+
+
+
+task downloadRawDependencies(type: Copy) {
     // Download the dependencies onto the local disk.
     from configurations.compileClasspath
     into 'build/dependencies'
     dependsOn configurations.compileClasspath
 }
+
+task downloadDependencies(type: Copy) {
+    // Rename the complex openapi.yaml file into something easier to use elsewhere.
+    // So the path to the new file is build/dependencies/openapi.yaml
+    from "build/dependencies/dev.galasa.framework.api.openapi-${galasaOpenApiYamlVersion}.yaml"
+    into "build/dependencies"
+    rename { fileName -> "openapi.yaml" }
+    dependsOn downloadRawDependencies
+}
+
 //tasks.register('installJarsIntoTemplates', Copy) {
 task installJarsIntoTemplates(type: Copy) {
     // We want to embed some files into the executable.

--- a/genapi.sh
+++ b/genapi.sh
@@ -27,7 +27,7 @@ if [[ ! -e ${OPENAPI_GENERATOR_CLI_JAR} ]]; then
     exit 1
 fi
 
-export OPENAPI_YAML_FILE="../framework/openapi.yaml"
+export OPENAPI_YAML_FILE="${BASEDIR}/build/dependencies/openapi.yaml"
 
 if [[ ! -e ${OPENAPI_YAML_FILE} ]]; then  
     echo "This build requires that the galasa.dev/framework repository is checked-out to ${BASEDIR}"

--- a/generate.sh
+++ b/generate.sh
@@ -29,7 +29,7 @@ if [[ ! -e ${OPENAPI_GENERATOR_CLI_JAR} ]]; then
     exit 1
 fi
 
-export OPENAPI_YAML_FILE="../framework/openapi.yaml"
+export OPENAPI_YAML_FILE="${BASEDIR}/build/dependencies/openapi.yaml"
 
 if [[ ! -e ${OPENAPI_YAML_FILE} ]]; then  
     echo "This build requires that the galasa.dev/framework repository is checked-out to ${BASEDIR}"


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

CLI build locally doesn't depend on ../framework/openapi.yaml, but gets it from a dependency
it downloads.

It currently expects the openapi.yaml file to be in dev.galasa.framework.api.openapi
at the same version as the framework itself.

Once this PR is merged, we can change the automation to use the newly downloaded openapi.yaml file too.