### PR TITLE
be more safe when accessing cps property returned from the remote API

### DIFF
--- a/pkg/launcher/remoteLauncher.go
+++ b/pkg/launcher/remoteLauncher.go
@@ -96,7 +96,7 @@ func (launcher *RemoteLauncher) GetStreams() ([]string, error) {
 	cpsProperty, _, err := launcher.apiClient.ConfigurationPropertyStoreAPIApi.
 		GetCpsNamespaceCascadeProperty(nil, "framework", "test", "streams").Execute()
 	if err == nil {
-		if cpsProperty.Data.Value == nil {
+		if cpsProperty == nil || cpsProperty.Data == nil || cpsProperty.Data.Value == nil {
 			streams = make([]string, 0)
 		} else {
 			streams = strings.Split(*cpsProperty.Data.Value, ",")


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Be wary about using the value of a CPS property returned by the API in case it's nil.