### PR TITLE
Allow auth properties as environment variables instead of always being within the galasactl.properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ GALASA_ACCESS_TOKEN=<a personal access token>
 
 These properties can be retrieved by creating a new personal access token from a Galasa ecosystem's web user interface.
 
+If you prefer, these variables can be set as environment variables instead of being read from this file.
+
 On a successful login, a `bearer-token.json` file will be created in your `GALASA_HOME` directory. This file will contain a bearer token that `galasactl` will use to authenticate requests when communicating with a Galasa ecosystem.
 
 If your bearer token expires, `galasactl` will automatically attempt to re-authenticate with your Galasa ecosystem. Alternatively, you can run the `auth login` command again to re-authenticate with your Galasa ecosystem.

--- a/docs/generated/errors-list.md
+++ b/docs/generated/errors-list.md
@@ -105,7 +105,6 @@ The `galasactl` tool can generate the following errors:
 - GAL1102E: name '{}' is invalid. '--name' is a mandatory flag for this command. Use the --help flag for more information, or refer to the documentation at https://galasa.dev/docs/reference/cli-commands.
 - GAL1103E: Could not query CPS results. Reason: '{}'
 - GAL1104E: Unable to delete the bearer token file '{}'.
-- GAL1105E: Property '{}' was expected but has not been set in the galasactl.properties file.
 - GAL1106E: Could not get security bearer token from API server. Reason: '{}'. Please ensure you have allocated a personal access token and configured your client program by storing it in your galasactl.properties file together with the related client ID and secret
 - GAL1107E: Could not get security bearer token from file '{}'. Reason: '{}'. Please ensure you are authenticated by running 'galasactl auth login' and that your personal access token has not expired or been revoked
 - GAL1108E: Invalid bearer token. Please ensure you are authenticated by running 'galasactl auth login' and that your personal access token has not expired or been revoked
@@ -122,6 +121,7 @@ The `galasactl` tool can generate the following errors:
 - GAL1119E: The server thinks you are unauthorized to perform this operation.
 - GAL1120E: Program logic error. Collect a log using the '--log' option and send to the Galasa development team.
 - GAL1121E: Unable to retrieve rest api version. Reason is: {}. Try downloading the latest version of galasa or rebuilding a clean version.
+- GAL1122E: Authentication property {} is not available, which is needed to connect to the Galasa Ecosystem. It either needs to be in a file '{}' or set as an environment variable.
 - GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '{}', and 'pre-release' repository is '{}'
 - GAL2501I: Downloaded {} artifacts to folder '{}'
 

--- a/pkg/auth/authLogin.go
+++ b/pkg/auth/authLogin.go
@@ -19,74 +19,80 @@ import (
 )
 
 // Login - performs all the logic to implement the `galasactl auth login` command
-func Login(apiServerUrl string, fileSystem files.FileSystem, galasaHome utils.GalasaHome) error {
+func Login(apiServerUrl string, fileSystem files.FileSystem, galasaHome utils.GalasaHome, env utils.Environment) error {
 
-    var err error = nil
-    var authProperties galasaapi.AuthProperties
-    authProperties, err = GetAuthProperties(fileSystem, galasaHome)
-    if err == nil {
-        var jwt string
-        jwt, err = GetJwtFromRestApi(apiServerUrl, authProperties)
-        if err == nil {
-            err = WriteBearerTokenJsonFile(fileSystem, galasaHome, jwt)
-        }
-    }
-    return err
+	var err error = nil
+	var authProperties galasaapi.AuthProperties
+	authProperties, err = GetAuthProperties(fileSystem, galasaHome, env)
+	if err == nil {
+		var jwt string
+		jwt, err = GetJwtFromRestApi(apiServerUrl, authProperties)
+		if err == nil {
+			err = WriteBearerTokenJsonFile(fileSystem, galasaHome, jwt)
+		}
+	}
+	return err
 }
 
 // Gets a JSON Web Token (JWT) from the API server's /auth endpoint
 func GetJwtFromRestApi(apiServerUrl string, authProperties galasaapi.AuthProperties) (string, error) {
-    var err error = nil
-    var context context.Context = nil
-    var jwtJsonStr string
-    var restApiVersion string
+	var err error = nil
+	var context context.Context = nil
+	var jwtJsonStr string
+	var restApiVersion string
 
-    restApiVersion, err = embedded.GetGalasactlRestApiVersion()
+	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 
-    if err == nil{
-        apiClient := api.InitialiseAPI(apiServerUrl)
+	if err == nil {
+		apiClient := api.InitialiseAPI(apiServerUrl)
 
-        var tokenResponse *galasaapi.TokenResponse
-        var httpResponse *http.Response
-        tokenResponse, httpResponse, err = apiClient.AuthenticationAPIApi.PostAuthenticate(context).
-            AuthProperties(authProperties).
-            ClientApiVersion(restApiVersion).
-            Execute()
-        if err != nil {
-            log.Println("Failed to retrieve bearer token from API server")
-            err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RETRIEVING_BEARER_TOKEN_FROM_API_SERVER, err.Error())
-        } else {
-            defer httpResponse.Body.Close()
-            var tokenResponseJson []byte
-            tokenResponseJson, err = tokenResponse.MarshalJSON()
-            jwtJsonStr = string(tokenResponseJson)
-            log.Println("Bearer token received from API server OK")
-        }
-    }
+		var tokenResponse *galasaapi.TokenResponse
+		var httpResponse *http.Response
+		tokenResponse, httpResponse, err = apiClient.AuthenticationAPIApi.PostAuthenticate(context).
+			AuthProperties(authProperties).
+			ClientApiVersion(restApiVersion).
+			Execute()
+		if err != nil {
+			log.Println("Failed to retrieve bearer token from API server")
+			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RETRIEVING_BEARER_TOKEN_FROM_API_SERVER, err.Error())
+		} else {
+			defer httpResponse.Body.Close()
+			var tokenResponseJson []byte
+			tokenResponseJson, err = tokenResponse.MarshalJSON()
+			jwtJsonStr = string(tokenResponseJson)
+			log.Println("Bearer token received from API server OK")
+		}
+	}
 
-    return jwtJsonStr, err
+	return jwtJsonStr, err
 }
 
 // Gets a new authenticated API client, attempting to log in if a bearer token file does not exist
-func GetAuthenticatedAPIClient(apiServerUrl string, fileSystem files.FileSystem, galasaHome utils.GalasaHome, timeService utils.TimeService) *galasaapi.APIClient {
-    bearerToken, err := GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
-    if err != nil {
-        // Attempt to log in
-        log.Printf("Logging in to the Galasa Ecosystem at '%s'", apiServerUrl)
-        err = Login(apiServerUrl, fileSystem, galasaHome)
-        if err == nil {
-            log.Printf("Logged in to the Galasa Ecosystem at '%s' OK", apiServerUrl)
-            bearerToken, err = GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
-        }
-    }
+func GetAuthenticatedAPIClient(
+	apiServerUrl string,
+	fileSystem files.FileSystem,
+	galasaHome utils.GalasaHome,
+	timeService utils.TimeService,
+	env utils.Environment,
+) *galasaapi.APIClient {
+	bearerToken, err := GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
+	if err != nil {
+		// Attempt to log in
+		log.Printf("Logging in to the Galasa Ecosystem at '%s'", apiServerUrl)
+		err = Login(apiServerUrl, fileSystem, galasaHome, env)
+		if err == nil {
+			log.Printf("Logged in to the Galasa Ecosystem at '%s' OK", apiServerUrl)
+			bearerToken, err = GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
+		}
+	}
 
-    var apiClient *galasaapi.APIClient
-    if err == nil {
-        apiClient = api.InitialiseAuthenticatedAPI(apiServerUrl, bearerToken)
-    } else {
-        // Temporary code to allow the CLI to continue running commands while authentication is being implemented.
-        // Remove this once authentication has been delivered and users can authenticate against an ecosystem
-        apiClient = api.InitialiseAPI(apiServerUrl)
-    }
-    return apiClient
+	var apiClient *galasaapi.APIClient
+	if err == nil {
+		apiClient = api.InitialiseAuthenticatedAPI(apiServerUrl, bearerToken)
+	} else {
+		// Temporary code to allow the CLI to continue running commands while authentication is being implemented.
+		// Remove this once authentication has been delivered and users can authenticate against an ecosystem
+		apiClient = api.InitialiseAPI(apiServerUrl)
+	}
+	return apiClient
 }

--- a/pkg/auth/authProperties.go
+++ b/pkg/auth/authProperties.go
@@ -6,6 +6,7 @@
 package auth
 
 import (
+	"log"
 	"path/filepath"
 
 	"github.com/galasa-dev/cli/pkg/files"
@@ -22,45 +23,85 @@ const (
 	ACCESS_TOKEN_PROPERTY = "GALASA_ACCESS_TOKEN"
 )
 
+// Gets authentication properties from the user's galasactl.properties file or from the environment or a mixture.
+func GetAuthProperties(fileSystem files.FileSystem, galasaHome utils.GalasaHome, env utils.Environment) (galasaapi.AuthProperties, error) {
+	var err error = nil
+
+	// Work out which file we we want to draw properties from.
+	galasactlPropertiesFilePath := filepath.Join(galasaHome.GetNativeFolderPath(), "galasactl.properties")
+
+	// Get the file-based properties if we can
+	authProperties, fileAccessErr := getAuthPropertiesFromFile(fileSystem, galasactlPropertiesFilePath, env)
+	if fileAccessErr != nil {
+		authProperties = *galasaapi.NewAuthProperties()
+	}
+
+	// We now have a structure which may be filled-in with values from the file.
+	// Over-write those values if there is an environment variable set to do that.
+	authProperties.SetClientId(getPropertyWithOverride(env, authProperties.GetClientId(), galasactlPropertiesFilePath, CLIENT_ID_PROPERTY))
+	authProperties.SetRefreshToken(getPropertyWithOverride(env, authProperties.GetRefreshToken(), galasactlPropertiesFilePath, ACCESS_TOKEN_PROPERTY))
+	authProperties.SetSecret(getPropertyWithOverride(env, authProperties.GetSecret(), galasactlPropertiesFilePath, SECRET_PROPERTY))
+
+	// Make sure all the properties have values that we need.
+	err = checkPropertyIsSet(authProperties.GetClientId(), CLIENT_ID_PROPERTY, galasactlPropertiesFilePath, fileAccessErr)
+	if err == nil {
+		err = checkPropertyIsSet(authProperties.GetRefreshToken(), ACCESS_TOKEN_PROPERTY, galasactlPropertiesFilePath, fileAccessErr)
+		if err == nil {
+			err = checkPropertyIsSet(authProperties.GetSecret(), SECRET_PROPERTY, galasactlPropertiesFilePath, fileAccessErr)
+		}
+	}
+
+	return authProperties, err
+}
+
+func checkPropertyIsSet(propertyValue string, propertyName string, galasactlPropertiesFilePath string, fileAccessErr error) error {
+	var err error
+	if propertyValue == "" {
+		// Property has not been set.
+		if fileAccessErr != nil {
+			// Being unable to read the file was the cause of this.
+			err = fileAccessErr
+		} else {
+			log.Printf("Error: Auth property '%s' has not been set", propertyName)
+			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_AUTH_PROPERTY_NOT_AVAILABLE, propertyName, galasactlPropertiesFilePath)
+		}
+	}
+	return err
+}
+
+func getPropertyWithOverride(env utils.Environment, valueFromFile string, filePathGatheredFrom string, propertyName string) string {
+	value := env.GetEnv(propertyName)
+	if value != "" {
+		// env var has been set.
+		if valueFromFile == "" {
+			log.Printf("environment variable '%s' over-rides a value from file '%s'", propertyName, filePathGatheredFrom)
+		} else {
+			log.Printf("environment variable '%s' used to control authentication.", propertyName)
+		}
+	} else {
+		value = valueFromFile
+	}
+	return value
+}
+
 // Gets authentication properties from the user's galasactl.properties file
-func GetAuthProperties(fileSystem files.FileSystem, galasaHome utils.GalasaHome) (galasaapi.AuthProperties, error) {
-    var err error = nil
-    authProperties := galasaapi.NewAuthProperties()
+func getAuthPropertiesFromFile(fileSystem files.FileSystem, galasactlPropertiesFilePath string, env utils.Environment) (galasaapi.AuthProperties, error) {
+	var err error = nil
+	authProperties := galasaapi.NewAuthProperties()
 
-    galasactlPropertiesFilePath := filepath.Join(galasaHome.GetNativeFolderPath(), "galasactl.properties")
-    
-    var galasactlProperties props.JavaProperties
-    galasactlProperties, err = props.ReadPropertiesFile(fileSystem, galasactlPropertiesFilePath)
-    if err == nil {
-        requiredAuthProperties := getAuthPropertiesList()
-        err = validateRequiredGalasactlProperties(requiredAuthProperties, galasactlProperties)
+	var galasactlProperties props.JavaProperties
+	galasactlProperties, err = props.ReadPropertiesFile(fileSystem, galasactlPropertiesFilePath)
+	if err == nil {
 
-        if err == nil {
-            authProperties.SetClientId(galasactlProperties[CLIENT_ID_PROPERTY])
-            authProperties.SetSecret(galasactlProperties[SECRET_PROPERTY])
-            authProperties.SetRefreshToken(galasactlProperties[ACCESS_TOKEN_PROPERTY])
-        }
+		if err == nil {
+			authProperties.SetClientId(galasactlProperties[CLIENT_ID_PROPERTY])
+			authProperties.SetSecret(galasactlProperties[SECRET_PROPERTY])
+			authProperties.SetRefreshToken(galasactlProperties[ACCESS_TOKEN_PROPERTY])
+		}
 
-    } else {
-        err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_READ_FILE, galasactlPropertiesFilePath, err.Error())
-    }
+	} else {
+		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_READ_FILE, galasactlPropertiesFilePath, err.Error())
+	}
 
-    return *authProperties, err
-}
-
-// Ensures the provided galasactl properties contain values for the required properties, returning an error if a property is missing
-func validateRequiredGalasactlProperties(requiredProperties []string, galasactlProperties props.JavaProperties) error {
-    var err error = nil
-    for _, property := range requiredProperties {
-        if galasactlProperties[property] == "" {
-            err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_MISSING_GALASACTL_PROPERTY, property)
-            break
-        }
-    }
-    return err
-}
-
-// Returns a list of auth properties
-func getAuthPropertiesList() []string {
-	return []string{CLIENT_ID_PROPERTY, SECRET_PROPERTY, ACCESS_TOKEN_PROPERTY}
+	return *authProperties, err
 }

--- a/pkg/auth/authProperties_test.go
+++ b/pkg/auth/authProperties_test.go
@@ -25,13 +25,13 @@ func TestGetAuthPropertiesWithValidPropertiesUnmarshalsAuthProperties(t *testing
 	accessTokenValue := "abc"
 
 	mockFileSystem.WriteTextFile(
-		mockGalasaHome.GetNativeFolderPath() + "/galasactl.properties",
+		mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties",
 		fmt.Sprintf(
-			"GALASA_CLIENT_ID=%s\n" +
-			"GALASA_SECRET=%s\n" +
-			"GALASA_ACCESS_TOKEN=%s", clientIdValue, secretValue, accessTokenValue))
+			"GALASA_CLIENT_ID=%s\n"+
+				"GALASA_SECRET=%s\n"+
+				"GALASA_ACCESS_TOKEN=%s", clientIdValue, secretValue, accessTokenValue))
 	// When...
-	authProperties, err := GetAuthProperties(mockFileSystem, mockGalasaHome)
+	authProperties, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
 
 	// Then...
 	assert.Nil(t, err, "Should not return an error if the galasactl.properties exists and all required properties are present")
@@ -40,20 +40,103 @@ func TestGetAuthPropertiesWithValidPropertiesUnmarshalsAuthProperties(t *testing
 	assert.Equal(t, accessTokenValue, authProperties.GetRefreshToken())
 }
 
+func TestGetAuthPropertiesWithNoClientIdValidPropertiesUnmarshalsAuthPropertiesFails(t *testing.T) {
+	// Given...
+	mockFileSystem := files.NewMockFileSystem()
+	mockEnvironment := utils.NewMockEnv()
+	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+
+	secretValue := "dummySecret"
+	accessTokenValue := "abc"
+
+	mockFileSystem.WriteTextFile(
+		mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties",
+		fmt.Sprintf(
+			// "GALASA_CLIENT_ID=%s\n"+
+			"GALASA_SECRET=%s\n"+
+				"GALASA_ACCESS_TOKEN=%s",
+			// clientIdValue,
+			secretValue, accessTokenValue))
+	// When...
+	_, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
+
+	// Then...
+	assert.NotNil(t, err, "Should return an error as the galasactl.properties exists but the client id is missing from the file.")
+	assert.Contains(t, err.Error(), "GAL1122E")
+	assert.Contains(t, err.Error(), "GALASA_CLIENT_ID")
+}
+
+func TestGetAuthPropertiesWithNoSecretIdValidPropertiesUnmarshalsAuthPropertiesFails(t *testing.T) {
+	// Given...
+	mockFileSystem := files.NewMockFileSystem()
+	mockEnvironment := utils.NewMockEnv()
+	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+
+	clientIdValue := "my-client-id"
+	// secretValue := "dummySecret"
+	accessTokenValue := "abc"
+
+	mockFileSystem.WriteTextFile(
+		mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties",
+		fmt.Sprintf(
+			"GALASA_CLIENT_ID=%s\n"+
+				// "GALASA_SECRET=%s\n"+
+				"GALASA_ACCESS_TOKEN=%s",
+			clientIdValue,
+			// secretValue,
+			accessTokenValue))
+	// When...
+	_, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
+
+	// Then...
+	assert.NotNil(t, err, "Should return an error as the galasactl.properties exists but the secret is missing from the file.")
+	assert.Contains(t, err.Error(), "GAL1122E")
+	assert.Contains(t, err.Error(), "GALASA_SECRET")
+}
+
+func TestGetAuthPropertiesWithNoRefreshTokenIdValidPropertiesUnmarshalsAuthPropertiesFails(t *testing.T) {
+	// Given...
+	mockFileSystem := files.NewMockFileSystem()
+	mockEnvironment := utils.NewMockEnv()
+	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+
+	clientIdValue := "my-client-id"
+	secretValue := "dummySecret"
+	// accessTokenValue := "abc"
+
+	mockFileSystem.WriteTextFile(
+		mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties",
+		fmt.Sprintf(
+			"GALASA_CLIENT_ID=%s\n"+
+				"GALASA_SECRET=%s\n",
+			// "GALASA_ACCESS_TOKEN=%s",
+			clientIdValue,
+			secretValue,
+		// accessTokenValue,
+		))
+	// When...
+	_, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
+
+	// Then...
+	assert.NotNil(t, err, "Should return an error as the galasactl.properties exists but the secret is missing from the file.")
+	assert.Contains(t, err.Error(), "GAL1122E")
+	assert.Contains(t, err.Error(), "GALASA_ACCESS_TOKEN")
+}
+
 func TestGetAuthPropertiesWithEmptyGalasactlPropertiesReturnsError(t *testing.T) {
 	// Given...
 	mockFileSystem := files.NewMockFileSystem()
 	mockEnvironment := utils.NewMockEnv()
 	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
 
-	mockFileSystem.WriteTextFile(mockGalasaHome.GetNativeFolderPath() + "/galasactl.properties", "")
+	mockFileSystem.WriteTextFile(mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties", "")
 
 	// When...
-	_, err := GetAuthProperties(mockFileSystem, mockGalasaHome)
+	_, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
 
 	// Then...
 	assert.NotNil(t, err, "Should return an error if the galasactl.properties is empty")
-	assert.ErrorContains(t, err, "GAL1105E")
+	assert.ErrorContains(t, err, "GAL1122E")
 }
 
 func TestGetAuthPropertiesWithMissingPropertiesReturnsError(t *testing.T) {
@@ -66,15 +149,15 @@ func TestGetAuthPropertiesWithMissingPropertiesReturnsError(t *testing.T) {
 
 	// Create a galasactl.properties file that is missing the GALASA_SECRET and GALASA_ACCESS_TOKEN properties
 	mockFileSystem.WriteTextFile(
-		mockGalasaHome.GetNativeFolderPath() + "/galasactl.properties",
+		mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties",
 		fmt.Sprintf("GALASA_CLIENT_ID=%s", clientIdValue))
 
 	// When...
-	_, err := GetAuthProperties(mockFileSystem, mockGalasaHome)
+	_, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
 
 	// Then...
 	assert.NotNil(t, err, "Should return an error if the galasactl.properties exists and some required properties are missing")
-	assert.ErrorContains(t, err, "GAL1105E")
+	assert.ErrorContains(t, err, "GAL1122E")
 }
 
 func TestGetAuthPropertiesWithMissingGalasactlPropertiesFileReturnsError(t *testing.T) {
@@ -84,9 +167,149 @@ func TestGetAuthPropertiesWithMissingGalasactlPropertiesFileReturnsError(t *test
 	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
 
 	// When...
-	_, err := GetAuthProperties(mockFileSystem, mockGalasaHome)
+	_, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
 
 	// Then...
 	assert.NotNil(t, err, "Should return an error if the galasactl.properties does not exist")
 	assert.ErrorContains(t, err, "GAL1043E")
+}
+
+func TestGetAuthPropertiesEnvVarsOverridesFileValues(t *testing.T) {
+	// Given...
+	mockFileSystem := files.NewMockFileSystem()
+	mockEnvironment := utils.NewMockEnv()
+	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+
+	clientIdValue := "client-id-from-file"
+	secretValue := "secret-from-file"
+	accessTokenValue := "token-from-file"
+
+	mockFileSystem.WriteTextFile(
+		mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties",
+		fmt.Sprintf(
+			"GALASA_CLIENT_ID=%s\n"+
+				"GALASA_SECRET=%s\n"+
+				"GALASA_ACCESS_TOKEN=%s", clientIdValue, secretValue, accessTokenValue))
+
+	clientIdValue = "client-id-from-env-var"
+	secretValue = "secret-from-env-var"
+	accessTokenValue = "token-from-env-var"
+
+	mockEnvironment.SetEnv(CLIENT_ID_PROPERTY, clientIdValue)
+	mockEnvironment.SetEnv(SECRET_PROPERTY, secretValue)
+	mockEnvironment.SetEnv(ACCESS_TOKEN_PROPERTY, accessTokenValue)
+
+	// When...
+	authProperties, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
+
+	// Then...
+	assert.Nil(t, err, "Should not return an error if the galasactl.properties exists and all required properties are present")
+	assert.Equal(t, clientIdValue, authProperties.GetClientId())
+	assert.Equal(t, secretValue, authProperties.GetSecret())
+	assert.Equal(t, accessTokenValue, authProperties.GetRefreshToken())
+}
+
+func TestGetAuthPropertiesClientIDEnvVarOverridesFileValue(t *testing.T) {
+	// Given...
+	mockFileSystem := files.NewMockFileSystem()
+	mockEnvironment := utils.NewMockEnv()
+	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+
+	clientIdValue := "client-id-from-file"
+	secretValue := "secret-from-file"
+	accessTokenValue := "token-from-file"
+
+	mockFileSystem.WriteTextFile(
+		mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties",
+		fmt.Sprintf(
+			"GALASA_CLIENT_ID=%s\n"+
+				"GALASA_SECRET=%s\n"+
+				"GALASA_ACCESS_TOKEN=%s", clientIdValue, secretValue, accessTokenValue))
+
+	clientIdValue = "client-id-from-env-var"
+	// secretValue = "secret-from-env-var"
+	// accessTokenValue = "token-from-env-var"
+
+	mockEnvironment.SetEnv(CLIENT_ID_PROPERTY, clientIdValue)
+	// mockEnvironment.SetEnv(SECRET_PROPERTY, secretValue)
+	// mockEnvironment.SetEnv(ACCESS_TOKEN_PROPERTY, accessTokenValue)
+
+	// When...
+	authProperties, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
+
+	// Then...
+	assert.Nil(t, err, "Should not return an error if the galasactl.properties exists and all required properties are present")
+	assert.Equal(t, clientIdValue, authProperties.GetClientId())
+	assert.Equal(t, secretValue, authProperties.GetSecret())
+	assert.Equal(t, accessTokenValue, authProperties.GetRefreshToken())
+}
+
+func TestGetAuthPropertiesSecretEnvVarOverridesFileValue(t *testing.T) {
+	// Given...
+	mockFileSystem := files.NewMockFileSystem()
+	mockEnvironment := utils.NewMockEnv()
+	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+
+	clientIdValue := "client-id-from-file"
+	secretValue := "secret-from-file"
+	accessTokenValue := "token-from-file"
+
+	mockFileSystem.WriteTextFile(
+		mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties",
+		fmt.Sprintf(
+			"GALASA_CLIENT_ID=%s\n"+
+				"GALASA_SECRET=%s\n"+
+				"GALASA_ACCESS_TOKEN=%s", clientIdValue, secretValue, accessTokenValue))
+
+	// clientIdValue = "client-id-from-env-var"
+	secretValue = "secret-from-env-var"
+	// accessTokenValue = "token-from-env-var"
+
+	// mockEnvironment.SetEnv(CLIENT_ID_PROPERTY, clientIdValue)
+	mockEnvironment.SetEnv(SECRET_PROPERTY, secretValue)
+	// mockEnvironment.SetEnv(ACCESS_TOKEN_PROPERTY, accessTokenValue)
+
+	// When...
+	authProperties, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
+
+	// Then...
+	assert.Nil(t, err, "Should not return an error if the galasactl.properties exists and all required properties are present")
+	assert.Equal(t, clientIdValue, authProperties.GetClientId())
+	assert.Equal(t, secretValue, authProperties.GetSecret())
+	assert.Equal(t, accessTokenValue, authProperties.GetRefreshToken())
+}
+
+func TestGetAuthPropertiesRefreshTokenEnvVarOverridesFileValue(t *testing.T) {
+	// Given...
+	mockFileSystem := files.NewMockFileSystem()
+	mockEnvironment := utils.NewMockEnv()
+	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+
+	clientIdValue := "client-id-from-file"
+	secretValue := "secret-from-file"
+	accessTokenValue := "token-from-file"
+
+	mockFileSystem.WriteTextFile(
+		mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties",
+		fmt.Sprintf(
+			"GALASA_CLIENT_ID=%s\n"+
+				"GALASA_SECRET=%s\n"+
+				"GALASA_ACCESS_TOKEN=%s", clientIdValue, secretValue, accessTokenValue))
+
+	// clientIdValue = "client-id-from-env-var"
+	// secretValue = "secret-from-env-var"
+	accessTokenValue = "token-from-env-var"
+
+	// mockEnvironment.SetEnv(CLIENT_ID_PROPERTY, clientIdValue)
+	// mockEnvironment.SetEnv(SECRET_PROPERTY, secretValue)
+	mockEnvironment.SetEnv(ACCESS_TOKEN_PROPERTY, accessTokenValue)
+
+	// When...
+	authProperties, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
+
+	// Then...
+	assert.Nil(t, err, "Should not return an error if the galasactl.properties exists and all required properties are present")
+	assert.Equal(t, clientIdValue, authProperties.GetClientId())
+	assert.Equal(t, secretValue, authProperties.GetSecret())
+	assert.Equal(t, accessTokenValue, authProperties.GetRefreshToken())
 }

--- a/pkg/cmd/authLogin.go
+++ b/pkg/cmd/authLogin.go
@@ -64,7 +64,7 @@ func (cmd *AuthLoginComamnd) createCobraCommand(
 	factory Factory,
 	authCommand GalasaCommand,
 	rootCmd GalasaCommand,
-	) (*cobra.Command, error) {
+) (*cobra.Command, error) {
 
 	var err error
 	authLoginCobraCmd := &cobra.Command{
@@ -125,6 +125,7 @@ func (cmd *AuthLoginComamnd) executeAuthLogin(
 				apiServerUrl,
 				fileSystem,
 				galasaHome,
+				env,
 			)
 		}
 	}

--- a/pkg/cmd/propertiesDelete.go
+++ b/pkg/cmd/propertiesDelete.go
@@ -60,10 +60,10 @@ func (cmd *PropertiesDeleteCommand) init(factory Factory, propertiesCommand Gala
 //  And then display a successful message or error
 
 func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
-	factory Factory, 
+	factory Factory,
 	propertiesCommand GalasaCommand,
 	rootCmd GalasaCommand) (*cobra.Command, error) {
-	
+
 	var err error = nil
 	propertiesCmdValues := propertiesCommand.Values().(*PropertiesCmdValues)
 
@@ -119,7 +119,7 @@ func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory Factory, pro
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService)
+				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
 				// Call to process the command in a unit-testable way.
 				err = properties.DeleteProperty(propertiesCmdValues.namespace, propertiesCmdValues.propertyName, apiClient)

--- a/pkg/cmd/propertiesGet.go
+++ b/pkg/cmd/propertiesGet.go
@@ -159,7 +159,7 @@ func (cmd *PropertiesGetCommand) executePropertiesGet(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService)
+				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
 				// Call to process the command in a unit-testable way.
 				err = properties.GetProperties(

--- a/pkg/cmd/propertiesNamespaceGet.go
+++ b/pkg/cmd/propertiesNamespaceGet.go
@@ -136,7 +136,7 @@ func (cmd *PropertiesNamespaceGetCommand) executePropertiesNamespaceGet(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService)
+				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
 				// Call to process the command in a unit-testable way.
 				err = properties.GetPropertiesNamespaces(apiClient, cmd.values.namespaceOutputFormat, console)

--- a/pkg/cmd/propertiesSet.go
+++ b/pkg/cmd/propertiesSet.go
@@ -2,7 +2,7 @@
 * Copyright contributors to the Galasa project
 *
 * SPDX-License-Identifier: EPL-2.0
-*/
+ */
 
 package cmd
 
@@ -70,10 +70,10 @@ func (cmd *PropertiesSetCommand) init(factory Factory, propertiesCommand GalasaC
 }
 
 func (cmd *PropertiesSetCommand) createCobraCommand(
-	factory Factory, 
-	propertiesCommand GalasaCommand, 
+	factory Factory,
+	propertiesCommand GalasaCommand,
 	rootCmdValues *RootCmdValues,
-	) (*cobra.Command, error) {
+) (*cobra.Command, error) {
 
 	var err error = nil
 	propertiesCmdValues := propertiesCommand.Values().(*PropertiesCmdValues)
@@ -136,13 +136,13 @@ func (cmd *PropertiesSetCommand) executePropertiesSet(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService)
+				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
 				// Call to process the command in a unit-testable way.
 				err = properties.SetProperty(
 					propertiesCmdValues.namespace,
 					propertiesCmdValues.propertyName,
-					cmd.values.propertyValue, 
+					cmd.values.propertyValue,
 					apiClient)
 			}
 		}

--- a/pkg/cmd/runsDownload.go
+++ b/pkg/cmd/runsDownload.go
@@ -76,7 +76,7 @@ func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 ) (*cobra.Command, error) {
 
 	var err error = nil
-	runsCmdValues := runsCommand.Values().(*RunsCmdValues) 
+	runsCmdValues := runsCommand.Values().(*RunsCmdValues)
 
 	runsDownloadCobraCmd := &cobra.Command{
 		Use:     "download",
@@ -138,7 +138,7 @@ func (cmd *RunsDownloadCommand) executeRunsDownload(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService)
+				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
 				// Call to process the command in a unit-testable way.
 				err = runs.DownloadArtifacts(

--- a/pkg/cmd/runsGet.go
+++ b/pkg/cmd/runsGet.go
@@ -62,8 +62,7 @@ func (cmd *RunsGetCommand) Values() interface{} {
 func (cmd *RunsGetCommand) init(factory Factory, runsCommand GalasaCommand, rootCommand GalasaCommand) error {
 	var err error
 	cmd.values = &RunsGetCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, runsCommand, rootCommand.Values().(*RootCmdValues),
-	)
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, runsCommand, rootCommand.Values().(*RootCmdValues))
 	return err
 }
 
@@ -71,7 +70,7 @@ func (cmd *RunsGetCommand) createCobraCommand(
 	factory Factory,
 	runsCommand GalasaCommand,
 	rootCmdValues *RootCmdValues,
-	) (*cobra.Command, error) {
+) (*cobra.Command, error) {
 
 	var err error = nil
 	runsCmdValues := runsCommand.Values().(*RunsCmdValues)
@@ -89,18 +88,18 @@ func (cmd *RunsGetCommand) createCobraCommand(
 
 	units := runs.GetTimeUnitsForErrorMessage()
 	formatters := runs.GetFormatterNamesString(runs.CreateFormatters())
-	runsGetCobraCmd.PersistentFlags().StringVar(&cmd.values.runName, "name", "", "the name of the test run we want information about." +
+	runsGetCobraCmd.PersistentFlags().StringVar(&cmd.values.runName, "name", "", "the name of the test run we want information about."+
 		" Cannot be used in conjunction with --requestor, --result or --active flags")
 	runsGetCobraCmd.PersistentFlags().StringVar(&cmd.values.age, "age", "", "the age of the test run(s) we want information about. Supported formats are: 'FROM' or 'FROM:TO', where FROM and TO are each ages,"+
 		" made up of an integer and a time-unit qualifier. Supported time-units are "+units+". If missing, the TO part is defaulted to '0h'. Examples: '--age 1d',"+
 		" '--age 6h:1h' (list test runs which happened from 6 hours ago to 1 hour ago)."+
 		" The TO part must be a smaller time-span than the FROM part.")
 	runsGetCobraCmd.PersistentFlags().StringVar(&cmd.values.outputFormatString, "format", "summary", "output format for the data returned. Supported formats are: "+formatters+".")
-	runsGetCobraCmd.PersistentFlags().StringVar(&cmd.values.requestor, "requestor", "", "the requestor of the test run we want information about." + 
+	runsGetCobraCmd.PersistentFlags().StringVar(&cmd.values.requestor, "requestor", "", "the requestor of the test run we want information about."+
 		" Cannot be used in conjunction with --name flag.")
-	runsGetCobraCmd.PersistentFlags().StringVar(&cmd.values.result, "result", "", "A filter on the test runs we want information about. Optional. Default is to display test runs with any result. Case insensitive. Value can be a single value or a comma-separated list. For example \"--result Failed,Ignored,EnvFail\"." + 
+	runsGetCobraCmd.PersistentFlags().StringVar(&cmd.values.result, "result", "", "A filter on the test runs we want information about. Optional. Default is to display test runs with any result. Case insensitive. Value can be a single value or a comma-separated list. For example \"--result Failed,Ignored,EnvFail\"."+
 		" Cannot be used in conjunction with --name or --active flag.")
-	runsGetCobraCmd.PersistentFlags().BoolVar(&cmd.values.isActiveRuns, "active", false, "parameter to retrieve runs that have not finished yet." + 
+	runsGetCobraCmd.PersistentFlags().BoolVar(&cmd.values.isActiveRuns, "active", false, "parameter to retrieve runs that have not finished yet."+
 		" Cannot be used in conjunction with --name or --result flag.")
 
 	runsGetCobraCmd.MarkFlagsMutuallyExclusive("name", "requestor")
@@ -117,7 +116,7 @@ func (cmd *RunsGetCommand) executeRunsGet(
 	factory Factory,
 	runsCmdValues *RunsCmdValues,
 	rootCmdValues *RootCmdValues,
-	) error {
+) error {
 
 	var err error
 
@@ -149,7 +148,7 @@ func (cmd *RunsGetCommand) executeRunsGet(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService)
+				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
 				// Call to process the command in a unit-testable way.
 				err = runs.GetRuns(

--- a/pkg/cmd/runsPrepare.go
+++ b/pkg/cmd/runsPrepare.go
@@ -151,7 +151,7 @@ func (cmd *RunsPrepareCommand) executeAssemble(
 
 					// Create an API client
 					apiServerUrl := bootstrapData.ApiServerURL
-					apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService)
+					apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 					launcher := launcher.NewRemoteLauncher(apiServerUrl, apiClient)
 
 					validator := runs.NewStreamBasedValidator()

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -65,7 +65,7 @@ func (cmd *RunsSubmitCommand) init(factory Factory, runsCommand GalasaCommand, r
 func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory Factory,
 	runsCommand GalasaCommand,
 	rootCmdValues *RootCmdValues,
-	) (*cobra.Command, error) {
+) (*cobra.Command, error) {
 
 	var err error = nil
 
@@ -172,7 +172,7 @@ func (cmd *RunsSubmitCommand) executeSubmit(
 
 				// The launcher we are going to use to start/monitor tests.
 				apiServerUrl := bootstrapData.ApiServerURL
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService)
+				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 				launcherInstance = launcher.NewRemoteLauncher(apiServerUrl, apiClient)
 
 				validator := runs.NewStreamBasedValidator()

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -191,7 +191,6 @@ var (
 	GALASA_ERROR_MISSING_NAME_FLAG                       = NewMessageType("GAL1102E: name '%s' is invalid. '--name' is a mandatory flag for this command."+SEE_COMMAND_REFERENCE, 1102, STACK_TRACE_WANTED)
 	GALASA_ERROR_QUERY_CPS_FAILED                        = NewMessageType("GAL1103E: Could not query CPS results. Reason: '%s'", 1103, STACK_TRACE_WANTED)
 	GALASA_ERROR_UNABLE_TO_DELETE_BEARER_TOKEN_FILE      = NewMessageType("GAL1104E: Unable to delete the bearer token file '%s'.", 1104, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_MISSING_GALASACTL_PROPERTY              = NewMessageType("GAL1105E: Property '%s' was expected but has not been set in the galasactl.properties file.", 1105, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_RETRIEVING_BEARER_TOKEN_FROM_API_SERVER = NewMessageType("GAL1106E: Could not get security bearer token from API server. Reason: '%s'. Please ensure you have allocated a personal access token and configured your client program by storing it in your galasactl.properties file together with the related client ID and secret", 1106, STACK_TRACE_WANTED)
 	GALASA_ERROR_RETRIEVING_BEARER_TOKEN_FROM_FILE       = NewMessageType("GAL1107E: Could not get security bearer token from file '%s'. Reason: '%s'. Please ensure you are authenticated by running 'galasactl auth login' and that your personal access token has not expired or been revoked", 1107, STACK_TRACE_WANTED)
 	GALASA_ERROR_INVALID_BEARER_TOKEN                    = NewMessageType("GAL1108E: Invalid bearer token. Please ensure you are authenticated by running 'galasactl auth login' and that your personal access token has not expired or been revoked", 1108, STACK_TRACE_NOT_WANTED)
@@ -208,6 +207,7 @@ var (
 	GALASA_ERROR_RESOURCE_RESP_UNAUTHORIZED_OPERATION    = NewMessageType("GAL1119E: The server thinks you are unauthorized to perform this operation.", 1119, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_COMMAND_NOT_FOUND_IN_CMD_COLLECTION     = NewMessageType("GAL1120E: Program logic error. Collect a log using the '--log' option and send to the Galasa development team.", 1120, STACK_TRACE_WANTED)
 	GALASA_ERROR_UNABLE_TO_RETRIEVE_REST_API_VERSION     = NewMessageType("GAL1121E: Unable to retrieve rest api version. Reason is: %s. Try downloading the latest version of galasa or rebuilding a clean version.", 1121, STACK_TRACE_WANTED)
+	GALASA_ERROR_AUTH_PROPERTY_NOT_AVAILABLE             = NewMessageType("GAL1122E: Authentication property %s is not available, which is needed to connect to the Galasa Ecosystem. It either needs to be in a file '%s' or set as an environment variable.", 1122, STACK_TRACE_NOT_WANTED)
 
 	// Warnings...
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'pre-release' repository is '%s'", 2000, STACK_TRACE_WANTED)

--- a/pkg/properties/propertiesGet_test.go
+++ b/pkg/properties/propertiesGet_test.go
@@ -330,7 +330,7 @@ func TestInvalidNamepsaceReturnsError(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	//When
 	err := GetProperties(namespace, name, prefix, suffix, infix, apiClient, propertiesOutputFormat, mockConsole)
@@ -360,7 +360,7 @@ func TestValidNamespaceReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `namespace      name      value
 validNamespace property0 value0
@@ -399,7 +399,7 @@ func TestEmptyNamespaceReturnsEmpty(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `Total:0
 `
@@ -431,7 +431,7 @@ func TestValidNamespaceAndPrefixReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `namespace      name             value
 validNamespace aPrefix.property prefixVal
@@ -467,7 +467,7 @@ func TestValidNamespaceAndSuffixReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `namespace      name             value
 validNamespace property.aSuffix suffixVal
@@ -503,7 +503,7 @@ func TestValidNamespaceWithMatchingPrefixAndSuffixReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `namespace      name                     value
 validNamespace aPrefix.property.aSuffix prefixSuffixVal
@@ -539,7 +539,7 @@ func TestValidNamespaceWithNoMatchingPrefixAndSuffixReturnsEmpty(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `Total:0
 `
@@ -572,7 +572,7 @@ func TestValidNamespaceAndNoMatchingPrefixReturnsEmpty(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `Total:0
 `
@@ -605,7 +605,7 @@ func TestValidNamespaceAndNoMatchingSuffixReturnsEmpty(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `Total:0
 `
@@ -638,7 +638,7 @@ func TestValidNamespaceWithMatchingInfixReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `namespace      name                value
 validNamespace extra.anInfix.extra infixVal
@@ -673,7 +673,7 @@ func TestValidNamespaceWithNoMatchingInfixReturnsEmpty(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `Total:0
 `
@@ -705,7 +705,7 @@ func TestValidNamespaceWithMatchingPrefixAndInfixReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `namespace      name                     value
 validNamespace aPrefix.anInfix.property prefixInfixVal
@@ -741,7 +741,7 @@ func TestValidNamespaceWithMatchingSuffixAndInfixReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `namespace      name                     value
 validNamespace property.anInfix.aSuffix suffixInfixVal
@@ -777,7 +777,7 @@ func TestValidNamespaceWithMatchingPrefixAndSuffixAndInfixReturnsOk(t *testing.T
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `namespace      name                             value
 validNamespace aPrefix.anInfix.property.aSuffix prefixSuffixInfixVal
@@ -813,7 +813,7 @@ func TestValidNamespaceWithValidNameReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `namespace      name      value
 validNamespace property0 value0
@@ -848,7 +848,7 @@ func TestValidNameWithEmptyValueValidNameReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `namespace      name           value
 validNamespace emptyValueName 
@@ -884,7 +884,7 @@ func TestInvalidPropertyNameReturnsEmpty(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `Total:0
 `
@@ -917,7 +917,7 @@ func TestValidNamespaceRawFormatReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `validNamespace|property0|value0
 validNamespace|property1|value1
@@ -952,7 +952,7 @@ func TestEmptyNamespaceRawFormatReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := ``
 	//When
@@ -983,7 +983,7 @@ func TestValidNamespaceYamlFormatReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := `apiVersion: null
 kind: null
@@ -1045,7 +1045,7 @@ func TestEmptyNamespaceYamlFormatReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	expectedOutput := ``
 	//When

--- a/pkg/properties/propertiesSet_test.go
+++ b/pkg/properties/propertiesSet_test.go
@@ -105,7 +105,7 @@ func TestCreatePropertyWithValidNamespaceReturnsOk(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -130,7 +130,7 @@ func TestUpdatePropertyWithInvalidNamespaceAndInvalidPropertyNameReturnsError(t 
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -158,7 +158,7 @@ func TestUpdatePropertyWithValidNamespaceAndVaidNameValueReturnsOk(t *testing.T)
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -183,7 +183,7 @@ func TestUpdatePropertyWithInvalidNamesapceAndValidNameReturnsError(t *testing.T
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -209,7 +209,7 @@ func TestSetNoNamespaceReturnsError(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -235,7 +235,7 @@ func TestSetNoNameReturnsError(t *testing.T) {
 	mockCurrentTime := time.UnixMilli(0)
 	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService)
+	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)

--- a/pkg/props/javaProperties.go
+++ b/pkg/props/javaProperties.go
@@ -34,23 +34,20 @@ func ReadProperties(propertyString string) JavaProperties {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		if strings.HasPrefix(line, "#") {
-			continue
+		if !strings.HasPrefix(line, "#") {
+
+			equalsPos := strings.Index(line, "=")
+			if equalsPos != -1 {
+
+				key := strings.TrimSpace(line[:equalsPos])
+				if key != "" {
+
+					value := strings.TrimSpace(line[equalsPos+1:])
+
+					properties[key] = value
+				}
+			}
 		}
-
-		equalsPos := strings.Index(line, "=")
-		if equalsPos == -1 {
-			continue
-		}
-
-		key := strings.TrimSpace(line[:equalsPos])
-		if key == "" {
-			continue
-		}
-
-		value := strings.TrimSpace(line[equalsPos+1:])
-
-		properties[key] = value
 	}
 
 	return properties


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- Allow auth properties to be set into the environment as env variables
- Env vars override whatever is in the file
- File is not needed if all env vars are present
- Missing env variables are sourced from the file
- Any missing properties get complained about
- Error message says add them to file or environment variable
- readme updates

This relates to story [CLI auth galasactl.properties values overridden using environment variables#1713](https://github.com/galasa-dev/projectmanagement/issues/1713)