### PR TITLE
download a re-run folder, and it gets rendered images too.

### DIFF
--- a/pkg/cmd/runsDownload.go
+++ b/pkg/cmd/runsDownload.go
@@ -6,14 +6,10 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
-	"github.com/galasa-dev/cli/pkg/embedded"
-	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
-	"github.com/galasa-dev/cli/pkg/images"
 	"github.com/galasa-dev/cli/pkg/runs"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -154,22 +150,6 @@ func (cmd *RunsDownloadCommand) executeRunsDownload(
 					apiClient,
 					cmd.values.runDownloadTargetFolder,
 				)
-
-				if err == nil {
-					// No error, so try to expand the files.
-					embeddedFileSystem := embedded.GetReadOnlyFileSystem()
-					renderer := images.NewImageRenderer(embeddedFileSystem)
-					expander := images.NewImageExpander(fileSystem, renderer)
-
-					err = expander.ExpandImages(cmd.values.runDownloadTargetFolder)
-					if err == nil {
-
-						// Write out a status string to the console about how many files were rendered.
-						count := expander.GetExpandedImageFileCount()
-						message := fmt.Sprintf(galasaErrors.GALASA_INFO_RENDERED_IMAGE_COUNT.Template, count)
-						console.WriteString(message)
-					}
-				}
 			}
 		}
 	}

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -221,5 +221,5 @@ var (
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'pre-release' repository is '%s'", 2000, STACK_TRACE_WANTED)
 	// Information messages...
 	GALASA_INFO_FOLDER_DOWNLOADED_TO = NewMessageType("GAL2501I: Downloaded %d artifacts to folder '%s'\n", 2501, STACK_TRACE_NOT_WANTED)
-	GALASA_INFO_RENDERED_IMAGE_COUNT = NewMessageType("GAL2502I: Rendered %d image files.\n", 2502, STACK_TRACE_NOT_WANTED)
+	GALASA_INFO_RENDERED_IMAGE_COUNT = NewMessageType("GAL2502I: Rendered %d image files in folder '%s'\n", 2502, STACK_TRACE_NOT_WANTED)
 )

--- a/pkg/images/imageExpander.go
+++ b/pkg/images/imageExpander.go
@@ -40,6 +40,8 @@ func (expander *ImageExpanderImpl) GetExpandedImageFileCount() int {
 func (expander *ImageExpanderImpl) ExpandImages(rootFolderPath string) error {
 	var err error
 
+	log.Printf("Expanding any 3270 image descriptions we have into images. Folder scanned: %s\n", rootFolderPath)
+
 	var paths []string
 	paths, err = expander.fs.GetAllFilePaths(rootFolderPath)
 

--- a/pkg/runs/runsDownload.go
+++ b/pkg/runs/runsDownload.go
@@ -172,7 +172,7 @@ func renderImagesInFolder(fileSystem files.FileSystem, folderName string, consol
 
 		// Write out a status string to the console about how many files were rendered.
 		count := expander.GetExpandedImageFileCount()
-		message := fmt.Sprintf(galasaErrors.GALASA_INFO_RENDERED_IMAGE_COUNT.Template, count)
+		message := fmt.Sprintf(galasaErrors.GALASA_INFO_RENDERED_IMAGE_COUNT.Template, count, folderName)
 		console.WriteString(message)
 	}
 	return err


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>


I noticed that downloads were being rendered right at the end of the process.

When I downloaded a test which has multiple re-run attempts, I only saw one rendering of the images... because the '.' folder was being used.

I fixed it now to show this:
```
>../bin/galasactl-darwin-arm64 runs download --name C20339 --force        
GAL2501I: Downloaded 5 artifacts to folder 'C20339-1'
GAL2502I: Rendered 0 image files in folder 'C20339-1'
GAL2501I: Downloaded 5 artifacts to folder 'C20339-2'
GAL2502I: Rendered 0 image files in folder 'C20339-2'
GAL2501I: Downloaded 5 artifacts to folder 'C20339-3'
GAL2502I: Rendered 0 image files in folder 'C20339-3'
```

and this when I download a test which actually has images inside:
```
>../bin/galasactl-darwin-arm64 runs download --name C20324 --force 
GAL2501I: Downloaded 303 artifacts to folder 'C20324'
GAL2502I: Rendered 2142 image files in folder 'C20324'
```