### PR TITLE
Update auth property format to GALASA_TOKEN and remove client secret from token

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ The `--galasahome` command-line flag can override the `GALASA_HOME` environment 
 Note: If you change this to a non-existent and/or non-initialised folder path, then 
 you will have to create and re-initialise the folder using the `galasactl local init` command again. That command will respect the `GALASA_HOME` variable and will create the folder and initialise it were it not to exist.
 
+### GALASA_TOKEN
+In order to authenticate with a Galasa ecosystem, you will need to create a personal access token from the Galasa web user interface.
+
+Once a personal access token has been created, you can either store the token in the galasactl.properties file within your Galasa home folder, or set the token as an environment variable named `GALASA_TOKEN`.
+
 
 ## Syntax
 The syntax is documented in generated documentation [here](docs/generated/galasactl.md)
@@ -95,17 +100,15 @@ If you wish the generated code to depend upon the very latest/bleeding-edge of g
 
 Before interacting with a Galasa ecosystem using `galasactl`, you must be authenticated with it. The `auth login` command allows you to log in to an ecosystem provided by your `GALASA_BOOTSTRAP` environment variable or through the `--bootstrap` flag.
 
-Prior to running this command, you must have a `galasactl.properties` file in your `GALASA_HOME` directory, which is automatically created when running `galasactl local init`, that contains a set of `auth` properties with the following format:
+Prior to running this command, you must have a `galasactl.properties` file in your `GALASA_HOME` directory, which is automatically created when running `galasactl local init`, that contains a `GALASA_TOKEN` property with the following format:
 
 ```
-GALASA_CLIENT_ID=<a client identifier>
-GALASA_SECRET=<a client secret>
-GALASA_ACCESS_TOKEN=<a personal access token>
+GALASA_TOKEN=<your personal access token>
 ```
 
-These properties can be retrieved by creating a new personal access token from a Galasa ecosystem's web user interface.
+A value for the `GALASA_TOKEN` property can be retrieved by creating a new personal access token from a Galasa ecosystem's web user interface.
 
-If you prefer, these variables can be set as environment variables instead of being read from this file.
+If you prefer, this property can be set as an environment variable instead of being read from this file.
 
 On a successful login, a `bearer-token.json` file will be created in your `GALASA_HOME` directory. This file will contain a bearer token that `galasactl` will use to authenticate requests when communicating with a Galasa ecosystem.
 

--- a/docs/generated/errors-list.md
+++ b/docs/generated/errors-list.md
@@ -124,6 +124,7 @@ The `galasactl` tool can generate the following errors:
 - GAL1122E: Authentication property {} is not available, which is needed to connect to the Galasa Ecosystem. It either needs to be in a file '{}' or set as an environment variable.
 - GAL1123E: Failed to read 3270 terminal JSON because the content is in the wrong format. Reason: {}
 - GAL1124E: Internal Failure. Terminal image could not be encoded into PNG format. Reason: {}
+- GAL1125E: Authentication property {} is invalid. Please ensure that it the value is made up of two parts that are separated by a '{}'.
 - GAL1225E: Failed to open file '{}' cause: {}. Check that this file exists, and that you have read permissions.
 - GAL1226E: Internal failure. Contents of gzip could be read, but not decoded. New gzip reader failed: file: {} error: {}
 - GAL1227E: Internal failure. Contents of gzip could not be decoded. {} error: {}

--- a/pkg/auth/authLogin_test.go
+++ b/pkg/auth/authLogin_test.go
@@ -31,7 +31,6 @@ func NewAuthServletMock(t *testing.T, status int, mockResponse string) *httptest
 
 			requestBodyStr := string(requestBody)
 			assert.Contains(t, requestBodyStr, "client_id")
-			assert.Contains(t, requestBodyStr, "secret")
 			assert.Contains(t, requestBodyStr, "refresh_token")
 
 			writer.Header().Set("Content-Type", "application/json")
@@ -95,12 +94,9 @@ func TestLoginCreatesBearerTokenFileContainingJWT(t *testing.T) {
 	galasactlPropertiesFilePath := mockGalasaHome.GetNativeFolderPath() + "/galasactl.properties"
 
 	mockClientId := "dummyId"
-	mockSecret := "shhhh"
 	mockRefreshToken := "abcdefg"
-	mockFileSystem.WriteTextFile(galasactlPropertiesFilePath, fmt.Sprintf(
-		"GALASA_CLIENT_ID=%s\n"+
-			"GALASA_SECRET=%s\n"+
-			"GALASA_ACCESS_TOKEN=%s", mockClientId, mockSecret, mockRefreshToken))
+	tokenPropertyValue := mockRefreshToken + TOKEN_SEPARATOR + mockClientId
+	mockFileSystem.WriteTextFile(galasactlPropertiesFilePath, fmt.Sprintf("GALASA_TOKEN=%s", tokenPropertyValue))
 
 	mockResponse := `{"jwt":"blah"}`
 	server := NewAuthServletMock(t, 200, mockResponse)
@@ -130,12 +126,9 @@ func TestLoginWithFailedFileWriteReturnsError(t *testing.T) {
 	galasactlPropertiesFilePath := mockGalasaHome.GetNativeFolderPath() + "/galasactl.properties"
 
 	mockClientId := "dummyId"
-	mockSecret := "shhhh"
 	mockRefreshToken := "abcdefg"
-	mockFileSystem.WriteTextFile(galasactlPropertiesFilePath, fmt.Sprintf(
-		"GALASA_CLIENT_ID=%s\n"+
-			"GALASA_SECRET=%s\n"+
-			"GALASA_ACCESS_TOKEN=%s", mockClientId, mockSecret, mockRefreshToken))
+	tokenPropertyValue := mockRefreshToken + TOKEN_SEPARATOR + mockClientId
+	mockFileSystem.WriteTextFile(galasactlPropertiesFilePath, fmt.Sprintf("GALASA_TOKEN=%s", tokenPropertyValue))
 
 	mockFileSystem.VirtualFunction_WriteTextFile = func(path string, contents string) error {
 		return errors.New("simulating a failed write operation")
@@ -164,13 +157,9 @@ func TestLoginWithFailedTokenRequestReturnsError(t *testing.T) {
 	galasactlPropertiesFilePath := mockGalasaHome.GetNativeFolderPath() + "/galasactl.properties"
 
 	mockClientId := "dummyId"
-	mockSecret := "shhhh"
 	mockRefreshToken := "abcdefg"
-
-	mockFileSystem.WriteTextFile(galasactlPropertiesFilePath, fmt.Sprintf(
-		"GALASA_CLIENT_ID=%s\n"+
-			"GALASA_SECRET=%s\n"+
-			"GALASA_ACCESS_TOKEN=%s", mockClientId, mockSecret, mockRefreshToken))
+	tokenPropertyValue := mockRefreshToken + TOKEN_SEPARATOR + mockClientId
+	mockFileSystem.WriteTextFile(galasactlPropertiesFilePath, fmt.Sprintf("GALASA_TOKEN=%s", tokenPropertyValue))
 
 	mockResponse := `{"error":"something went wrong!"}`
 	server := NewAuthServletMock(t, 500, mockResponse)
@@ -194,11 +183,7 @@ func TestLoginWithMissingAuthPropertyReturnsError(t *testing.T) {
 
 	galasactlPropertiesFilePath := mockGalasaHome.GetNativeFolderPath() + "/galasactl.properties"
 
-	mockClientId := "dummyId"
-	mockSecret := "shhhh"
-	mockFileSystem.WriteTextFile(galasactlPropertiesFilePath, fmt.Sprintf(
-		"GALASA_CLIENT_ID=%s\n"+
-			"GALASA_SECRET=%s\n", mockClientId, mockSecret))
+	mockFileSystem.WriteTextFile(galasactlPropertiesFilePath, "unknown.value=blah")
 
 	mockResponse := `{"jwt":"blah"}`
 	server := NewAuthServletMock(t, 200, mockResponse)
@@ -283,12 +268,9 @@ func TestGetAuthenticatedAPIClientWithUnavailableAPIContinuesWithoutToken(t *tes
 	galasactlPropertiesFilePath := mockGalasaHome.GetNativeFolderPath() + "/galasactl.properties"
 
 	mockClientId := "dummyId"
-	mockSecret := "shhhh"
 	mockRefreshToken := "abcdefg"
-	mockFileSystem.WriteTextFile(galasactlPropertiesFilePath, fmt.Sprintf(
-		"GALASA_CLIENT_ID=%s\n"+
-			"GALASA_SECRET=%s\n"+
-			"GALASA_ACCESS_TOKEN=%s", mockClientId, mockSecret, mockRefreshToken))
+	tokenPropertyValue := mockRefreshToken + TOKEN_SEPARATOR + mockClientId
+	mockFileSystem.WriteTextFile(galasactlPropertiesFilePath, fmt.Sprintf("GALASA_TOKEN=%s", tokenPropertyValue))
 
 	server := NewAuthServletMock(t, 500, "")
 	defer server.Close()

--- a/pkg/auth/authProperties_test.go
+++ b/pkg/auth/authProperties_test.go
@@ -58,6 +58,25 @@ func TestGetAuthPropertiesWithNoClientIdInTokenReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "GALASA_TOKEN")
 }
 
+func TestGetAuthPropertiesWithOnlySeparatorReturnsError(t *testing.T) {
+	// Given...
+	mockFileSystem := files.NewMockFileSystem()
+	mockEnvironment := utils.NewMockEnv()
+	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+
+	mockFileSystem.WriteTextFile(
+		mockGalasaHome.GetNativeFolderPath()+"/galasactl.properties",
+		fmt.Sprintf("GALASA_TOKEN=%s", TOKEN_SEPARATOR))
+
+	// When...
+	_, err := GetAuthProperties(mockFileSystem, mockGalasaHome, mockEnvironment)
+
+	// Then...
+	assert.NotNil(t, err, "Should return an error as the galasactl.properties exists but is missing the access token and client ID parts of the token.")
+	assert.Contains(t, err.Error(), "GAL1125E")
+	assert.Contains(t, err.Error(), "GALASA_TOKEN")
+}
+
 func TestGetAuthPropertiesWithSeparatorButNoClientIdReturnsError(t *testing.T) {
 	// Given...
 	mockFileSystem := files.NewMockFileSystem()

--- a/pkg/embedded/templates/galasahome/galasactl.properties
+++ b/pkg/embedded/templates/galasahome/galasactl.properties
@@ -1,8 +1,7 @@
-# The following properties allow the galasactl tool to communicate with the Galasa Ecosystem.
+# The GALASA_TOKEN property allows the galasactl tool to communicate with the Galasa Ecosystem.
 #
-# To obtain these values, log in to the Galasa web user interface and allocate a new personal
-# access token.
+# To obtain a value for this property, log in to the Galasa web user interface and allocate a new personal
+# access token. Once a personal access token has been allocated, please follow the instructions on the web 
+# user interface to copy the token into this file or set it as an environment variable.
 #
-# GALASA_ACCESS_TOKEN="my-access-token"
-# GALASA_CLIENT_ID="my-client-id"
-# GALASA_SECRET="my-secret"
+# GALASA_TOKEN=example:token

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -210,6 +210,7 @@ var (
 	GALASA_ERROR_AUTH_PROPERTY_NOT_AVAILABLE             = NewMessageType("GAL1122E: Authentication property %s is not available, which is needed to connect to the Galasa Ecosystem. It either needs to be in a file '%s' or set as an environment variable.", 1122, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_BAD_TERMINAL_JSON_FORMAT                = NewMessageType("GAL1123E: Failed to read 3270 terminal JSON because the content is in the wrong format. Reason: %s", 1123, STACK_TRACE_WANTED)
 	GALASA_ERROR_PNG_ENCODING_FAILED                     = NewMessageType("GAL1124E: Internal Failure. Terminal image could not be encoded into PNG format. Reason: %s", 1124, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_BAD_TOKEN_PROPERTY_FORMAT               = NewMessageType("GAL1125E: Authentication property %s is invalid. Please ensure that it the value is made up of two parts that are separated by a '%s'.", 1125, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_FAILED_TO_OPEN_GZIP_FILE                = NewMessageType("GAL1225E: Failed to open file '%s' cause: %v. Check that this file exists, and that you have read permissions.", 1225, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_FAILED_TO_SETUP_READER_GZIP_FILE        = NewMessageType("GAL1226E: Internal failure. Contents of gzip could be read, but not decoded. New gzip reader failed: file: %s error: %v", 1226, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_FAILED_TO_UNCOMPRESS_GZIP_FILE          = NewMessageType("GAL1227E: Internal failure. Contents of gzip could not be decoded. %v error: %v", 1227, STACK_TRACE_NOT_WANTED)


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1744

Changes:
- Updated the auth property format to use `GALASA_TOKEN={token}:{clientId}`
- Removed client secret from auth properties and any tests that were focused on testing the client secret property