### PR TITLE
Running local test creates excessive image rendering.

### DIFF
--- a/docs/generated/errors-list.md
+++ b/docs/generated/errors-list.md
@@ -146,8 +146,6 @@ The `galasactl` tool can generate the following errors:
 - GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '{}', and 'pre-release' repository is '{}'
 - GAL2501I: Downloaded {} artifacts to folder '{}'
 
-- GAL2502I: Rendered {} image files.
-
 - GAL2503I: The request to reset run '{}' has been accepted by the server.
 
 - GAL2504I: The request to cancel run '{}' has been accepted by the server.

--- a/docs/generated/errors-list.md
+++ b/docs/generated/errors-list.md
@@ -136,6 +136,7 @@ The `galasactl` tool can generate the following errors:
 - GAL1140E: The namespace, '{}', provided does not match formatting requirements. The namespace must start with a character in the 'a-z' range, followed by characters in the 'a'-'z' or '0'-'9' ranges only.
 - GAL1141E: Unable to compile the regex pattern for Galasa Property field '{}'. Reason: '{}'
 - GAL1142E: The {} field value, '{}', provided does not match formatting requirements. The {} field value must start with a character in the 'a-z' or 'A-Z' range, followed by any characters in the 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore) ranges only.
+- GAL1143E: Could not query run results. Server returned a non-200 code ({})
 - GAL1225E: Failed to open file '{}' cause: {}. Check that this file exists, and that you have read permissions.
 - GAL1226E: Internal failure. Contents of gzip could be read, but not decoded. New gzip reader failed: file: {} error: {}
 - GAL1227E: Internal failure. Contents of gzip could not be decoded. {} error: {}

--- a/docs/generated/galasactl_runs_prepare.md
+++ b/docs/generated/galasactl_runs_prepare.md
@@ -15,7 +15,7 @@ galasactl runs prepare [flags]
 ```
       --append             Append tests to existing portfolio
       --bundle strings     bundles of which tests will be selected from, bundles are selected if the name contains this string, or if --regex is specified then matches the regex
-      --class strings      test class names to run from the specified stream or portfolio. The format of each entry is osgi-bundle-name/java-class-name . Java class names are fully qualified. No .class suffix is needed.
+      --class strings      test class names to run from the specified stream or portfolio. The format of each entry is {osgi-bundle-name}/{java-class-name}.  Multiple values can be supplied using a comma-separated list of values, or by using multiple instances of the --class flag. Java class names are fully qualified. No .class suffix is needed.
       --gherkin strings    Gherkin feature file URL. Should start with 'file://'. 
   -h, --help               Displays the options for the 'runs prepare' command.
       --override strings   overrides to be sent with the tests (overrides in the portfolio will take precedence)

--- a/docs/generated/galasactl_runs_submit.md
+++ b/docs/generated/galasactl_runs_submit.md
@@ -14,7 +14,7 @@ galasactl runs submit [flags]
 
 ```
       --bundle strings             bundles of which tests will be selected from, bundles are selected if the name contains this string, or if --regex is specified then matches the regex
-      --class strings              test class names to run from the specified stream or portfolio. The format of each entry is osgi-bundle-name/java-class-name . Java class names are fully qualified. No .class suffix is needed.
+      --class strings              test class names to run from the specified stream or portfolio. The format of each entry is {osgi-bundle-name}/{java-class-name}.  Multiple values can be supplied using a comma-separated list of values, or by using multiple instances of the --class flag. Java class names are fully qualified. No .class suffix is needed.
       --gherkin strings            Gherkin feature file URL. Should start with 'file://'. 
   -g, --group string               the group name to assign the test runs to, if not provided, a psuedo unique id will be generated
   -h, --help                       Displays the options for the 'runs submit' command.

--- a/pkg/auth/authProperties.go
+++ b/pkg/auth/authProperties.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	TOKEN_PROPERTY = "GALASA_TOKEN"
+	TOKEN_PROPERTY  = "GALASA_TOKEN"
 	TOKEN_SEPARATOR = ":"
 )
 
@@ -32,7 +32,7 @@ func GetAuthProperties(fileSystem files.FileSystem, galasaHome utils.GalasaHome,
 	galasactlPropertiesFilePath := filepath.Join(galasaHome.GetNativeFolderPath(), "galasactl.properties")
 
 	// Get the file-based token property if we can
-	tokenProperty, fileAccessErr := getPropertyFromFile(fileSystem, galasactlPropertiesFilePath, env, TOKEN_PROPERTY)
+	tokenProperty, fileAccessErr := getPropertyFromFile(fileSystem, galasactlPropertiesFilePath, TOKEN_PROPERTY)
 
 	// Over-write the token property value if there is an environment variable set to do that.
 	tokenProperty = getPropertyWithOverride(env, tokenProperty, galasactlPropertiesFilePath, TOKEN_PROPERTY)
@@ -85,7 +85,7 @@ func getPropertyWithOverride(env utils.Environment, valueFromFile string, filePa
 }
 
 // Gets a property from the user's galasactl.properties file
-func getPropertyFromFile(fileSystem files.FileSystem, galasactlPropertiesFilePath string, env utils.Environment, propertyName string) (string, error) {
+func getPropertyFromFile(fileSystem files.FileSystem, galasactlPropertiesFilePath string, propertyName string) (string, error) {
 	var err error = nil
 	var galasactlProperties props.JavaProperties
 	galasactlProperties, err = props.ReadPropertiesFile(fileSystem, galasactlPropertiesFilePath)

--- a/pkg/auth/bearerTokenFile.go
+++ b/pkg/auth/bearerTokenFile.go
@@ -19,84 +19,85 @@ import (
 )
 
 type BearerTokenJson struct {
-    Jwt string `json:"jwt"`
+	Jwt string `json:"jwt"`
 }
 
 const (
-    TOKEN_EXPIRY_BUFFER_MINUTES = 10
+	TOKEN_EXPIRY_BUFFER_MINUTES = 10
 )
 
 // Writes a new bearer-token.json file containing a JWT in the following format:
-// {
-//   "jwt": "<bearer-token-here>"
-// }
+//
+//	{
+//	  "jwt": "<bearer-token-here>"
+//	}
 func WriteBearerTokenJsonFile(fileSystem files.FileSystem, galasaHome utils.GalasaHome, jwt string) error {
-    bearerTokenFilePath := filepath.Join(galasaHome.GetNativeFolderPath(), "bearer-token.json")
+	bearerTokenFilePath := filepath.Join(galasaHome.GetNativeFolderPath(), "bearer-token.json")
 
-    log.Printf("Writing bearer token to file '%s'", bearerTokenFilePath)
-    err := fileSystem.WriteTextFile(bearerTokenFilePath, jwt)
+	log.Printf("Writing bearer token to file '%s'", bearerTokenFilePath)
+	err := fileSystem.WriteTextFile(bearerTokenFilePath, jwt)
 
-    if err == nil {
-        log.Printf("Written bearer token to file '%s' OK", bearerTokenFilePath)
-    } else {
-        log.Printf("Failed to write bearer token file '%s'", bearerTokenFilePath)
-        err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_WRITE_FILE, bearerTokenFilePath, err.Error())
-    }
-    return err
+	if err == nil {
+		log.Printf("Written bearer token to file '%s' OK", bearerTokenFilePath)
+	} else {
+		log.Printf("Failed to write bearer token file '%s'", bearerTokenFilePath)
+		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_WRITE_FILE, bearerTokenFilePath, err.Error())
+	}
+	return err
 }
 
 // Gets the JWT from the bearer-token.json file if it exists, errors if the file does not exist or if the token is invalid
 func GetBearerTokenFromTokenJsonFile(fileSystem files.FileSystem, galasaHome utils.GalasaHome, timeService utils.TimeService) (string, error) {
-    var err error = nil
-    var bearerToken string = ""
-    var bearerTokenJsonContents string = ""
+	var err error = nil
+	var bearerToken string = ""
+	var bearerTokenJsonContents string = ""
 
-    bearerTokenFilePath := filepath.Join(galasaHome.GetNativeFolderPath(), "bearer-token.json")
+	bearerTokenFilePath := filepath.Join(galasaHome.GetNativeFolderPath(), "bearer-token.json")
 
-    log.Printf("Retrieving bearer token from file '%s'", bearerTokenFilePath)
-    bearerTokenJsonContents, err = fileSystem.ReadTextFile(bearerTokenFilePath)
-    if err == nil {
-        var bearerTokenJson BearerTokenJson
-        err = json.Unmarshal([]byte(bearerTokenJsonContents), &bearerTokenJson)
-        if err == nil {
-            bearerToken = bearerTokenJson.Jwt
-            log.Printf("Retrieved bearer token from file '%s' OK", bearerTokenFilePath)
-        }
-    }
+	log.Printf("Retrieving bearer token from file '%s'", bearerTokenFilePath)
+	bearerTokenJsonContents, err = fileSystem.ReadTextFile(bearerTokenFilePath)
+	if err == nil {
+		var bearerTokenJson BearerTokenJson
+		err = json.Unmarshal([]byte(bearerTokenJsonContents), &bearerTokenJson)
+		if err == nil {
+			bearerToken = bearerTokenJson.Jwt
+			log.Printf("Retrieved bearer token from file '%s' OK", bearerTokenFilePath)
+		}
+	}
 
-    if err != nil {
-        log.Printf("Could not retrieve bearer token from file '%s'", bearerTokenFilePath)
-        err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RETRIEVING_BEARER_TOKEN_FROM_FILE, bearerTokenFilePath, err.Error())
-    } else {
-        log.Printf("Validating bearer token retrieved from file '%s'", bearerTokenFilePath)
-        if (!IsBearerTokenValid(bearerToken, timeService)) {
-            err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_INVALID_BEARER_TOKEN)
-        } else {
-            log.Printf("Validated bearer token retrieved from file '%s' OK", bearerTokenFilePath)
-        }
-    }
+	if err != nil {
+		log.Printf("Could not retrieve bearer token from file '%s'", bearerTokenFilePath)
+		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RETRIEVING_BEARER_TOKEN_FROM_FILE, bearerTokenFilePath, err.Error())
+	} else {
+		log.Printf("Validating bearer token retrieved from file '%s'", bearerTokenFilePath)
+		if !IsBearerTokenValid(bearerToken, timeService) {
+			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_INVALID_BEARER_TOKEN)
+		} else {
+			log.Printf("Validated bearer token retrieved from file '%s' OK", bearerTokenFilePath)
+		}
+	}
 
-    return bearerToken, err
+	return bearerToken, err
 }
 
 // Checks whether a given bearer token is valid or not, returning true if it is valid and false otherwise
 func IsBearerTokenValid(bearerTokenString string, timeService utils.TimeService) bool {
-    var err error = nil
-    var bearerToken *jwt.Token
+	var err error = nil
+	var bearerToken *jwt.Token
 
-    // Decode the bearer token without verifying its signature
-    bearerToken, _, err = jwt.NewParser().ParseUnverified(bearerTokenString, jwt.MapClaims{})
-    if err == nil {
-        var tokenExpiry *jwt.NumericDate
-        tokenExpiry, err = bearerToken.Claims.GetExpirationTime()
-        if err == nil {
-            // Add a buffer to the current time to make sure the bearer token does not expire within
-            // this buffer (e.g. if the buffer is 10 mins, make sure the token doesn't expire within 10 mins)
-            acceptableExpiryTime := timeService.Now().Add(time.Duration(TOKEN_EXPIRY_BUFFER_MINUTES) * time.Minute)
-            if ((tokenExpiry.Time).After(acceptableExpiryTime)) {
-                return true
-            }
-        }
-    }
-    return false
+	// Decode the bearer token without verifying its signature
+	bearerToken, _, err = jwt.NewParser().ParseUnverified(bearerTokenString, jwt.MapClaims{})
+	if err == nil {
+		var tokenExpiry *jwt.NumericDate
+		tokenExpiry, err = bearerToken.Claims.GetExpirationTime()
+		if err == nil {
+			// Add a buffer to the current time to make sure the bearer token does not expire within
+			// this buffer (e.g. if the buffer is 10 mins, make sure the token doesn't expire within 10 mins)
+			acceptableExpiryTime := timeService.Now().Add(time.Duration(TOKEN_EXPIRY_BUFFER_MINUTES) * time.Minute)
+			if (tokenExpiry.Time).After(acceptableExpiryTime) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/cmd/commandCollection.go
+++ b/pkg/cmd/commandCollection.go
@@ -79,7 +79,7 @@ func (commands *commandCollectionImpl) GetRootCommand() GalasaCommand {
 
 func (commands *commandCollectionImpl) GetCommand(name string) (GalasaCommand, error) {
 	var err error
-	cmd, _ := commands.commandMap[name]
+	cmd := commands.commandMap[name]
 	if cmd == nil {
 		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_COMMAND_NOT_FOUND_IN_CMD_COLLECTION)
 		log.Printf("Caller tried to lookup %s in the command collection and it was not found.\n", name)
@@ -148,13 +148,11 @@ func (commands *commandCollectionImpl) addAuthCommands(factory Factory, rootComm
 	var authLoginCommand GalasaCommand
 	var authLogoutCommand GalasaCommand
 
+	authCommand, err = NewAuthCommand(rootCommand)
 	if err == nil {
-		authCommand, err = NewAuthCommand(rootCommand)
+		authLoginCommand, err = NewAuthLoginCommand(factory, authCommand, rootCommand)
 		if err == nil {
-			authLoginCommand, err = NewAuthLoginCommand(factory, authCommand, rootCommand)
-			if err == nil {
-				authLogoutCommand, err = NewAuthLogoutCommand(factory, authCommand, rootCommand)
-			}
+			authLogoutCommand, err = NewAuthLogoutCommand(factory, authCommand, rootCommand)
 		}
 	}
 
@@ -172,11 +170,9 @@ func (commands *commandCollectionImpl) addLocalCommands(factory Factory, rootCom
 	var localCommand GalasaCommand
 	var localInitCommand GalasaCommand
 
+	localCommand, err = NewLocalCommand(rootCommand)
 	if err == nil {
-		localCommand, err = NewLocalCommand(rootCommand)
-		if err == nil {
-			localInitCommand, err = NewLocalInitCommand(factory, localCommand, rootCommand)
-		}
+		localInitCommand, err = NewLocalInitCommand(factory, localCommand, rootCommand)
 	}
 
 	if err == nil {
@@ -190,11 +186,10 @@ func (commands *commandCollectionImpl) addProjectCommands(factory Factory, rootC
 	var err error
 
 	var projectCommand GalasaCommand
+
+	projectCommand, err = NewProjectCmd(rootCommand)
 	if err == nil {
-		projectCommand, err = NewProjectCmd(rootCommand)
-		if err == nil {
-			commands.commandMap[projectCommand.Name()] = projectCommand
-		}
+		commands.commandMap[projectCommand.Name()] = projectCommand
 	}
 
 	if err == nil {
@@ -214,17 +209,15 @@ func (commands *commandCollectionImpl) addPropertiesCommands(factory Factory, ro
 	var propertiesDeleteCommand GalasaCommand
 	var propertiesSetCommand GalasaCommand
 
+	propertiesCommand, err = NewPropertiesCommand(rootCommand)
 	if err == nil {
-		propertiesCommand, err = NewPropertiesCommand(rootCommand)
+		propertiesGetCommand, err = NewPropertiesGetCommand(factory, propertiesCommand, rootCommand)
 		if err == nil {
-			propertiesGetCommand, err = NewPropertiesGetCommand(factory, propertiesCommand, rootCommand)
+			propertiesSetCommand, err = NewPropertiesSetCommand(factory, propertiesCommand, rootCommand)
 			if err == nil {
-				propertiesSetCommand, err = NewPropertiesSetCommand(factory, propertiesCommand, rootCommand)
+				propertiesDeleteCommand, err = NewPropertiesDeleteCommand(factory, propertiesCommand, rootCommand)
 				if err == nil {
-					propertiesDeleteCommand, err = NewPropertiesDeleteCommand(factory, propertiesCommand, rootCommand)
-					if err == nil {
-						err = commands.addPropertiesNamespaceCommands(factory, rootCommand, propertiesCommand)
-					}
+					err = commands.addPropertiesNamespaceCommands(factory, rootCommand, propertiesCommand)
 				}
 			}
 		}
@@ -245,11 +238,9 @@ func (commands *commandCollectionImpl) addPropertiesNamespaceCommands(factory Fa
 	var propertiesNamespaceCommand GalasaCommand
 	var propertiesNamespaceGetCommand GalasaCommand
 
+	propertiesNamespaceCommand, err = NewPropertiesNamespaceCommand(propertiesCommand, rootCommand)
 	if err == nil {
-		propertiesNamespaceCommand, err = NewPropertiesNamespaceCommand(propertiesCommand, rootCommand)
-		if err == nil {
-			propertiesNamespaceGetCommand, err = NewPropertiesNamespaceGetCommand(factory, propertiesNamespaceCommand, propertiesCommand, rootCommand)
-		}
+		propertiesNamespaceGetCommand, err = NewPropertiesNamespaceGetCommand(factory, propertiesNamespaceCommand, propertiesCommand, rootCommand)
 	}
 
 	if err == nil {
@@ -271,23 +262,21 @@ func (commands *commandCollectionImpl) addRunsCommands(factory Factory, rootComm
 	var runsResetCommand GalasaCommand
 	var runsCancelCommand GalasaCommand
 
+	runsCommand, err = NewRunsCmd(rootCommand)
 	if err == nil {
-		runsCommand, err = NewRunsCmd(rootCommand)
+		runsDownloadCommand, err = NewRunsDownloadCommand(factory, runsCommand, rootCommand)
 		if err == nil {
-			runsDownloadCommand, err = NewRunsDownloadCommand(factory, runsCommand, rootCommand)
+			runsGetCommand, err = NewRunsGetCommand(factory, runsCommand, rootCommand)
 			if err == nil {
-				runsGetCommand, err = NewRunsGetCommand(factory, runsCommand, rootCommand)
+				runsPrepareCommand, err = NewRunsPrepareCommand(factory, runsCommand, rootCommand)
 				if err == nil {
-					runsPrepareCommand, err = NewRunsPrepareCommand(factory, runsCommand, rootCommand)
+					runsSubmitCommand, err = NewRunsSubmitCommand(factory, runsCommand, rootCommand)
 					if err == nil {
-						runsSubmitCommand, err = NewRunsSubmitCommand(factory, runsCommand, rootCommand)
+						runsSubmitLocalCommand, err = NewRunsSubmitLocalCommand(factory, runsSubmitCommand, runsCommand, rootCommand)
 						if err == nil {
-							runsSubmitLocalCommand, err = NewRunsSubmitLocalCommand(factory, runsSubmitCommand, runsCommand, rootCommand)
+							runsResetCommand, err = NewRunsResetCommand(factory, runsCommand, rootCommand)
 							if err == nil {
-								runsResetCommand, err = NewRunsResetCommand(factory, runsCommand, rootCommand)
-								if err == nil {
-									runsCancelCommand, err = NewRunsCancelCommand(factory, runsCommand, rootCommand)
-								}
+								runsCancelCommand, err = NewRunsCancelCommand(factory, runsCommand, rootCommand)
 							}
 						}
 					}
@@ -319,17 +308,15 @@ func (commands *commandCollectionImpl) addResourcesCommands(factory Factory, roo
 	var resourcesUpdateCommand GalasaCommand
 	var resourcesDeleteCommand GalasaCommand
 
+	resourcesCommand, err = NewResourcesCmd(rootCommand)
 	if err == nil {
-		resourcesCommand, err = NewResourcesCmd(rootCommand)
+		resourcesApplyCommand, err = NewResourcesApplyCommand(factory, resourcesCommand, rootCommand)
 		if err == nil {
-			resourcesApplyCommand, err = NewResourcesApplyCommand(factory, resourcesCommand, rootCommand)
+			resourcesCreateCommand, err = NewResourcesCreateCommand(factory, resourcesCommand, rootCommand)
 			if err == nil {
-				resourcesCreateCommand, err = NewResourcesCreateCommand(factory, resourcesCommand, rootCommand)
+				resourcesUpdateCommand, err = NewResourcesUpdateCommand(factory, resourcesCommand, rootCommand)
 				if err == nil {
-					resourcesUpdateCommand, err = NewResourcesUpdateCommand(factory, resourcesCommand, rootCommand)
-					if err == nil {
-						resourcesDeleteCommand, err = NewResourcesDeleteCommand(factory, resourcesCommand, rootCommand)
-					}
+					resourcesDeleteCommand, err = NewResourcesDeleteCommand(factory, resourcesCommand, rootCommand)
 				}
 			}
 		}

--- a/pkg/cmd/factory.go
+++ b/pkg/cmd/factory.go
@@ -50,18 +50,18 @@ func (*RealFactory) GetFinalWordHandler() FinalWordHandler {
 
 // We only ever expect there to be a single console object, which collects all the
 // command output.
-func (this *RealFactory) GetStdOutConsole() utils.Console {
-	if this.stdOutConsole == nil {
-		this.stdOutConsole = utils.NewRealConsole()
+func (factory *RealFactory) GetStdOutConsole() utils.Console {
+	if factory.stdOutConsole == nil {
+		factory.stdOutConsole = utils.NewRealConsole()
 	}
-	return this.stdOutConsole
+	return factory.stdOutConsole
 }
 
-func (this *RealFactory) GetStdErrConsole() utils.Console {
-	if this.stdErrConsole == nil {
-		this.stdErrConsole = utils.NewRealConsole()
+func (factory *RealFactory) GetStdErrConsole() utils.Console {
+	if factory.stdErrConsole == nil {
+		factory.stdErrConsole = utils.NewRealConsole()
 	}
-	return this.stdErrConsole
+	return factory.stdErrConsole
 }
 
 func (*RealFactory) GetTimeService() utils.TimeService {

--- a/pkg/cmd/factoryMock.go
+++ b/pkg/cmd/factoryMock.go
@@ -23,44 +23,44 @@ func NewMockFactory() Factory {
 	return &MockFactory{}
 }
 
-func (this *MockFactory) GetFileSystem() files.FileSystem {
-	if this.fileSystem == nil {
-		this.fileSystem = files.NewMockFileSystem()
+func (factory *MockFactory) GetFileSystem() files.FileSystem {
+	if factory.fileSystem == nil {
+		factory.fileSystem = files.NewMockFileSystem()
 	}
-	return this.fileSystem
+	return factory.fileSystem
 }
 
-func (this *MockFactory) GetEnvironment() utils.Environment {
-	if this.env == nil {
-		this.env = utils.NewMockEnv()
+func (factory *MockFactory) GetEnvironment() utils.Environment {
+	if factory.env == nil {
+		factory.env = utils.NewMockEnv()
 	}
-	return this.env
+	return factory.env
 }
 
-func (this *MockFactory) GetFinalWordHandler() FinalWordHandler {
-	if this.finalWordHandler == nil {
-		this.finalWordHandler = NewMockFinalWordHandler()
+func (factory *MockFactory) GetFinalWordHandler() FinalWordHandler {
+	if factory.finalWordHandler == nil {
+		factory.finalWordHandler = NewMockFinalWordHandler()
 	}
-	return this.finalWordHandler
+	return factory.finalWordHandler
 }
 
-func (this *MockFactory) GetStdOutConsole() utils.Console {
-	if this.stdOutConsole == nil {
-		this.stdOutConsole = utils.NewMockConsole()
+func (factory *MockFactory) GetStdOutConsole() utils.Console {
+	if factory.stdOutConsole == nil {
+		factory.stdOutConsole = utils.NewMockConsole()
 	}
-	return this.stdOutConsole
+	return factory.stdOutConsole
 }
 
-func (this *MockFactory) GetStdErrConsole() utils.Console {
-	if this.stdErrConsole == nil {
-		this.stdErrConsole = utils.NewMockConsole()
+func (factory *MockFactory) GetStdErrConsole() utils.Console {
+	if factory.stdErrConsole == nil {
+		factory.stdErrConsole = utils.NewMockConsole()
 	}
-	return this.stdErrConsole
+	return factory.stdErrConsole
 }
 
-func (this *MockFactory) GetTimeService() utils.TimeService {
-	if this.timeService == nil {
-		this.timeService = utils.NewMockTimeService()
+func (factory *MockFactory) GetTimeService() utils.TimeService {
+	if factory.timeService == nil {
+		factory.timeService = utils.NewMockTimeService()
 	}
-	return this.timeService
+	return factory.timeService
 }

--- a/pkg/cmd/finalWordHandlerMock.go
+++ b/pkg/cmd/finalWordHandlerMock.go
@@ -13,7 +13,7 @@ func NewMockFinalWordHandler() FinalWordHandler {
 	return new(MockFinalWordHandler)
 }
 
-func (this *MockFinalWordHandler) FinalWord(rootCmd GalasaCommand, errorToExctractFrom interface{}) {
+func (handler *MockFinalWordHandler) FinalWord(rootCmd GalasaCommand, errorToExctractFrom interface{}) {
 	// Capture the final word object to see what was sent.
-	this.ReportedObject = errorToExctractFrom
+	handler.ReportedObject = errorToExctractFrom
 }

--- a/pkg/cmd/projectCreate.go
+++ b/pkg/cmd/projectCreate.go
@@ -267,11 +267,9 @@ func createParentFolderContents(
 ) error {
 	var err error = nil
 
-	if err == nil {
-		if useMaven {
-			err = createParentFolderPom(fileGenerator, packageName, featureNames,
-				isOBRProjectRequired, forceOverwrite)
-		}
+	if useMaven {
+		err = createParentFolderPom(fileGenerator, packageName, featureNames,
+			isOBRProjectRequired, forceOverwrite)
 	}
 
 	if err == nil {

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
+	"github.com/galasa-dev/cli/pkg/images"
 	"github.com/galasa-dev/cli/pkg/launcher"
 	"github.com/galasa-dev/cli/pkg/runs"
 	"github.com/galasa-dev/cli/pkg/utils"
@@ -181,7 +182,7 @@ func (cmd *RunsSubmitCommand) executeSubmit(
 
 					var console = factory.GetStdOutConsole()
 
-					submitter := runs.NewSubmitter(galasaHome, fileSystem, launcherInstance, timeService, env, console)
+					submitter := runs.NewSubmitter(galasaHome, fileSystem, launcherInstance, timeService, env, console, images.NewImageExpanderNullImpl())
 
 					err = submitter.ExecuteSubmitRuns(cmd.values, cmd.values.TestSelectionFlagValues)
 				}

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -183,9 +183,7 @@ func (cmd *RunsSubmitCommand) executeSubmit(
 
 					submitter := runs.NewSubmitter(galasaHome, fileSystem, launcherInstance, timeService, env, console)
 
-					if err == nil {
-						err = submitter.ExecuteSubmitRuns(cmd.values, cmd.values.TestSelectionFlagValues)
-					}
+					err = submitter.ExecuteSubmitRuns(cmd.values, cmd.values.TestSelectionFlagValues)
 				}
 			}
 		}

--- a/pkg/cmd/runsSubmitLocal.go
+++ b/pkg/cmd/runsSubmitLocal.go
@@ -6,7 +6,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 	"strconv"
 
@@ -14,8 +13,6 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/embedded"
-	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
-	"github.com/galasa-dev/cli/pkg/files"
 	"github.com/galasa-dev/cli/pkg/images"
 	"github.com/galasa-dev/cli/pkg/launcher"
 	"github.com/galasa-dev/cli/pkg/runs"
@@ -211,6 +208,9 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 					if err == nil {
 						var console = factory.GetStdOutConsole()
 
+						renderer := images.NewImageRenderer(embeddedFileSystem)
+						expander := images.NewImageExpander(fileSystem, renderer, true)
+
 						// Do the launching of the tests.
 						submitter := runs.NewSubmitter(
 							galasaHome,
@@ -219,6 +219,7 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 							timeService,
 							env,
 							console,
+							expander,
 						)
 
 						err = submitter.ExecuteSubmitRuns(
@@ -227,7 +228,7 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 						)
 
 						if err == nil {
-							scanFilesAndExpandImages(fileSystem, embeddedFileSystem, galasaHome, console)
+							reportOnExpandedImages(expander, console)
 						}
 					}
 				}
@@ -238,26 +239,13 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 	return err
 }
 
-func scanFilesAndExpandImages(fs files.FileSystem, embeddedFs embedded.ReadOnlyFileSystem, galasaHome utils.GalasaHome, console utils.Console) error {
-	var err error
-	log.Printf("Starting to scan files to expand .gz files into terminal images. Root folder: %s", galasaHome.GetNativeFolderPath())
-	renderer := images.NewImageRenderer(embeddedFs)
-	expander := images.NewImageExpander(fs, renderer)
+func reportOnExpandedImages(expander images.ImageExpander, console utils.Console) error {
 
-	folderToScan := galasaHome.GetNativeFolderPath()
+	// Write out a status string to the console about how many files were rendered.
+	count := expander.GetExpandedImageFileCount()
 
-	err = expander.ExpandImages(folderToScan)
-	if err == nil {
+	// Only bother writing out a message if any images have been expanded.
+	log.Printf("Expanded a total of %d images from .gz files.", count)
 
-		// Write out a status string to the console about how many files were rendered.
-		count := expander.GetExpandedImageFileCount()
-
-		// Only bother writing out a message if any images have been expanded.
-		if count > 0 {
-			message := fmt.Sprintf(galasaErrors.GALASA_INFO_RENDERED_IMAGE_COUNT.Template, count)
-			console.WriteString(message)
-		}
-	}
-	log.Printf("Scanning of files to expand .gz files into terminal images completed.\n")
-	return err
+	return nil
 }

--- a/pkg/cmd/runsSubmitLocal.go
+++ b/pkg/cmd/runsSubmitLocal.go
@@ -148,8 +148,8 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 
 	runs.AddGherkinFlag(runsSubmitLocalCobraCmd, cmd.values.submitLocalSelectionFlags, false, "Gherkin feature file URL. Should start with 'file://'. ")
 
-	runsSubmitLocalCobraCmd.MarkFlagsRequiredTogether("class","obr")
-	runsSubmitLocalCobraCmd.MarkFlagsOneRequired("class","gherkin")
+	runsSubmitLocalCobraCmd.MarkFlagsRequiredTogether("class", "obr")
+	runsSubmitLocalCobraCmd.MarkFlagsOneRequired("class", "gherkin")
 
 	runsSubmitCmd.CobraCommand().AddCommand(runsSubmitLocalCobraCmd)
 
@@ -221,19 +221,14 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 							console,
 						)
 
-						job := images.NewPollingJob(
-							"local test run image expander",
-							images.DEFAULT_MILLISECS_BETWEEN_POLLS,
-							func() error { return scanFilesAndExpandImages(fileSystem, embeddedFileSystem, galasaHome, console) },
-						)
-						defer job.Stop()
-						job.Start()
-
 						err = submitter.ExecuteSubmitRuns(
 							runsSubmitCmdValues,
 							cmd.values.submitLocalSelectionFlags,
 						)
 
+						if err == nil {
+							scanFilesAndExpandImages(fileSystem, embeddedFileSystem, galasaHome, console)
+						}
 					}
 				}
 			}

--- a/pkg/embedded/templates/galasahome/bootstrap.properties
+++ b/pkg/embedded/templates/galasahome/bootstrap.properties
@@ -17,9 +17,9 @@
 # galasactl.jvm.local.launch.options - Add a space-separated string which contains all the extra options
 #   you want added to a command which launches the JVM to run a test in that local JVM.
 #   For example:
-#   framework.jvm.local.launch.options=-Xmx80m
+#   galasactl.jvm.local.launch.options=-Xmx80m
 #   or
-#   framework.jvm.local.launch.options=-Xmx80m -Xms20m
+#   galasactl.jvm.local.launch.options=-Xmx80m -Xms20m
 #
 # galasactl.jvm.local.launch.debug.mode - Only used when the --debug flag is used on launching a test 
 #   within a local JVM. 

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -237,7 +237,6 @@ var (
 
 	// Information messages...
 	GALASA_INFO_FOLDER_DOWNLOADED_TO = NewMessageType("GAL2501I: Downloaded %d artifacts to folder '%s'\n", 2501, STACK_TRACE_NOT_WANTED)
-	GALASA_INFO_RENDERED_IMAGE_COUNT = NewMessageType("GAL2502I: Rendered %d image files.\n", 2502, STACK_TRACE_NOT_WANTED)
 	GALASA_INFO_RUNS_RESET_SUCCESS   = NewMessageType("GAL2503I: The request to reset run '%s' has been accepted by the server.\n", 2503, STACK_TRACE_NOT_WANTED)
 	GALASA_INFO_RUNS_CANCEL_SUCCESS  = NewMessageType("GAL2504I: The request to cancel run '%s' has been accepted by the server.\n", 2504, STACK_TRACE_NOT_WANTED)
 )

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -153,7 +153,7 @@ var (
 	GALASA_ERROR_INVALID_CLASS_TOO_MANY_SLASHES           = NewMessageType("GAL1065E: Badly formed Class parameter '%s'. Expected it to be of the form <OSGiBundleId>/<FullyQualifiedJavaClass> with no .class suffix. Too many slashes found.", 1065, STACK_TRACE_WANTED)
 	GALASA_ERROR_INVALID_CLASS_SUFFIX_FOUND               = NewMessageType("GAL1066E: Badly formed Class parameter '%s'. Expected it to be of the form <OSGiBundleId>/<FullyQualifiedJavaClass> with no .class suffix. Unwanted .class suffix detected.", 1066, STACK_TRACE_WANTED)
 	GALASA_ERROR_INVALID_OUTPUT_FORMAT                    = NewMessageType("GAL1067E: Unsupported value '%s' for parameter --format. Supported values are: %s."+SEE_COMMAND_REFERENCE, 1067, STACK_TRACE_WANTED)
-	GALASA_ERROR_QUERY_RUNS_FAILED                        = NewMessageType("GAL1068E: Could not query run results. Reason: '%s'", 1068, STACK_TRACE_WANTED)
+	GALASA_ERROR_QUERY_RUNS_FAILED                        = NewMessageType("GAL1068E: Could not query run results. Reason: '%s'", 1068, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_LOG_FILE_IS_A_FOLDER                     = NewMessageType("GAL1069E: Could not open log file for writing. '%s' is a directory, the --log parameter should refer to a file path (existing or not), or '-' (the console)", 1069, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_BOOTSTRAP_BAD_DEBUG_MODE_VALUE           = NewMessageType("GAL1070E: Invalid value '%s' detected for optional property '%s' in bootstrap properties. Valid values are 'listen' or 'attach'. Only used when --debug flag is set. Defaults to 'listen'. Can be overridden with the --debugMode flag.", 1070, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_ARG_BAD_DEBUG_MODE_VALUE                 = NewMessageType("GAL1071E: Invalid value '%s' detected for optional --debugMode argument. Valid values are 'listen' or 'attach'. Only used when --debug flag is set. Defaults to 'listen'. Default can be set with an optional property '%s' in bootstrap properties.", 1071, STACK_TRACE_NOT_WANTED)
@@ -230,6 +230,7 @@ var (
 	GALASA_ERROR_FAILED_TO_COMPILE_PROPERTY_FIELD_REGEX = NewMessageType("GAL1141E: Unable to compile the regex pattern for Galasa Property field '%s'. Reason: '%s'", 1141, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_INVALID_PROPERTY_FIELD_FORMAT          = NewMessageType("GAL1142E: The %s field value, '%s', provided does not match formatting requirements. "+
 		"The %s field value must start with a character in the 'a-z' or 'A-Z' range, followed by any characters in the 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore) ranges only.", 1142, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_QUERY_RUNS_NON_OK_STATUS = NewMessageType("GAL1143E: Could not query run results. Server returned a non-200 code (%s)", 1143, STACK_TRACE_NOT_WANTED)
 
 	// Warnings...
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'pre-release' repository is '%s'", 2000, STACK_TRACE_WANTED)

--- a/pkg/images/imageExpander.go
+++ b/pkg/images/imageExpander.go
@@ -83,9 +83,7 @@ func (expander *ImageExpanderImpl) expandGzFile(gzFilePath string) error {
 
 					writer := NewImageFileWriter(expander.fs, targetImageFolderPath)
 
-					if err == nil {
-						err = expander.renderer.RenderJsonBytesToImageFiles(binaryContent, writer)
-					}
+					err = expander.renderer.RenderJsonBytesToImageFiles(binaryContent, writer)
 
 					expander.expandedFileCounter = expander.expandedFileCounter + writer.GetImageFilesWrittenCount()
 				}

--- a/pkg/images/imageExpander.go
+++ b/pkg/images/imageExpander.go
@@ -105,13 +105,13 @@ func (expander *ImageExpanderImpl) calculateTargetImagePaths(gzFilePath string) 
 	filePathParts := strings.Split(gzFilePath, separator)
 
 	if len(filePathParts)-3 < 0 {
-		log.Printf("gz file %s found, but it's not in a 'terminals/termXXX' folder so ignoring.\n", gzFilePath)
+		// log.Printf("gz file %s found, but it's not in a 'terminals/termXXX' folder so ignoring.\n", gzFilePath)
 	} else {
 		// The json descriptions of the panels appear in zos3270/terminals/term1/term1-0001.gz
 		// So we want images to appear in zos3270/images/term1/term1-0001.png
 		if filePathParts[len(filePathParts)-3] != "terminals" {
 			// It's not in the correct structure, so ignoring.
-			log.Printf("gz file %s found, but it's not in a 'terminals' folder so ignoring.\n", gzFilePath)
+			// log.Printf("gz file %s found, but it's not in a 'terminals' folder so ignoring.\n", gzFilePath)
 		} else {
 
 			// Replace the .gz file extension with .png

--- a/pkg/images/imageFileWriter.go
+++ b/pkg/images/imageFileWriter.go
@@ -53,7 +53,7 @@ func (writer *ImageFileWriterImpl) isFullyQualifiedImageFileWritable(qualifiedFi
 	isExistsAlready, err = writer.fs.Exists(qualifiedFileName)
 	if err == nil {
 		if isExistsAlready {
-			log.Printf("File %s already exists. So not over-writing it.\n", qualifiedFileName)
+			// log.Printf("File %s already exists. So not over-writing it.\n", qualifiedFileName)
 		} else {
 			// It's writeable.
 			isWritable = true

--- a/pkg/images/imageFileWriter.go
+++ b/pkg/images/imageFileWriter.go
@@ -18,16 +18,18 @@ type ImageFileWriter interface {
 }
 
 type ImageFileWriterImpl struct {
-	fs                     files.FileSystem
-	imageFolderPath        string
-	imageFilesWrittenCount int
+	fs                          files.FileSystem
+	imageFolderPath             string
+	imageFilesWrittenCount      int
+	forceOverwriteExistingFiles bool
 }
 
-func NewImageFileWriter(fs files.FileSystem, imageFolderPath string) ImageFileWriter {
+func NewImageFileWriter(fs files.FileSystem, imageFolderPath string, forceOverwriteExistingFiles bool) ImageFileWriter {
 	writer := new(ImageFileWriterImpl)
 	writer.fs = fs
 	writer.imageFolderPath = imageFolderPath
 	writer.imageFilesWrittenCount = 0
+	writer.forceOverwriteExistingFiles = forceOverwriteExistingFiles
 	return writer
 }
 
@@ -54,6 +56,7 @@ func (writer *ImageFileWriterImpl) isFullyQualifiedImageFileWritable(qualifiedFi
 	if err == nil {
 		if isExistsAlready {
 			// log.Printf("File %s already exists. So not over-writing it.\n", qualifiedFileName)
+			isWritable = writer.forceOverwriteExistingFiles
 		} else {
 			// It's writeable.
 			isWritable = true

--- a/pkg/images/imageFileWriter_test.go
+++ b/pkg/images/imageFileWriter_test.go
@@ -15,7 +15,7 @@ import (
 func TestCanWriteAFile(t *testing.T) {
 	fs := files.NewMockFileSystem()
 	fs.MkdirAll("/my/images/folder")
-	writer := NewImageFileWriter(fs, "/my/images/folder")
+	writer := NewImageFileWriter(fs, "/my/images/folder", false)
 	buff := []byte("hello world")
 
 	err := writer.WriteImageFile("File1.png", buff)
@@ -38,10 +38,10 @@ func TestCanWriteAFile(t *testing.T) {
 	assert.Equal(t, writer.GetImageFilesWrittenCount(), 1)
 }
 
-func TestDoesntWriteOverAFileIfItAlreadyExists(t *testing.T) {
+func TestDoesntWriteOverAFileIfItAlreadyExistsAndForceOverwriteIsTrue(t *testing.T) {
 	fs := files.NewMockFileSystem()
 	fs.MkdirAll("/my/images/folder")
-	writer := NewImageFileWriter(fs, "/my/images/folder")
+	writer := NewImageFileWriter(fs, "/my/images/folder", true)
 	buff := []byte("hello world")
 
 	err := writer.WriteImageFile("File1.png", buff)
@@ -63,7 +63,53 @@ func TestDoesntWriteOverAFileIfItAlreadyExists(t *testing.T) {
 
 	// Now try to write the same thing again... but a different message.
 
-	buff = []byte("Not hello world")
+	buff = []byte("Not the original file")
+	err = writer.WriteImageFile("File1.png", buff)
+
+	if assert.Nil(t, err, "should have been able to write an image file with no error!") {
+		var isExists bool
+		isExists, err = fs.Exists("/my/images/folder/File1.png")
+		if assert.Nil(t, err, "The image file should have been created! Error trying to see if it's there or not.") {
+			if assert.True(t, isExists, "The image file should have been created. It's not there.") {
+				var bytesReadBack []byte
+				bytesReadBack, err = fs.ReadBinaryFile("/my/images/folder/File1.png")
+				if assert.Nil(t, err, "Should have been able to read the file contents back.") {
+					stringGotBack := string(bytesReadBack)
+					assert.Equal(t, stringGotBack, "Not the original file", "test didn't get back the new text. File has not been over-written when it should have been.")
+				}
+			}
+		}
+	}
+
+	assert.Equal(t, writer.GetImageFilesWrittenCount(), 2) // One for the original file written, A second for the over-write.
+}
+
+func TestDoesntWriteOverAFileIfItAlreadyExistsAndForceOverWriteIsFalse(t *testing.T) {
+	fs := files.NewMockFileSystem()
+	fs.MkdirAll("/my/images/folder")
+	writer := NewImageFileWriter(fs, "/my/images/folder", false)
+	buff := []byte("hello world")
+
+	err := writer.WriteImageFile("File1.png", buff)
+
+	if assert.Nil(t, err, "should have been able to write an image file with no error!") {
+		var isExists bool
+		isExists, err = fs.Exists("/my/images/folder/File1.png")
+		if assert.Nil(t, err, "The image file should have been created! Error trying to see if it's there or not.") {
+			if assert.True(t, isExists, "The image file should have been created. It's not there.") {
+				var bytesReadBack []byte
+				bytesReadBack, err = fs.ReadBinaryFile("/my/images/folder/File1.png")
+				if assert.Nil(t, err, "Should have been able to read the file contents back.") {
+					stringGotBack := string(bytesReadBack)
+					assert.Equal(t, stringGotBack, "hello world", "test didn't get back what it thinks it wrote to disk")
+				}
+			}
+		}
+	}
+
+	// Now try to write the same thing again... but a different message.
+
+	buff = []byte("Not the original file")
 	err = writer.WriteImageFile("File1.png", buff)
 
 	if assert.Nil(t, err, "should have been able to write an image file with no error!") {

--- a/pkg/images/imageRenderer_test.go
+++ b/pkg/images/imageRenderer_test.go
@@ -77,7 +77,7 @@ func TestRenderEmptyTerminalRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -118,7 +118,7 @@ func TestRenderTerminalWithFieldRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -159,7 +159,7 @@ func TestRenderTerminalWithSmallerSizeRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -200,7 +200,7 @@ func TestRenderTerminalWithFieldAtOriginRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -244,7 +244,7 @@ func TestRenderTerminalWithFieldAtTopRightRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -289,7 +289,7 @@ func TestRenderTerminalWithFieldAtBottomLeftRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -333,7 +333,7 @@ func TestRenderTerminalWithFieldAtBottomRightRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -377,7 +377,7 @@ func TestRenderTerminalWithFullRowRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, false)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -425,7 +425,7 @@ func TestRenderTerminalWithFullColumnRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -469,7 +469,7 @@ func TestRenderTerminalWithWrappingRowRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -530,7 +530,7 @@ func TestRenderTerminaColorsRenderOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -585,7 +585,7 @@ func TestRenderTerminaUnicodeTextRendersOk(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...
@@ -626,7 +626,7 @@ func TestRenderTerminalWithMissingFontDefaultsToMonoFont(t *testing.T) {
 	terminal := createTerminal(imageId, terminalImage)
 	terminalJsonBytes, _ := json.Marshal(terminal)
 
-	imageFileWriter := NewImageFileWriter(fs, tempDir)
+	imageFileWriter := NewImageFileWriter(fs, tempDir, true)
 	imageRenderer := NewImageRenderer(embeddedFs)
 
 	// When...

--- a/pkg/launcher/jvmLauncher.go
+++ b/pkg/launcher/jvmLauncher.go
@@ -362,7 +362,7 @@ func createTemporaryOverridesFile(
 	fileSystem files.FileSystem,
 	overrides map[string]interface{},
 ) (string, error) {
-	overrides = addStandardOverrideProperties(galasaHome, fileSystem, overrides)
+	overrides = addStandardOverrideProperties(galasaHome, overrides)
 
 	// Write the properties to a file
 	overridesFilePath := temporaryFolderPath + "overrides.properties"
@@ -372,7 +372,6 @@ func createTemporaryOverridesFile(
 
 func addStandardOverrideProperties(
 	galasaHome utils.GalasaHome,
-	fileSystem files.FileSystem,
 	overrides map[string]interface{},
 ) map[string]interface{} {
 

--- a/pkg/launcher/jvmLauncher_test.go
+++ b/pkg/launcher/jvmLauncher_test.go
@@ -322,7 +322,7 @@ func TestJvmLauncherSetsRASStoreOverride(t *testing.T) {
 	env := utils.NewMockEnv()
 	galasaHome, _ := utils.NewGalasaHome(fs, env, "")
 
-	overridesGotBack := addStandardOverrideProperties(galasaHome, fs, overrides)
+	overridesGotBack := addStandardOverrideProperties(galasaHome, overrides)
 	assert.Contains(t, overridesGotBack, "framework.resultarchive.store")
 }
 
@@ -332,7 +332,7 @@ func TestJvmLauncherSets3270TerminalOutputFormatProperty(t *testing.T) {
 	env := utils.NewMockEnv()
 	galasaHome, _ := utils.NewGalasaHome(fs, env, "")
 
-	overridesGotBack := addStandardOverrideProperties(galasaHome, fs, overrides)
+	overridesGotBack := addStandardOverrideProperties(galasaHome, overrides)
 
 	assert.Contains(t, overridesGotBack, "zos3270.terminal.output")
 	assert.Contains(t, overridesGotBack["zos3270.terminal.output"], "png")

--- a/pkg/launcher/remoteLauncher.go
+++ b/pkg/launcher/remoteLauncher.go
@@ -65,7 +65,7 @@ func (launcher *RemoteLauncher) SubmitTestRun(
 	stream string,
 	obrFromPortfolio string,
 	isTraceEnabled bool,
-	GherkinURL       string,
+	GherkinURL string,
 	GherkinFeature string,
 	overrides map[string]interface{},
 ) (*galasaapi.TestRuns, error) {

--- a/pkg/runs/junitReporter_test.go
+++ b/pkg/runs/junitReporter_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func submitFinishedRunsAndReturnJunitReport(t *testing.T, finishedRunsMap map[string]*TestRun, lostRunsMap map[string]*TestRun, expectedReport string) string {
+func submitFinishedRunsAndReturnJunitReport(t *testing.T, finishedRunsMap map[string]*TestRun, lostRunsMap map[string]*TestRun, expectedReport string) {
 	mockFileSystem := files.NewMockFileSystem()
 
 	err := ReportJunit(
@@ -39,7 +39,22 @@ func submitFinishedRunsAndReturnJunitReport(t *testing.T, finishedRunsMap map[st
 		assert.Fail(t, "Could not read the junit file. "+err.Error())
 	}
 
-	return actualContents
+	expected := stripWhitespace(expectedReport)
+	actual := stripWhitespace(actualContents)
+
+	//Then...
+	assert.Equal(t, len(expected), len(actual), "Lengths are not valid. Expected:%d Actual:%d", len(expected), len(actual))
+
+	for index := range expected {
+		expectedChar := expected[index]
+		actualChar := actual[index]
+		expectedCharOrd, _ := strconv.Atoi(string(expectedChar))
+		actualCharOrd, _ := strconv.Atoi(string(actualChar))
+		assert.Equal(t, expectedChar, actualChar, "Characters are not the same! expected:'%v' actual:'%v'", expectedCharOrd, actualCharOrd)
+	}
+
+	assert.EqualValues(t, expected, actual)
+
 }
 
 func stripWhitespace(input string) string {
@@ -74,14 +89,7 @@ func TestJunitReportPassedRunWith2PassedTestsWorks(t *testing.T) {
 	</testsuites>`
 
 	// When...
-	actualContents := submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
-
-	expected := stripWhitespace(expectedReport)
-	actual := stripWhitespace(actualContents)
-
-	//Then...
-	assert.Equal(t, len(expected), len(actual), "Lengths are not valid. Expected:%d Actual:%d", len(expected), len(actual))
-	assert.EqualValues(t, expected, actual)
+	submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
 }
 
 func TestJunitReportFailedRunWith2PassedTestsWorks(t *testing.T) {
@@ -109,14 +117,7 @@ func TestJunitReportFailedRunWith2PassedTestsWorks(t *testing.T) {
 	</testsuites>`
 
 	// When...
-	actualContents := submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
-
-	expected := stripWhitespace(expectedReport)
-	actual := stripWhitespace(actualContents)
-
-	//Then...
-	assert.Equal(t, len(expected), len(actual), "Lengths are not valid. Expected:%d Actual:%d", len(expected), len(actual))
-	assert.EqualValues(t, expected, actual)
+	submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
 }
 
 func TestJunitReportWith0TestsWorks(t *testing.T) {
@@ -141,14 +142,7 @@ func TestJunitReportWith0TestsWorks(t *testing.T) {
 	</testsuites>`
 
 	// When...
-	actualContents := submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
-
-	expected := stripWhitespace(expectedReport)
-	actual := stripWhitespace(actualContents)
-
-	//Then...
-	assert.Equal(t, len(expected), len(actual), "Lengths are not valid. Expected:%d Actual:%d", len(expected), len(actual))
-	assert.EqualValues(t, expected, actual)
+	submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
 }
 
 func TestJunitReportWith1FailedTestWorks(t *testing.T) {
@@ -180,14 +174,7 @@ func TestJunitReportWith1FailedTestWorks(t *testing.T) {
 	</testsuites>`
 
 	//When...
-	actualContents := submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
-
-	expected := stripWhitespace(expectedReport)
-	actual := stripWhitespace(actualContents)
-
-	//Then...
-	assert.Equal(t, len(expected), len(actual), "Lengths are not valid. Expected:%d Actual:%d", len(expected), len(actual))
-	assert.EqualValues(t, expected, actual)
+	submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
 }
 
 func TestJunitReportWith2RunsAndMixedResultTestsReturnsOk(t *testing.T) {
@@ -232,23 +219,7 @@ func TestJunitReportWith2RunsAndMixedResultTestsReturnsOk(t *testing.T) {
 	</testsuites>`
 
 	//When..
-	actualContents := submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
-
-	expected := stripWhitespace(expectedReport)
-	actual := stripWhitespace(actualContents)
-
-	//Then...
-	assert.Equal(t, len(expected), len(actual), "Lengths are not valid. Expected:%d Actual:%d", len(expected), len(actual))
-
-	for index := range expected {
-		expectedChar := expected[index]
-		actualChar := actual[index]
-		expectedCharOrd, _ := strconv.Atoi(string(expectedChar))
-		actualCharOrd, _ := strconv.Atoi(string(actualChar))
-		assert.Equal(t, expectedChar, actualChar, "Characters are not the same! expected:'%v' actual:'%v'", expectedCharOrd, actualCharOrd)
-	}
-
-	assert.EqualValues(t, actual, expected)
+	submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
 }
 
 func TestJunitReportWithManyRunsAndMixedResultTestsReturnsAlphabeticallyOk(t *testing.T) {
@@ -307,23 +278,7 @@ func TestJunitReportWithManyRunsAndMixedResultTestsReturnsAlphabeticallyOk(t *te
 	</testsuites>`
 
 	// When...
-	actualContents := submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
-
-	expected := stripWhitespace(expectedReport)
-	actual := stripWhitespace(actualContents)
-
-	//Then...
-	assert.Equal(t, len(expected), len(actual), "Lengths are not valid. Expected:%d Actual:%d", len(expected), len(actual))
-
-	for index := range expected {
-		expectedChar := expected[index]
-		actualChar := actual[index]
-		expectedCharOrd, _ := strconv.Atoi(string(expectedChar))
-		actualCharOrd, _ := strconv.Atoi(string(actualChar))
-		assert.Equal(t, expectedChar, actualChar, "Characters are not the same! expected:'%v' actual:'%v'", expectedCharOrd, actualCharOrd)
-	}
-
-	assert.EqualValues(t, actual, expected)
+	submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, nil, expectedReport)
 }
 
 func TestJunitReportPassedRunWithLostRunsWorks(t *testing.T) {
@@ -366,12 +321,5 @@ func TestJunitReportPassedRunWithLostRunsWorks(t *testing.T) {
 	</testsuites>`
 
 	// When...
-	actualContents := submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, lostRunsMap, expectedReport)
-
-	expected := stripWhitespace(expectedReport)
-	actual := stripWhitespace(actualContents)
-
-	//Then...
-	assert.Equal(t, len(expected), len(actual), "Lengths are not valid. Expected:%d Actual:%d", len(expected), len(actual))
-	assert.EqualValues(t, expected, actual)
+	submitFinishedRunsAndReturnJunitReport(t, finishedRunsMap, lostRunsMap, expectedReport)
 }

--- a/pkg/runs/resultParameterChecker.go
+++ b/pkg/runs/resultParameterChecker.go
@@ -38,7 +38,7 @@ func ValidateResultParameter(resultInputString string, apiClient *galasaapi.APIC
 		if err == nil {
 			if httpResponse.StatusCode != http.StatusOK {
 				httpError := "\nhttp response status code: " + strconv.Itoa(httpResponse.StatusCode)
-				errString := err.Error() + httpError
+				errString := httpError
 				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_QUERY_RESULTNAMES_FAILED, errString)
 			} else {
 				rasResultNames := rasResultNamesData.GetResultnames()

--- a/pkg/runs/runsCancel.go
+++ b/pkg/runs/runsCancel.go
@@ -57,7 +57,7 @@ func CancelRun(
 				consoleErr := console.WriteString(fmt.Sprintf(galasaErrors.GALASA_INFO_RUNS_CANCEL_SUCCESS.Template, runName))
 
 				// Console error is not as important to report as the original error if there was one.
-				if consoleErr != nil && err == nil {
+				if consoleErr != nil {
 					err = consoleErr
 				}
 			}

--- a/pkg/runs/runsDownload.go
+++ b/pkg/runs/runsDownload.go
@@ -41,7 +41,7 @@ func DownloadArtifacts(
 	var err error = nil
 	var runs []galasaapi.Run
 
-	if (err == nil) && (runName != "") {
+	if runName != "" {
 		err = ValidateRunName(runName)
 	}
 	if err == nil {

--- a/pkg/runs/runsDownload.go
+++ b/pkg/runs/runsDownload.go
@@ -159,25 +159,6 @@ func nameDownloadFolder(run galasaapi.Run, runName string, timeService utils.Tim
 	return directoryName, err
 }
 
-func renderImagesInFolder(fileSystem files.FileSystem, folderName string, console utils.Console) error {
-	var err error
-
-	// No error, so try to expand the files.
-	embeddedFileSystem := embedded.GetReadOnlyFileSystem()
-	renderer := images.NewImageRenderer(embeddedFileSystem)
-	expander := images.NewImageExpander(fileSystem, renderer)
-
-	err = expander.ExpandImages(folderName)
-	if err == nil {
-
-		// Write out a status string to the console about how many files were rendered.
-		count := expander.GetExpandedImageFileCount()
-		message := fmt.Sprintf(galasaErrors.GALASA_INFO_RENDERED_IMAGE_COUNT.Template, count, folderName)
-		console.WriteString(message)
-	}
-	return err
-}
-
 func downloadArtifactsAndRenderImagesToDirectory(apiClient *galasaapi.APIClient,
 	directoryName string,
 	run galasaapi.Run,
@@ -196,10 +177,33 @@ func downloadArtifactsAndRenderImagesToDirectory(apiClient *galasaapi.APIClient,
 		directoryName = filepath.Join(runDownloadTargetFolder, directoryName)
 	}
 
-	err = downloadArtifactsToDirectory(apiClient, directoryName, run, fileSystem, forceDownload, console)
+	var filePathsCreated []string
+	filePathsCreated, err = downloadArtifactsToDirectory(apiClient, directoryName, run, fileSystem, forceDownload, console)
 
 	if err == nil {
-		err = renderImagesInFolder(fileSystem, directoryName, console)
+		renderImages(fileSystem, filePathsCreated, forceDownload)
+	}
+	return err
+}
+
+func renderImages(fileSystem files.FileSystem, filePathsCreated []string, forceOverwriteExistingFiles bool) error {
+	var err error
+
+	embeddedFileSystem := embedded.GetReadOnlyFileSystem()
+	renderer := images.NewImageRenderer(embeddedFileSystem)
+	expander := images.NewImageExpander(fileSystem, renderer, forceOverwriteExistingFiles)
+
+	for _, filePath := range filePathsCreated {
+		err = expander.ExpandImage(filePath)
+		if err != nil {
+			break
+		}
+	}
+
+	if err == nil {
+		// Write out a status string to the console about how many files were rendered.
+		count := expander.GetExpandedImageFileCount()
+		log.Printf("Expanded a total of %d image files.", count)
 	}
 
 	return err
@@ -211,9 +215,10 @@ func downloadArtifactsToDirectory(apiClient *galasaapi.APIClient,
 	fileSystem files.FileSystem,
 	forceDownload bool,
 	console utils.Console,
-) error {
+) (filePathsCreated []string, err error) {
 
 	runId := run.GetRunId()
+	filePathsCreated = make([]string, 0)
 
 	filesWrittenOkCount := 0
 
@@ -227,9 +232,13 @@ func downloadArtifactsToDirectory(apiClient *galasaapi.APIClient,
 				artifactData, isArtifactDataEmpty, httpResponse, err = GetFileFromRestApi(runId, strings.TrimPrefix(artifactPath, "/"), apiClient)
 				if err == nil {
 					if !isArtifactDataEmpty {
-						err = WriteArtifactToFileSystem(fileSystem, directoryName, artifactPath, artifactData, forceDownload, console)
+
+						targetFilePath := filepath.Join(directoryName, artifactPath)
+
+						err = WriteArtifactToFileSystem(fileSystem, targetFilePath, artifactPath, artifactData, forceDownload, console)
 						if err == nil {
 							filesWrittenOkCount += 1
+							filePathsCreated = append(filePathsCreated, targetFilePath)
 						}
 					}
 				}
@@ -257,7 +266,7 @@ func downloadArtifactsToDirectory(apiClient *galasaapi.APIClient,
 		}
 	}
 
-	return err
+	return filePathsCreated, err
 }
 
 // Retrieves the paths of all artifacts for a given test run using its runId.
@@ -299,7 +308,7 @@ func GetArtifactPathsFromRestApi(runId string, apiClient *galasaapi.APIClient) (
 // the "runs download" command.
 func WriteArtifactToFileSystem(
 	fileSystem files.FileSystem,
-	runDirectory string,
+	targetFilePath string,
 	artifactPath string,
 	fileDownloaded io.Reader,
 	shouldOverwrite bool,
@@ -309,7 +318,6 @@ func WriteArtifactToFileSystem(
 
 	pathParts := strings.Split(artifactPath, "/")
 	fileName := pathParts[len(pathParts)-1]
-	targetFilePath := filepath.Join(runDirectory, artifactPath)
 
 	// Check if a new file should be created or if an existing one should be overwritten.
 	var fileExists bool

--- a/pkg/runs/runsGet.go
+++ b/pkg/runs/runsGet.go
@@ -184,7 +184,8 @@ func GetRunDetailsFromRasSearchRuns(runs []galasaapi.Run, apiClient *galasaapi.A
 				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_QUERY_RUNS_FAILED, err.Error())
 			} else {
 				if httpResponse.StatusCode != http.StatusOK {
-					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_QUERY_RUNS_FAILED, err.Error())
+
+					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_QUERY_RUNS_NON_OK_STATUS, strconv.Itoa(httpResponse.StatusCode))
 				} else {
 					runsDetails = append(runsDetails, *details)
 				}
@@ -259,7 +260,7 @@ func GetRunsFromRestApi(
 			} else {
 				if httpResponse.StatusCode != http.StatusOK {
 					httpError := "\nhttp response status code: " + strconv.Itoa(httpResponse.StatusCode)
-					errString := err.Error() + httpError
+					errString := httpError
 					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_QUERY_RUNS_FAILED, errString)
 				} else {
 

--- a/pkg/runs/runsReset.go
+++ b/pkg/runs/runsReset.go
@@ -57,7 +57,7 @@ func ResetRun(
 				consoleErr := console.WriteString(fmt.Sprintf(galasaErrors.GALASA_INFO_RUNS_RESET_SUCCESS.Template, runName))
 
 				// Console error is not as important to report as the original error if there was one.
-				if consoleErr != nil && err == nil {
+				if consoleErr != nil {
 					err = consoleErr
 				}
 			}

--- a/pkg/runs/streams.go
+++ b/pkg/runs/streams.go
@@ -20,22 +20,21 @@ func GetStreams(launcher launcher.Launcher) ([]string, error) {
 }
 
 func ValidateStream(validStreamNames []string, streamNameToCheck string) error {
-	log.Printf("Validating that stream %s exists in the list of valid streams.\n",streamNameToCheck)
+	log.Printf("Validating that stream %s exists in the list of valid streams.\n", streamNameToCheck)
 
 	var err error = nil
 
 	var streamFound = false
-	
+
 	for _, s := range validStreamNames {
 		if s == streamNameToCheck {
 			log.Println("Stream is found in the list of valid streams.")
 			streamFound = true
-			break;
+			break
 		}
 	}
 
-	
-	if ! streamFound {
+	if !streamFound {
 		// Not a valid stream name. Build the error message.
 		log.Println("Stream not found, deciding error.")
 		if len(validStreamNames) < 1 {

--- a/pkg/runs/submitter_test.go
+++ b/pkg/runs/submitter_test.go
@@ -78,7 +78,7 @@ func TestReadBackThrottleFileFailsIfNoThrottleFileThere(t *testing.T) {
 
 	_, err = submitter.readThrottleFile("throttle")
 	if err == nil {
-		assert.Fail(t, "Should have failed to read from a throttle file. "+err.Error())
+		assert.Fail(t, "Should have failed to read from a throttle file. ")
 	}
 	assert.Contains(t, err.Error(), "GAL1048", "Error returned should contain GAL1048 error indicating read throttle file failed."+err.Error())
 }
@@ -108,7 +108,7 @@ func TestReadBackThrottleFileFailsIfFileContainsInvalidInt(t *testing.T) {
 
 	_, err = submitter.readThrottleFile("throttle")
 	if err == nil {
-		assert.Fail(t, "Should have failed to read from a throttle file. "+err.Error())
+		assert.Fail(t, "Should have failed to read from a throttle file. ")
 	}
 	assert.Contains(t, err.Error(), "GAL1049E", "Error returned should contain GAL1049E error indicating read invalid throttle file content."+err.Error())
 }
@@ -318,7 +318,7 @@ func TestOverridesWithDashFileDontReadFromAnyFile(t *testing.T) {
 
 	mockFileSystem := files.NewMockFileSystem()
 	env := utils.NewMockEnv()
-	galasaHome, err := utils.NewGalasaHome(mockFileSystem, env, "")
+	galasaHome, _ := utils.NewGalasaHome(mockFileSystem, env, "")
 
 	commandParameters := utils.RunsSubmitCmdValues{
 		Overrides:        []string{"a=b"},
@@ -482,7 +482,7 @@ func TestSubmitRunwithGherkinFile(t *testing.T) {
 	groupName := "groupname"
 	var readyRuns []TestRun
 	testRun := TestRun{
-		GherkinUrl: "gherkin.feature" ,
+		GherkinUrl: "gherkin.feature",
 	}
 	readyRuns = append(readyRuns, testRun)
 	submittedRuns := make(map[string]*TestRun)
@@ -492,9 +492,9 @@ func TestSubmitRunwithGherkinFile(t *testing.T) {
 	requestor := "user"
 	requestType := ""
 
-	run, err := submitter.submitRun(groupName, readyRuns, submittedRuns, lostRuns ,runOverrides ,trace ,requestor ,requestType)
-	assert.Nil(t,err)
-	assert.Empty(t,run)
+	run, err := submitter.submitRun(groupName, readyRuns, submittedRuns, lostRuns, runOverrides, trace, requestor, requestType)
+	assert.Nil(t, err)
+	assert.Empty(t, run)
 	assert.Contains(t, submittedRuns["M100"].GherkinUrl, "gherkin.feature")
 
 }
@@ -575,7 +575,7 @@ func TestGetReadyRunsFromPortfolioReturnsGherkinReadyRuns(t *testing.T) {
 
 	overrides := make(map[string]string)
 
-	readyRuns := submitter.buildListOfRunsToSubmit(portfolio,overrides)
+	readyRuns := submitter.buildListOfRunsToSubmit(portfolio, overrides)
 
 	assert.NotEmpty(t, readyRuns)
 	assert.Contains(t, readyRuns[0].GherkinUrl, "file:///demo/gherkin.feature")
@@ -623,7 +623,7 @@ func TestSubmitRunsFromGherkinPortfolioOutputsFeatureNames(t *testing.T) {
 
 	overrides := make(map[string]string)
 
-	readyRuns := submitter.buildListOfRunsToSubmit(portfolio,overrides)
+	readyRuns := submitter.buildListOfRunsToSubmit(portfolio, overrides)
 
 	assert.NotEmpty(t, readyRuns)
 	assert.Contains(t, readyRuns[0].GherkinUrl, "file:///demo/gherkin.feature")

--- a/pkg/runs/submitter_test.go
+++ b/pkg/runs/submitter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/galasa-dev/cli/pkg/files"
+	"github.com/galasa-dev/cli/pkg/images"
 	"github.com/galasa-dev/cli/pkg/launcher"
 	"github.com/galasa-dev/cli/pkg/props"
 	"github.com/galasa-dev/cli/pkg/utils"
@@ -33,6 +34,7 @@ func TestCanWriteAndReadBackThrottleFile(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 
 	err := submitter.writeThrottleFile("throttle", 101)
@@ -74,6 +76,7 @@ func TestReadBackThrottleFileFailsIfNoThrottleFileThere(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 
 	_, err = submitter.readThrottleFile("throttle")
@@ -104,6 +107,7 @@ func TestReadBackThrottleFileFailsIfFileContainsInvalidInt(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 
 	_, err = submitter.readThrottleFile("throttle")
@@ -130,6 +134,7 @@ func TestUpdateThrottleFromFileIfDifferentChangesValueWhenDifferent(t *testing.T
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 
 	mockFileSystem.WriteTextFile("throttle", "10")
@@ -156,6 +161,7 @@ func TestUpdateThrottleFromFileIfDifferentDoesntChangeIfFileMissing(t *testing.T
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 
 	// mockFileSystem.WriteTextFile("throttle", "10") - file is missing now.
@@ -191,6 +197,7 @@ func TestOverridesReadFromOverridesFile(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 
 	overrides, err := submitter.buildOverrideMap(commandParameters)
@@ -229,6 +236,7 @@ func TestOverridesFileSpecifiedButDoesNotExist(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 	overrides, err := submitter.buildOverrideMap(commandParameters)
 
@@ -262,6 +270,7 @@ func TestOverrideFileCorrectedWhenDefaultedAndOverridesFileNotExists(t *testing.
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 	err = submitter.correctOverrideFilePathParameter(&commandParameters)
 
@@ -305,6 +314,7 @@ func TestOverrideFileCorrectedWhenDefaultedAndNoOverridesFileDoesExist(t *testin
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 	err = submitter.correctOverrideFilePathParameter(&commandParameters)
 
@@ -335,6 +345,7 @@ func TestOverridesWithDashFileDontReadFromAnyFile(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 	overrides, err := submitter.buildOverrideMap(commandParameters)
 
@@ -385,6 +396,7 @@ func TestValidateAndCorrectParametersSetsDefaultOverrideFile(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 	err = submitter.validateAndCorrectParams(commandParameters, submitSelectionFlags)
 
@@ -437,6 +449,7 @@ func TestLocalLaunchCanUseAPortfolioOk(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 	// Do the launching of the tests.
 	err = submitter.ExecuteSubmitRuns(
@@ -477,6 +490,7 @@ func TestSubmitRunwithGherkinFile(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 
 	groupName := "groupname"
@@ -520,6 +534,7 @@ func TestGetPortfolioReturnsGherkinPortfolio(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 
 	flags := NewTestSelectionFlagValues()
@@ -559,6 +574,7 @@ func TestGetReadyRunsFromPortfolioReturnsGherkinReadyRuns(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 
 	flags := NewTestSelectionFlagValues()
@@ -607,6 +623,7 @@ func TestSubmitRunsFromGherkinPortfolioOutputsFeatureNames(t *testing.T) {
 		mockTimeService,
 		env,
 		console,
+		images.NewImageExpanderNullImpl(),
 	)
 
 	flags := NewTestSelectionFlagValues()

--- a/pkg/runs/testSelection.go
+++ b/pkg/runs/testSelection.go
@@ -96,7 +96,9 @@ func AddCommandFlags(command *cobra.Command, flags *utils.TestSelectionFlagValue
 	flags.RegexSelect = command.Flags().Bool("regex", false, "Test selection is performed by using regex")
 
 	AddClassFlag(command, flags, false, "test class names to run from the specified stream or portfolio."+
-		" The format of each entry is osgi-bundle-name/java-class-name . Java class names are fully qualified. No .class suffix is needed.")
+		" The format of each entry is {osgi-bundle-name}/{java-class-name}. "+
+		" Multiple values can be supplied using a comma-separated list of values, or by using multiple instances of the --class flag."+
+		" Java class names are fully qualified. No .class suffix is needed.")
 
 	AddGherkinFlag(command, flags, false, "Gherkin feature file URL. Should start with 'file://'. ")
 }
@@ -302,8 +304,11 @@ func selectTestsByTest(testCatalog launcher.TestCatalog, testSelection *TestSele
 	return err
 }
 
-func selectTestsByClass(testCatalog launcher.TestCatalog, // Shouldn't this be used ?
-	testSelection *TestSelection, flags *utils.TestSelectionFlagValues) error {
+func selectTestsByClass(
+	testCatalog launcher.TestCatalog, // Shouldn't this be used ?
+	testSelection *TestSelection,
+	flags *utils.TestSelectionFlagValues,
+) error {
 
 	var err error = nil
 	if len(*flags.Classes) < 1 {

--- a/pkg/runs/testSelection.go
+++ b/pkg/runs/testSelection.go
@@ -98,7 +98,7 @@ func AddCommandFlags(command *cobra.Command, flags *utils.TestSelectionFlagValue
 	AddClassFlag(command, flags, false, "test class names to run from the specified stream or portfolio."+
 		" The format of each entry is osgi-bundle-name/java-class-name . Java class names are fully qualified. No .class suffix is needed.")
 
-	AddGherkinFlag(command,flags, false, "Gherkin feature file URL. Should start with 'file://'. ")
+	AddGherkinFlag(command, flags, false, "Gherkin feature file URL. Should start with 'file://'. ")
 }
 
 func AddClassFlag(command *cobra.Command, flags *utils.TestSelectionFlagValues, isRequired bool, helpText string) {
@@ -173,9 +173,8 @@ func SelectTests(launcherInstance launcher.Launcher, flags *utils.TestSelectionF
 	if err == nil {
 		testSelection = TestSelection{Classes: make([]TestClass, 0)}
 
-		if err == nil {
-			err = selectTestsByBundle(testCatalog, &testSelection, flags)
-		}
+		err = selectTestsByBundle(testCatalog, &testSelection, flags)
+
 		if err == nil {
 			err = selectTestsByPackage(testCatalog, &testSelection, flags)
 		}
@@ -189,29 +188,28 @@ func SelectTests(launcherInstance launcher.Launcher, flags *utils.TestSelectionF
 			err = selectTestsByClass(testCatalog, &testSelection, flags)
 		}
 		if err == nil {
-			err = selectTestsByGherkin(testCatalog, &testSelection, flags)
+			err = selectTestsByGherkin(&testSelection, flags)
 		}
 	}
 
 	return testSelection, err
 }
 
-func selectTestsByGherkin(testCatalog launcher.TestCatalog, testSelection *TestSelection, flags *utils.TestSelectionFlagValues) error {
+func selectTestsByGherkin(testSelection *TestSelection, flags *utils.TestSelectionFlagValues) error {
 	var err error = nil
 
-	if len(*flags.GherkinUrl) < 1{
+	if len(*flags.GherkinUrl) < 1 {
 		return err
 	}
 	gherkinUrls := *flags.GherkinUrl
-	for _, gherkin := range gherkinUrls{
-		
+	for _, gherkin := range gherkinUrls {
+
 		newSelectedClass := TestClass{
 			GherkinUrl: gherkin,
 		}
-	
+
 		testSelection.Classes = append(testSelection.Classes, newSelectedClass)
 	}
-
 
 	return err
 }
@@ -304,7 +302,8 @@ func selectTestsByTest(testCatalog launcher.TestCatalog, testSelection *TestSele
 	return err
 }
 
-func selectTestsByClass(testCatalog launcher.TestCatalog, testSelection *TestSelection, flags *utils.TestSelectionFlagValues) error {
+func selectTestsByClass(testCatalog launcher.TestCatalog, // Shouldn't this be used ?
+	testSelection *TestSelection, flags *utils.TestSelectionFlagValues) error {
 
 	var err error = nil
 	if len(*flags.Classes) < 1 {

--- a/pkg/runs/yamlReporter.go
+++ b/pkg/runs/yamlReporter.go
@@ -48,7 +48,7 @@ func ReportYaml(
 	}
 
 	// Write the report out to disk
-	fileSystem.WriteBinaryFile(reportYamlFilename, bytes)
+	err = fileSystem.WriteBinaryFile(reportYamlFilename, bytes)
 	if err != nil {
 		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_SUBMIT_CREATE_REPORT_YAML, reportYamlFilename, err)
 		return err

--- a/pkg/utils/galasaHome.go
+++ b/pkg/utils/galasaHome.go
@@ -57,6 +57,11 @@ func NewGalasaHome(fs files.FileSystem, env Environment, cmdFlagGalasaHome strin
 func validateUserHomeDir(path string, fs files.FileSystem) error {
 	var err error = nil
 
+	// path is a string, so can never be nil
+	if strings.Trim(path, "\n \t") == "" {
+
+	}
+
 	return err
 }
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- bootstrap.properties comments has a small bug inside. Fixed.
- build-locally.sh script runs 2 simple tests to up the unit test for extra coverage, instead of 1.
- found lots of code where err was being checked but we already know it's nill or non-nil.
- found some code which would trap. eg: err.Error() when we already know err is nil.
- found some unused parameters. 2 I commented, as i'm unsure why the code is like it is... think there is something wrong in those two areas ?
- image rendering only happens once after a local run, against the entire home folder.
- messages suppressed to make logs more readable.
- removed unused parameters in some places.
- Local runs : images are rendered only on the runs folders which were created by the runs.
- Download --force allows images to be overwritten.
