### PR TITLE
Replace prod URL with prod1 in ecosystem test scripts

### DIFF
--- a/test-galasactl-ecosystem.sh
+++ b/test-galasactl-ecosystem.sh
@@ -83,7 +83,7 @@ done
 
 # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
 if [[ "${bootstrap}" == "" ]]; then
-    export bootstrap="https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap"
+    export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
     info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
 fi
 
@@ -100,14 +100,14 @@ export GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT="10"
 export GALASA_TEST_RUN_GET_EXPECTED_NUMBER_ARTIFACT_RUNNING_COUNT="10"
 
 CALLED_BY_MAIN="true"
-source ${BASEDIR}/test-scripts/calculate-galasactl-executables.sh
+source ${BASEDIR}/test-scripts/calculate-galasactl-executables.sh --bootstrap "${bootstrap}"
 calculate_galasactl_executable
 
-source ${BASEDIR}/test-scripts/runs-tests.sh
+source ${BASEDIR}/test-scripts/runs-tests.sh --bootstrap "${bootstrap}"
 test_runs_commands
 
-source ${BASEDIR}/test-scripts/properties-tests.sh
+source ${BASEDIR}/test-scripts/properties-tests.sh --bootstrap "${bootstrap}"
 properties_tests
 
-source ${BASEDIR}/test-scripts/resources-tests.sh
+source ${BASEDIR}/test-scripts/resources-tests.sh --bootstrap "${bootstrap}"
 resources_tests

--- a/test-scripts/calculate-galasactl-executables.sh
+++ b/test-scripts/calculate-galasactl-executables.sh
@@ -60,7 +60,7 @@ done
 
 # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
 if [[ "${bootstrap}" == "" ]]; then
-    export bootstrap="https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap"
+    export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
     info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
 fi
 

--- a/test-scripts/gherkin-runs-tests.sh
+++ b/test-scripts/gherkin-runs-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap"
+        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 

--- a/test-scripts/properties-tests.sh
+++ b/test-scripts/properties-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap"
+        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 

--- a/test-scripts/resources-tests.sh
+++ b/test-scripts/resources-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap"
+        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 

--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap"
+        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1747

Changes:
- Update the default bootstrap URL to use the prod1 ecosystem instead of prod in CLI ecosystem test scripts