### PR TITLE
remove the need for the framework test.streams cps property

### DIFF
--- a/pkg/cmd/runsSubmitLocal.go
+++ b/pkg/cmd/runsSubmitLocal.go
@@ -228,7 +228,7 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 						)
 
 						if err == nil {
-							reportOnExpandedImages(expander, console)
+							reportOnExpandedImages(expander)
 						}
 					}
 				}
@@ -239,7 +239,7 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 	return err
 }
 
-func reportOnExpandedImages(expander images.ImageExpander, console utils.Console) error {
+func reportOnExpandedImages(expander images.ImageExpander) error {
 
 	// Write out a status string to the console about how many files were rendered.
 	count := expander.GetExpandedImageFileCount()

--- a/pkg/launcher/remoteLauncher_test.go
+++ b/pkg/launcher/remoteLauncher_test.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package launcher
+
+import (
+	"testing"
+
+	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessingGoodPropertiesExtractsStreamsOk(t *testing.T) {
+
+	var inputProperties []galasaapi.GalasaProperty = make([]galasaapi.GalasaProperty, 0)
+
+	name1 := "thames"
+	name1full := "test.stream." + name1 + ".repo"
+	name2 := "avon"
+	name2full := "test.stream." + name2 + ".repo"
+
+	inputProperties = append(inputProperties, galasaapi.GalasaProperty{
+		Metadata: &galasaapi.GalasaPropertyMetadata{
+			Name: &name1full,
+		},
+	})
+
+	inputProperties = append(inputProperties, galasaapi.GalasaProperty{
+		Metadata: &galasaapi.GalasaPropertyMetadata{
+			Name: &name2full,
+		},
+	})
+
+	streams, err := getStreamNamesFromProperties(inputProperties)
+	assert.Nil(t, err)
+	assert.NotNil(t, streams)
+	assert.Equal(t, 2, len(streams))
+
+	assert.Equal(t, streams[0], name1)
+	assert.Equal(t, streams[1], name2)
+}
+
+func TestProcessingEmptyPropertiesListExtractsZeroStreamsOk(t *testing.T) {
+
+	var inputProperties []galasaapi.GalasaProperty = make([]galasaapi.GalasaProperty, 0)
+
+	streams, err := getStreamNamesFromProperties(inputProperties)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, streams)
+	assert.Equal(t, 0, len(streams))
+}
+
+


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Instead of using the framework.test.streams property, use a wider query to find all the test.stream.xxx.repo properties in the CPS... that gives the same list (one would hope)

Doing this means we shouldn't need to manually maintain the test.streams CPS property, which is a pain.

This is really a sticking plaster where what we should have is a REST service which delivers the streams as structures.

But if we can avoid people needing to maintain the test.streams value that would be a help.