### PR TITLE
Remove some logging statements. We get lots of detail if things fail anyway

### DIFF
--- a/pkg/images/imageExpander.go
+++ b/pkg/images/imageExpander.go
@@ -156,9 +156,6 @@ func (expander *ImageExpanderImpl) calculateTargetImagePaths(gzFilePath string) 
 
 			// Roll together all the parts of the files to get the folder and the file
 			desiredImageFolderPath = strings.Join(filePathParts[:len(filePathParts)-1], separator)
-
-			log.Printf("Expanding gzFile %s to folder %s\n", gzFilePath, desiredImageFolderPath)
-
 		}
 	}
 	return desiredImageFolderPath, err

--- a/pkg/images/imageFileWriter.go
+++ b/pkg/images/imageFileWriter.go
@@ -6,8 +6,6 @@
 package images
 
 import (
-	"log"
-
 	"github.com/galasa-dev/cli/pkg/files"
 )
 
@@ -76,7 +74,6 @@ func (writer *ImageFileWriterImpl) WriteImageFile(simpleFileName string, imageBy
 			err = writer.fs.WriteBinaryFile(fullyQualifiedTargetImageFilePath, imageBytes)
 			if err == nil {
 				writer.imageFilesWrittenCount = writer.imageFilesWrittenCount + 1
-				log.Printf("Image file has been created: %s\n", fullyQualifiedTargetImageFilePath)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Tom Slattery says we are still creating too much logging when rendering the image files.

Cutting it down even further.

Any errors are raised with lots of detail anyway I believe.

This PR contributes to this issue: CLI: Galsactl logs too much when rendering images during local test runs
[#1803](https://github.com/galasa-dev/projectmanagement/issues/1803)
