### PR TITLE
gradle templates should publish test catalog to maven repo

### DIFF
--- a/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
@@ -18,10 +18,8 @@ dependencies {
 {{- end }}
 }
 
+def testcatalog = file('build/testcatalog.json')
 def obrFile = file('build/galasa.obr')
-artifacts {
-    archives obrFile
-}
 
 // Tell gradle to publish the built OBR as a maven artifact on the 
 // local maven repository.
@@ -29,6 +27,10 @@ publishing {
     publications {
         maven(MavenPublication) {
             artifact obrFile
+            artifact (testcatalog) {
+                classifier "testcatalog"
+                extension "json"
+            }
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- Causes the generated gradle plugin to publish the test catalog as a maven artifact.