### PR TITLE
Remove temporary code and return an error instead of trying to send unauthenticated requests

### DIFF
--- a/pkg/auth/authLogin.go
+++ b/pkg/auth/authLogin.go
@@ -75,6 +75,24 @@ func GetAuthenticatedAPIClient(
 	timeService utils.TimeService,
 	env utils.Environment,
 ) (*galasaapi.APIClient, error) {
+	bearerToken, err := GetBearerToken(apiServerUrl, fileSystem, galasaHome, timeService, env)
+
+	var apiClient *galasaapi.APIClient
+	if err == nil {
+		apiClient = api.InitialiseAuthenticatedAPI(apiServerUrl, bearerToken)
+	}
+	return apiClient, err
+}
+
+// Gets a locally-stored bearer token, or attempts to log in and retrieve a new bearer token if
+// one does not already exist
+func GetBearerToken(
+	apiServerUrl string,
+	fileSystem files.FileSystem,
+	galasaHome utils.GalasaHome,
+	timeService utils.TimeService,
+	env utils.Environment,
+) (string, error) {
 	bearerToken, err := GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
 	if err != nil {
 		// Attempt to log in
@@ -85,10 +103,5 @@ func GetAuthenticatedAPIClient(
 			bearerToken, err = GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
 		}
 	}
-
-	var apiClient *galasaapi.APIClient
-	if err == nil {
-		apiClient = api.InitialiseAuthenticatedAPI(apiServerUrl, bearerToken)
-	}
-	return apiClient, err
+	return bearerToken, err
 }

--- a/pkg/auth/authLogin.go
+++ b/pkg/auth/authLogin.go
@@ -74,7 +74,7 @@ func GetAuthenticatedAPIClient(
 	galasaHome utils.GalasaHome,
 	timeService utils.TimeService,
 	env utils.Environment,
-) *galasaapi.APIClient {
+) (*galasaapi.APIClient, error) {
 	bearerToken, err := GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
 	if err != nil {
 		// Attempt to log in
@@ -89,10 +89,6 @@ func GetAuthenticatedAPIClient(
 	var apiClient *galasaapi.APIClient
 	if err == nil {
 		apiClient = api.InitialiseAuthenticatedAPI(apiServerUrl, bearerToken)
-	} else {
-		// Temporary code to allow the CLI to continue running commands while authentication is being implemented.
-		// Remove this once authentication has been delivered and users can authenticate against an ecosystem
-		apiClient = api.InitialiseAPI(apiServerUrl)
 	}
-	return apiClient
+	return apiClient, err
 }

--- a/pkg/cmd/propertiesDelete.go
+++ b/pkg/cmd/propertiesDelete.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/properties"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -119,10 +120,12 @@ func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory Factory, pro
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
-
-				// Call to process the command in a unit-testable way.
-				err = properties.DeleteProperty(propertiesCmdValues.namespace, propertiesCmdValues.propertyName, apiClient)
+				var apiClient *galasaapi.APIClient
+				apiClient, err = auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
+				if err == nil {
+					// Call to process the command in a unit-testable way.
+					err = properties.DeleteProperty(propertiesCmdValues.namespace, propertiesCmdValues.propertyName, apiClient)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/propertiesGet.go
+++ b/pkg/cmd/propertiesGet.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/properties"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -165,19 +166,22 @@ func (cmd *PropertiesGetCommand) executePropertiesGet(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
+				var apiClient *galasaapi.APIClient
+				apiClient, err = auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
-				// Call to process the command in a unit-testable way.
-				err = properties.GetProperties(
-					propertiesCmdValues.namespace,
-					propertiesCmdValues.propertyName,
-					cmd.values.propertiesPrefix,
-					cmd.values.propertiesSuffix,
-					cmd.values.propertiesInfix,
-					apiClient,
-					cmd.values.propertiesOutputFormat,
-					console,
-				)
+				if err == nil {
+					// Call to process the command in a unit-testable way.
+					err = properties.GetProperties(
+						propertiesCmdValues.namespace,
+						propertiesCmdValues.propertyName,
+						cmd.values.propertiesPrefix,
+						cmd.values.propertiesSuffix,
+						cmd.values.propertiesInfix,
+						apiClient,
+						cmd.values.propertiesOutputFormat,
+						console,
+					)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/propertiesNamespaceGet.go
+++ b/pkg/cmd/propertiesNamespaceGet.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/properties"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -136,10 +137,13 @@ func (cmd *PropertiesNamespaceGetCommand) executePropertiesNamespaceGet(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
+				var apiClient *galasaapi.APIClient
+				apiClient, err = auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
-				// Call to process the command in a unit-testable way.
-				err = properties.GetPropertiesNamespaces(apiClient, cmd.values.namespaceOutputFormat, console)
+				if err == nil {
+					// Call to process the command in a unit-testable way.
+					err = properties.GetPropertiesNamespaces(apiClient, cmd.values.namespaceOutputFormat, console)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/propertiesSet.go
+++ b/pkg/cmd/propertiesSet.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/properties"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -138,14 +139,17 @@ func (cmd *PropertiesSetCommand) executePropertiesSet(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
+				var apiClient *galasaapi.APIClient
+				apiClient, err = auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
-				// Call to process the command in a unit-testable way.
-				err = properties.SetProperty(
-					propertiesCmdValues.namespace,
-					propertiesCmdValues.propertyName,
-					cmd.values.propertyValue,
-					apiClient)
+				if err == nil {
+					// Call to process the command in a unit-testable way.
+					err = properties.SetProperty(
+						propertiesCmdValues.namespace,
+						propertiesCmdValues.propertyName,
+						cmd.values.propertyValue,
+						apiClient)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/resourcesApply.go
+++ b/pkg/cmd/resourcesApply.go
@@ -10,6 +10,7 @@ import (
 	"log"
 
 	"github.com/galasa-dev/cli/pkg/api"
+	"github.com/galasa-dev/cli/pkg/auth"
 	"github.com/galasa-dev/cli/pkg/resources"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -126,12 +127,20 @@ func loadAndPassDataIntoResourcesApi(action string, factory Factory, resourcesCm
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				err = resources.ApplyResources(
-					action,
-					resourcesCmdValues.filePath,
-					fileSystem,
-					apiServerUrl,
-				)
+				timeService := factory.GetTimeService()
+
+				var bearerToken string
+				bearerToken, err = auth.GetBearerToken(apiServerUrl, fileSystem, galasaHome, timeService, env)
+
+				if err == nil {
+					err = resources.ApplyResources(
+						action,
+						resourcesCmdValues.filePath,
+						fileSystem,
+						apiServerUrl,
+						bearerToken,
+					)
+				}
 			}
 
 		}

--- a/pkg/cmd/runsCancel.go
+++ b/pkg/cmd/runsCancel.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/runs"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -130,16 +131,19 @@ func (cmd *RunsCancelCommand) executeCancel(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API Server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
+				var apiClient *galasaapi.APIClient
+				apiClient, err = auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
-				// Call to process command in unit-testable way.
-				err = runs.CancelRun(
-					cmd.values.runName,
-					timeService,
-					console,
-					apiServerUrl,
-					apiClient,
-				)
+				if err == nil {
+					// Call to process command in unit-testable way.
+					err = runs.CancelRun(
+						cmd.values.runName,
+						timeService,
+						console,
+						apiServerUrl,
+						apiClient,
+					)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/runsDownload.go
+++ b/pkg/cmd/runsDownload.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/runs"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -138,18 +139,21 @@ func (cmd *RunsDownloadCommand) executeRunsDownload(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
+				var apiClient *galasaapi.APIClient
+				apiClient, err = auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
-				// Call to process the command in a unit-testable way.
-				err = runs.DownloadArtifacts(
-					cmd.values.runNameDownload,
-					cmd.values.runForceDownload,
-					fileSystem,
-					timeService,
-					console,
-					apiClient,
-					cmd.values.runDownloadTargetFolder,
-				)
+				if err == nil {
+					// Call to process the command in a unit-testable way.
+					err = runs.DownloadArtifacts(
+						cmd.values.runNameDownload,
+						cmd.values.runForceDownload,
+						fileSystem,
+						timeService,
+						console,
+						apiClient,
+						cmd.values.runDownloadTargetFolder,
+					)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/runsGet.go
+++ b/pkg/cmd/runsGet.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/runs"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -148,21 +149,24 @@ func (cmd *RunsGetCommand) executeRunsGet(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
+				var apiClient *galasaapi.APIClient
+				apiClient, err = auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
-				// Call to process the command in a unit-testable way.
-				err = runs.GetRuns(
-					cmd.values.runName,
-					cmd.values.age,
-					cmd.values.requestor,
-					cmd.values.result,
-					cmd.values.isActiveRuns,
-					cmd.values.outputFormatString,
-					timeService,
-					console,
-					apiServerUrl,
-					apiClient,
-				)
+				if err == nil {
+					// Call to process the command in a unit-testable way.
+					err = runs.GetRuns(
+						cmd.values.runName,
+						cmd.values.age,
+						cmd.values.requestor,
+						cmd.values.result,
+						cmd.values.isActiveRuns,
+						cmd.values.outputFormatString,
+						timeService,
+						console,
+						apiServerUrl,
+						apiClient,
+					)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/runsReset.go
+++ b/pkg/cmd/runsReset.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/runs"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -130,16 +131,19 @@ func (cmd *RunsResetCommand) executeReset(
 				apiServerUrl := bootstrapData.ApiServerURL
 				log.Printf("The API Server is at '%s'\n", apiServerUrl)
 
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
+				var apiClient *galasaapi.APIClient
+				apiClient, err = auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 
-				// Call to process command in unit-testable way.
-				err = runs.ResetRun(
-					cmd.values.runName,
-					timeService,
-					console,
-					apiServerUrl,
-					apiClient,
-				)
+				if err == nil {
+					// Call to process command in unit-testable way.
+					err = runs.ResetRun(
+						cmd.values.runName,
+						timeService,
+						console,
+						apiServerUrl,
+						apiClient,
+					)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/auth"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/galasa-dev/cli/pkg/images"
 	"github.com/galasa-dev/cli/pkg/launcher"
 	"github.com/galasa-dev/cli/pkg/runs"
@@ -173,18 +174,22 @@ func (cmd *RunsSubmitCommand) executeSubmit(
 
 				// The launcher we are going to use to start/monitor tests.
 				apiServerUrl := bootstrapData.ApiServerURL
-				apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
-				launcherInstance = launcher.NewRemoteLauncher(apiServerUrl, apiClient)
 
-				validator := runs.NewStreamBasedValidator()
-				err = validator.Validate(cmd.values.TestSelectionFlagValues)
+				var apiClient *galasaapi.APIClient
+				apiClient, err = auth.GetAuthenticatedAPIClient(apiServerUrl, fileSystem, galasaHome, timeService, env)
 				if err == nil {
-
-					var console = factory.GetStdOutConsole()
-
-					submitter := runs.NewSubmitter(galasaHome, fileSystem, launcherInstance, timeService, env, console, images.NewImageExpanderNullImpl())
-
-					err = submitter.ExecuteSubmitRuns(cmd.values, cmd.values.TestSelectionFlagValues)
+					launcherInstance = launcher.NewRemoteLauncher(apiServerUrl, apiClient)
+	
+					validator := runs.NewStreamBasedValidator()
+					err = validator.Validate(cmd.values.TestSelectionFlagValues)
+					if err == nil {
+	
+						var console = factory.GetStdOutConsole()
+	
+						submitter := runs.NewSubmitter(galasaHome, fileSystem, launcherInstance, timeService, env, console, images.NewImageExpanderNullImpl())
+	
+						err = submitter.ExecuteSubmitRuns(cmd.values, cmd.values.TestSelectionFlagValues)
+					}
 				}
 			}
 		}

--- a/pkg/properties/propertiesGet_test.go
+++ b/pkg/properties/propertiesGet_test.go
@@ -11,10 +11,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/galasa-dev/cli/pkg/auth"
-	"github.com/galasa-dev/cli/pkg/files"
+	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -324,13 +322,7 @@ func TestInvalidNamepsaceReturnsError(t *testing.T) {
 
 	mockConsole := utils.NewMockConsole()
 
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
-
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	//When
 	err := GetProperties(namespace, name, prefix, suffix, infix, apiClient, propertiesOutputFormat, mockConsole)
@@ -354,13 +346,8 @@ func TestValidNamespaceReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name      value
 validnamespace property0 value0
@@ -393,13 +380,8 @@ func TestEmptyNamespaceReturnsEmpty(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `Total:0
 `
@@ -425,13 +407,8 @@ func TestValidNamespaceAndPrefixReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name             value
 validnamespace aPrefix.property prefixVal
@@ -461,13 +438,8 @@ func TestValidNamespaceAndSuffixReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name             value
 validnamespace property.aSuffix suffixVal
@@ -497,13 +469,8 @@ func TestValidNamespaceWithMatchingPrefixAndSuffixReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name                     value
 validnamespace aPrefix.property.aSuffix prefixSuffixVal
@@ -533,13 +500,8 @@ func TestValidNamespaceWithNoMatchingPrefixAndSuffixReturnsEmpty(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `Total:0
 `
@@ -566,13 +528,8 @@ func TestValidNamespaceAndNoMatchingPrefixReturnsEmpty(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `Total:0
 `
@@ -599,13 +556,8 @@ func TestValidNamespaceAndNoMatchingSuffixReturnsEmpty(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `Total:0
 `
@@ -632,13 +584,8 @@ func TestValidNamespaceWithMatchingInfixReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name                value
 validnamespace extra.anInfix.extra infixVal
@@ -667,13 +614,8 @@ func TestValidNamespaceWithMatchingInfixesReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name                value
 validnamespace extra.anInfix.extra infixVal
@@ -702,13 +644,8 @@ func TestValidNamespaceWithNoMatchingInfixReturnsEmpty(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `Total:0
 `
@@ -734,13 +671,8 @@ func TestValidNamespaceWithMatchingPrefixAndInfixReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name                     value
 validnamespace aPrefix.anInfix.property prefixInfixVal
@@ -770,13 +702,8 @@ func TestValidNamespaceWithMatchingSuffixAndInfixReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name                     value
 validnamespace property.anInfix.aSuffix suffixInfixVal
@@ -806,13 +733,8 @@ func TestValidNamespaceWithMatchingPrefixAndSuffixAndInfixReturnsOk(t *testing.T
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name                             value
 validnamespace aPrefix.anInfix.property.aSuffix prefixSuffixInfixVal
@@ -842,13 +764,8 @@ func TestValidNamespaceWithValidNameReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name      value
 validnamespace property0 value0
@@ -877,13 +794,8 @@ func TestValidNameWithEmptyValueValidNameReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `namespace      name           value
 validnamespace emptyValueName 
@@ -913,13 +825,8 @@ func TestInvalidPropertyNameReturnsEmpty(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `Total:0
 `
@@ -946,13 +853,8 @@ func TestValidNamespaceRawFormatReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `validnamespace|property0|value0
 validnamespace|property1|value1
@@ -981,13 +883,8 @@ func TestEmptyNamespaceRawFormatReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := ``
 	//When
@@ -1012,13 +909,8 @@ func TestValidNamespaceYamlFormatReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := `apiVersion: null
 kind: null
@@ -1074,13 +966,8 @@ func TestEmptyNamespaceYamlFormatReturnsOk(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := ``
 	//When
@@ -1160,13 +1047,8 @@ func TestInvalidNamespaceFormatWithCapitalLettersReturnsError(t *testing.T) {
 	defer server.Close()
 
 	mockConsole := utils.NewMockConsole()
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
 
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	expectedOutput := ``
 	//When

--- a/pkg/properties/propertiesSet_test.go
+++ b/pkg/properties/propertiesSet_test.go
@@ -11,11 +11,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/galasa-dev/cli/pkg/auth"
-	"github.com/galasa-dev/cli/pkg/files"
-	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -99,13 +96,7 @@ func TestCreatePropertyWithValidNamespaceReturnsOk(t *testing.T) {
 	apiServerUrl := server.URL
 	defer server.Close()
 
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
-
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -124,13 +115,7 @@ func TestUpdatePropertyWithInvalidNamespaceAndInvalidPropertyNameReturnsError(t 
 	apiServerUrl := server.URL
 	defer server.Close()
 
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
-
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -152,13 +137,7 @@ func TestUpdatePropertyWithValidNamespaceAndVaidNameValueReturnsOk(t *testing.T)
 	apiServerUrl := server.URL
 	defer server.Close()
 
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
-
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -177,13 +156,7 @@ func TestUpdatePropertyWithInvalidNamespaceAndValidNameReturnsError(t *testing.T
 	apiServerUrl := server.URL
 	defer server.Close()
 
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
-
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -203,13 +176,7 @@ func TestSetNoNamespaceReturnsError(t *testing.T) {
 	apiServerUrl := server.URL
 	defer server.Close()
 
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
-
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -229,13 +196,7 @@ func TestSetNoNameReturnsError(t *testing.T) {
 	apiServerUrl := server.URL
 	defer server.Close()
 
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
-
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)
@@ -272,13 +233,7 @@ func TestInvalidNamespaceFormatWithStartingNumReturnsError(t *testing.T) {
 	apiServerUrl := server.URL
 	defer server.Close()
 
-	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
-
-	apiClient := auth.GetAuthenticatedAPIClient(apiServerUrl, mockFileSystem, mockGalasaHome, mockTimeService, mockEnvironment)
+	apiClient := api.InitialiseAPI(apiServerUrl)
 
 	//When
 	err := SetProperty(namespace, name, value, apiClient)

--- a/pkg/resources/resourcesApplier.go
+++ b/pkg/resources/resourcesApplier.go
@@ -26,6 +26,7 @@ func ApplyResources(
 	filePath string,
 	fileSystem files.FileSystem,
 	apiServerUrl string,
+	bearerToken string,
 ) error {
 	var err error
 	var fileContent string
@@ -42,13 +43,13 @@ func ApplyResources(
 		}
 
 		if err == nil {
-			err = sendResourcesRequestToServer(jsonBytes, apiServerUrl)
+			err = sendResourcesRequestToServer(jsonBytes, apiServerUrl, bearerToken)
 		}
 	}
 	return err
 }
 
-func sendResourcesRequestToServer(payloadJsonToSend []byte, apiServerUrl string) error {
+func sendResourcesRequestToServer(payloadJsonToSend []byte, apiServerUrl string, bearerToken string) error {
 
 	var err error
 	var responseBody []byte
@@ -61,6 +62,7 @@ func sendResourcesRequestToServer(payloadJsonToSend []byte, apiServerUrl string)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("Accept-Encoding", "gzip,deflate,br")
+		req.Header.Set("Authorization", "Bearer " + bearerToken)
 
 		// WARNING:
 		// Don't leave the following log statement enabled. It might log secret namespace property values, which would be a security violation.

--- a/pkg/resources/resourcesApplier_test.go
+++ b/pkg/resources/resourcesApplier_test.go
@@ -92,6 +92,7 @@ func TestCanApplySingleValidResource(t *testing.T) {
 
 	mockServlet := NewMockServlet(t, nil, http.StatusOK, []byte(expectedJsonArrivingInServlet))
 	mockservletUrl := mockServlet.getUrl()
+	mockBearerToken := "my-bearer-token"
 
 	yamlToApply := validResourcesYamlFileContentSingleProperty
 
@@ -107,6 +108,7 @@ func TestCanApplySingleValidResource(t *testing.T) {
 		filePath,
 		fs,
 		mockservletUrl,
+		mockBearerToken,
 	)
 
 	// Then
@@ -156,6 +158,7 @@ func TestCanApplyValidMultipleResources(t *testing.T) {
 
 	mockServlet := NewMockServlet(t, nil, http.StatusOK, []byte(expectedJsonArrivingInServlet))
 	mockservletUrl := mockServlet.getUrl()
+	mockBearerToken := "my-bearer-token"
 
 	yamlToApply := validResourcesYamlFileContentMultipleProperties
 
@@ -171,6 +174,7 @@ func TestCanApplyValidMultipleResources(t *testing.T) {
 		filePath,
 		fs,
 		mockservletUrl,
+		mockBearerToken,
 	)
 
 	// Then
@@ -188,6 +192,7 @@ func TestCanApplyEmptyValidResource(t *testing.T) {
 
 	mockServlet := NewMockServlet(t, nil, http.StatusOK, []byte(expectedJsonArrivingInServlet))
 	mockservletUrl := mockServlet.getUrl()
+	mockBearerToken := "my-bearer-token"
 
 	yamlToApply := ""
 
@@ -203,6 +208,7 @@ func TestCanApplyEmptyValidResource(t *testing.T) {
 		filePath,
 		fs,
 		mockservletUrl,
+		mockBearerToken,
 	)
 
 	// Then
@@ -241,9 +247,10 @@ func TestUnauthorizedResponseStatusFromServerShowsUnauthorizedError(t *testing.T
 
 	mockServlet := NewMockServlet(t, bytesToReturn, 401, expectedBytesArrivingAtServlet)
 	mockservletUrl := mockServlet.getUrl()
+	mockBearerToken := "my-bearer-token"
 
 	// When
-	err := sendResourcesRequestToServer(expectedBytesArrivingAtServlet, mockservletUrl)
+	err := sendResourcesRequestToServer(expectedBytesArrivingAtServlet, mockservletUrl, mockBearerToken)
 
 	// Then
 	assert.NotNil(t, err)
@@ -289,9 +296,10 @@ func TestBadRequestResponseStatusFromServerShowsErrorsReturned(t *testing.T) {
 
 	mockServlet := NewMockServlet(t, bytesToReturn, 400, expectedBytesArrivingAtServlet)
 	mockservletUrl := mockServlet.getUrl()
+	mockBearerToken := "my-bearer-token"
 
 	// When
-	err := sendResourcesRequestToServer(expectedBytesArrivingAtServlet, mockservletUrl)
+	err := sendResourcesRequestToServer(expectedBytesArrivingAtServlet, mockservletUrl, mockBearerToken)
 
 	// Then
 	assert.NotNil(t, err)
@@ -332,9 +340,10 @@ func TestInternalServerErrorResponseStatusFromServerReturnsServerError(t *testin
 
 	mockServlet := NewMockServlet(t, bytesToReturn, 500, expectedBytesArrivingAtServlet)
 	mockservletUrl := mockServlet.getUrl()
+	mockBearerToken := "my-bearer-token"
 
 	// When
-	err := sendResourcesRequestToServer(expectedBytesArrivingAtServlet, mockservletUrl)
+	err := sendResourcesRequestToServer(expectedBytesArrivingAtServlet, mockservletUrl, mockBearerToken)
 
 	// Then
 	assert.NotNil(t, err)
@@ -380,9 +389,10 @@ func TestResponseStatusCodeFromApiIsAnUnexpectedError(t *testing.T) {
 
 	mockServlet := NewMockServlet(t, bytesToReturn, 203, expectedBytesArrivingAtServlet)
 	mockservletUrl := mockServlet.getUrl()
+	mockBearerToken := "my-bearer-token"
 
 	// When
-	err := sendResourcesRequestToServer(expectedBytesArrivingAtServlet, mockservletUrl)
+	err := sendResourcesRequestToServer(expectedBytesArrivingAtServlet, mockservletUrl, mockBearerToken)
 
 	// Then
 	assert.NotNil(t, err)
@@ -410,6 +420,7 @@ func TestCanDeleteSingleValidResource(t *testing.T) {
 
 	mockServlet := NewMockServlet(t, nil, http.StatusOK, []byte(expectedJsonArrivingInServlet))
 	mockservletUrl := mockServlet.getUrl()
+	mockBearerToken := "my-bearer-token"
 
 	yamlToApply := validResourcesYamlFileContentSingleProperty
 
@@ -425,6 +436,7 @@ func TestCanDeleteSingleValidResource(t *testing.T) {
 		filePath,
 		fs,
 		mockservletUrl,
+		mockBearerToken,
 	)
 
 	// Then
@@ -474,6 +486,7 @@ func TestCanDeleteValidMultipleResources(t *testing.T) {
 
 	mockServlet := NewMockServlet(t, nil, http.StatusOK, []byte(expectedJsonArrivingInServlet))
 	mockservletUrl := mockServlet.getUrl()
+	mockBearerToken := "my-bearer-token"
 
 	yamlToApply := validResourcesYamlFileContentMultipleProperties
 
@@ -489,6 +502,7 @@ func TestCanDeleteValidMultipleResources(t *testing.T) {
 		filePath,
 		fs,
 		mockservletUrl,
+		mockBearerToken,
 	)
 
 	// Then
@@ -506,6 +520,7 @@ func TestCanDeleteEmptyValidResource(t *testing.T) {
 
 	mockServlet := NewMockServlet(t, nil, http.StatusOK, []byte(expectedJsonArrivingInServlet))
 	mockservletUrl := mockServlet.getUrl()
+	mockBearerToken := "my-bearer-token"
 
 	yamlToApply := ""
 
@@ -521,6 +536,7 @@ func TestCanDeleteEmptyValidResource(t *testing.T) {
 		filePath,
 		fs,
 		mockservletUrl,
+		mockBearerToken,
 	)
 
 	// Then

--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -47,9 +47,9 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
     bold() { printf "${bold}%s${reset}\n" "$@" ;}
     note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
 
-    #-----------------------------------------------------------------------------------------                   
+    #-----------------------------------------------------------------------------------------
     # Process parameters
-    #-----------------------------------------------------------------------------------------                   
+    #-----------------------------------------------------------------------------------------
     bootstrap=""
 
     while [ "$1" != "" ]; do
@@ -75,11 +75,11 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     info "Running tests against ecosystem bootstrap ${bootstrap}"
 
-    #-----------------------------------------------------------------------------------------                   
+    #-----------------------------------------------------------------------------------------
     # Constants
-    #-----------------------------------------------------------------------------------------   
-    export GALASA_TEST_NAME_SHORT="local.CoreLocalJava11Ubuntu"   
-    export GALASA_TEST_NAME_LONG="dev.galasa.inttests.core.${GALASA_TEST_NAME_SHORT}" 
+    #-----------------------------------------------------------------------------------------
+    export GALASA_TEST_NAME_SHORT="local.CoreLocalJava11Ubuntu"
+    export GALASA_TEST_NAME_LONG="dev.galasa.inttests.core.${GALASA_TEST_NAME_SHORT}"
     export GALASA_TEST_RUN_GET_EXPECTED_SUMMARY_LINE_COUNT="4"
     export GALASA_TEST_RUN_GET_EXPECTED_DETAILS_LINE_COUNT="13"
     export GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT="10"
@@ -97,7 +97,7 @@ function get_random_property_name_number {
 
 #-----------------------------------------------------------------------------------------
 # Tests
-#----------------------------------------------------------------------------------------- 
+#-----------------------------------------------------------------------------------------
 function launch_test_on_ecosystem_with_portfolio {
 
     h2 "Building a portfolio..."
@@ -117,7 +117,7 @@ function launch_test_on_ecosystem_with_portfolio {
     $cmd
     rc=$?
     # We expect a return code of '0' because this test is in the ecosystem's testcatalog.
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Failed to create a portfolio with a known test from the ecosystem's testcatalog."
         exit 1
     fi
@@ -137,7 +137,7 @@ function launch_test_on_ecosystem_with_portfolio {
     --log -"
 
     info "Command is: $cmd"
-    
+
     set -o pipefail # Fail everything if anything in the pipeline fails. Else we are just checking the 'tee' return code.
     $cmd | tee runs-submit-output.txt # Store the output of galasactl runs submit to use later
 
@@ -145,7 +145,7 @@ function launch_test_on_ecosystem_with_portfolio {
     # We expect a return code of '0' because the ecosystem should be able to run this test.
     # We have specified the flag --noexitcodeontestfailures so that we still receive a return code '0' even if the test fails,
     # as we are testing galasactl here, not the test itself
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Failed to submit a test to a remote ecosystem."
         exit 1
     fi
@@ -176,7 +176,7 @@ function runs_download_check_folder_names_during_test_run {
     $cmd
     rc=$?
     # We expect a return code of '0' because this test is in the ecosystem's testcatalog.
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Failed to create a portfolio with a known test from the ecosystem's testcatalog."
         exit 1
     fi
@@ -206,22 +206,22 @@ function runs_download_check_folder_names_during_test_run {
     retries=0
     max=100
     target_line=""
-    
+
     # Loop waiting until we can extract the name of the test run which is running in the background.
     while [[ "${is_done}" == "false" ]]; do
         if [[ -e $log_file ]]; then
             success "file exists"
             target_line=$(cat ${log_file} | grep "submitted")
-            
+
 
             if [[ "$target_line" != "" ]]; then
                 info "Target line is found."
                 is_done="true"
             fi
-        fi    
+        fi
         sleep 1
         ((retries++))
-        if (( $retries > $max )); then 
+        if (( $retries > $max )); then
             error "Too many retries."
             exit 1
         fi
@@ -255,18 +255,18 @@ function runs_download_check_folder_names_during_test_run {
         if [[ "$target_line" != "" ]]; then
             success "Target line is found."
             is_test_finished="true"
-           
+
             folder_name=$(cat $output_file| cut -d' ' -f 7)
-           
-            echo $folder_name | grep ":" 
+
+            echo $folder_name | grep ":"
             rc=$?
-            if [[ "${rc}" != "1" ]]; then 
+            if [[ "${rc}" != "1" ]]; then
                 error "Folder named incorrectly. Has timestamp when it should not."
                 exit 1
             fi
-            
+
         else
-            
+
             test_building_line=$(cat ${log_file} | grep "now 'building'")
             if [[ "$test_building_line" != "" ]]; then
                 cat ${log_file} | grep "now 'running'" -q #if now running is there, dont look further -
@@ -278,23 +278,23 @@ function runs_download_check_folder_names_during_test_run {
                     no_artifacts=$(($no_artifacts+0))
                     expected_artifact_count=$GALASA_TEST_RUN_GET_EXPECTED_NUMBER_ARTIFACT_RUNNING_COUNT
                     expected_artifact_count=$(($expected_artifact_count+0))
-                    echo $folder_name | grep ":" 
+                    echo $folder_name | grep ":"
                     rc=$?
-                    if [[ "${rc}" != "0" ]]; then 
+                    if [[ "${rc}" != "0" ]]; then
                         if [[ "${no_artifacts}" < "${expected_artifact_count}" ]]; then
                             error "Folder named incorrectly. Has no timestamp when it should, because downloading from running tests should create a folder with a time in, such as U456-16:50:32."
                             exit 1
                         fi
                     fi
-                fi    
+                fi
             fi
         fi
 
-        
-        
+
+
         # Give up if we've been waiting for the test to finish for too long. Test could be stuck.
         ((retries++))
-        if (( $retries > $max )); then 
+        if (( $retries > $max )); then
             error "Too many retries."
             exit 1
         fi
@@ -337,7 +337,7 @@ function runs_reset_check_retry_present {
     retries=0
     max=100
     target_line=""
-    
+
     # Loop waiting until we can extract the name of the test run which is running in the background.
     while [[ "${run_name_found}" == "false" ]]; do
         if [[ -e $runs_submit_log_file ]]; then
@@ -349,10 +349,10 @@ function runs_reset_check_retry_present {
                 info "Target line is found - the test is now building."
                 run_name_found="true"
             fi
-        fi    
+        fi
         sleep 3
         ((retries++))
-        if (( $retries > $max )); then 
+        if (( $retries > $max )); then
             error "Too many retries."
             exit 1
         fi
@@ -397,7 +397,7 @@ function runs_reset_check_retry_present {
 
         # Give up if we've been waiting for the test to finish for too long. Test could be stuck.
         ((retries++))
-        if (( $retries > $max )); then 
+        if (( $retries > $max )); then
             error "Too many retries."
             exit 1
         fi
@@ -447,7 +447,7 @@ function runs_cancel_check_test_is_lost {
     retries=0
     max=100
     target_line=""
-    
+
     # Loop waiting until we can extract the name of the test run which is running in the background.
     while [[ "${run_name_found}" == "false" ]]; do
         if [[ -e $runs_submit_log_file ]]; then
@@ -459,10 +459,10 @@ function runs_cancel_check_test_is_lost {
                 info "Target line is found - the test is now building."
                 run_name_found="true"
             fi
-        fi    
+        fi
         sleep 3
         ((retries++))
-        if (( $retries > $max )); then 
+        if (( $retries > $max )); then
             error "Too many retries."
             exit 1
         fi
@@ -502,7 +502,7 @@ function runs_cancel_check_test_is_lost {
 
         # Give up if we've been waiting for the test to show as cancelled for too long.
         ((retries++))
-        if (( $retries > $max )); then 
+        if (( $retries > $max )); then
             error "Too many retries."
             exit 1
         fi
@@ -519,9 +519,9 @@ function get_result_with_runname {
     # Get the RunName from the output of galasactl runs submit
 
     # Gets the line from the last part of the output stream the RunName is found in
-    cat runs-submit-output.txt | grep -o "Run.*-" | tail -1  > line.txt 
+    cat runs-submit-output.txt | grep -o "Run.*-" | tail -1  > line.txt
 
-    # Get just the RunName from the line. 
+    # Get just the RunName from the line.
     # There is a line in the output like this:
     #   Run C6967 - inttests/dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu
     # Environment failure of the test results in "C6976(EnvFail)" ... so the '('...')' part needs removing also.
@@ -543,7 +543,7 @@ function get_result_with_runname {
     $cmd | grep "${runname}" # Checks the RunName can be found in the output from galasactl runs get
     rc=$?
     # We expect a return code of '0' because the ecosystem should be able to find this test as we just ran it.
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Failed to query the result of run ${runname} in the remote ecosystem."
         exit 1
     fi
@@ -576,7 +576,7 @@ function runs_get_check_summary_format_output {
     grep "${GALASA_TEST_NAME_LONG}" $output_file -q
     rc=$?
     # We expect a return code of '0' because the test name should be output.
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Did not find ${GALASA_TEST_NAME_LONG} in summary output"
         exit 1
     fi
@@ -589,16 +589,16 @@ function runs_get_check_summary_format_output {
         grep ${header} $output_file -q
         rc=$?
         # We expect a return code of '0' because the header name should be output.
-        if [[ "${rc}" != "0" ]]; then 
+        if [[ "${rc}" != "0" ]]; then
             error "Did not find header $header in summary output"
             exit 1
         fi
-    done    
+    done
 
     # Check that we got 4 lines - headers, result data, empty line, totals count
     line_count=$(cat $output_file | wc -l | xargs)
     expected_line_count=$GALASA_TEST_RUN_GET_EXPECTED_SUMMARY_LINE_COUNT
-    if [[ "${line_count}" != "${expected_line_count}" ]]; then 
+    if [[ "${line_count}" != "${expected_line_count}" ]]; then
         error "line count is wrong. expected ${expected_line_count} got ${line_count}"
         exit 1
     fi
@@ -629,7 +629,7 @@ function runs_get_check_details_format_output {
     grep "test-name[[:space:]]*:[[:space:]]*${GALASA_TEST_NAME_LONG}" $output_file -q
     rc=$?
     # We expect a return code of '0' because the ecosystem should be able to find this test as we just ran it.
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Did not find ${GALASA_TEST_NAME_LONG} in details output"
         exit 1
     fi
@@ -642,16 +642,16 @@ function runs_get_check_details_format_output {
         grep "${header}" $output_file -q
         rc=$?
         # We expect a return code of '0' because the header name should be output.
-        if [[ "${rc}" != "0" ]]; then 
+        if [[ "${rc}" != "0" ]]; then
             error "Did not find header $header in details output"
             exit 1
         fi
-    done  
+    done
 
-    #check methods start on line 13 - implies other test details have outputted 
+    #check methods start on line 13 - implies other test details have outputted
     line_count=$(grep -n "method[[:space:]]*type[[:space:]]*status[[:space:]]*result[[:space:]]*start-time(UTC)[[:space:]]*end-time(UTC)[[:space:]]*duration(ms)" $output_file | head -n1 | sed 's/:.*//')
     expected_line_count=$GALASA_TEST_RUN_GET_EXPECTED_DETAILS_LINE_COUNT
-    if [[ "${line_count}" != "${expected_line_count}" ]]; then 
+    if [[ "${line_count}" != "${expected_line_count}" ]]; then
         # We expect a return code of '0' because the method header should be output on line 13.
         error "line count is wrong. expected methods to start on ${expected_line_count} got ${line_count}"
         exit 1
@@ -682,15 +682,15 @@ function runs_get_check_raw_format_output {
     grep "${GALASA_TEST_NAME_LONG}" $output_file -q
     rc=$?
     # We expect a return code of '0' because the test name should be output.
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Did not find ${GALASA_TEST_NAME_LONG} in raw output"
         exit 1
-    fi  
+    fi
 
     # Check that we got 10 pipes
     pipe_count=$(grep -o "|" $output_file | wc -l | xargs)
     expected_pipe_count=$GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT
-    if [[ "${pipe_count}" != "${expected_pipe_count}" ]]; then 
+    if [[ "${pipe_count}" != "${expected_pipe_count}" ]]; then
         error "pipe count is wrong. expected ${expected_pipe_count} got ${pipe_count}"
         exit 1
     fi
@@ -721,12 +721,12 @@ function runs_get_check_raw_format_output_with_from_and_to {
     grep "${run_name}" $output_file -q
     rc=$?
     # We expect a return code of '0' because the run name should be output.
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Did not find ${run_name} in raw output"
         exit 1
-    fi  
+    fi
 
-    success "galasactl runs get with age parameter returned results okay." 
+    success "galasactl runs get with age parameter returned results okay."
 }
 
 #--------------------------------------------------------------------------
@@ -752,12 +752,12 @@ function runs_get_check_raw_format_output_with_just_from {
     grep "${run_name}" $output_file -q
     rc=$?
     # We expect a return code of '0' because the run name should be output.
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Did not find ${run_name} in raw output"
         exit 1
-    fi  
+    fi
 
-    success "galasactl runs get with age parameter with just from value returned results okay." 
+    success "galasactl runs get with age parameter with just from value returned results okay."
 }
 
 #--------------------------------------------------------------------------
@@ -773,12 +773,12 @@ function runs_get_check_raw_format_output_with_no_runname_and_no_age_param {
     $cmd
     rc=$?
     # We expect a return code of '1' because this should return the error GAL1079E.
-    if [[ "${rc}" != "1" ]]; then 
+    if [[ "${rc}" != "1" ]]; then
         error "Failed to return an error."
         exit 1
     fi
 
-    success "galasactl runs get with no run name and no age returned an error okay." 
+    success "galasactl runs get with no run name and no age returned an error okay."
 }
 
 #--------------------------------------------------------------------------
@@ -796,12 +796,12 @@ function runs_get_check_raw_format_output_with_invalid_age_param {
     $cmd
     rc=$?
     # We expect a return code of '1' because this should return the error GAL1078E.
-    if [[ "${rc}" != "1" ]]; then 
+    if [[ "${rc}" != "1" ]]; then
         error "Failed to return an error."
         exit 1
     fi
 
-    success "galasactl runs get with invalid age values returned an error okay." 
+    success "galasactl runs get with invalid age values returned an error okay."
 }
 
 #--------------------------------------------------------------------------
@@ -819,17 +819,18 @@ function runs_get_check_raw_format_output_with_older_to_than_from_age {
     $cmd
     rc=$?
     # We expect a return code of '1' because this should return the error GAL1077E.
-    if [[ "${rc}" != "1" ]]; then 
+    if [[ "${rc}" != "1" ]]; then
         error "Failed to return an error."
         exit 1
     fi
 
-    success "galasactl runs get with older to age than from age returned an error okay." 
+    success "galasactl runs get with older to age than from age returned an error okay."
 }
 
 #--------------------------------------------------------------------------
 function runs_get_check_requestor_parameter {
-    requestor=$(whoami)
+    # Temporarily set the requestor to Eamonn's ID until the pipelines are changed to use a functional ID
+    requestor="eamonn.mansour@ibm.com"
     h2 "Performing runs get with details format providing a from age and requestor as $requestor..."
 
     cd ${BASEDIR}/temp
@@ -849,12 +850,12 @@ function runs_get_check_requestor_parameter {
     grep "requestor[ ]*:[ ]*${requestor}" $output_file -q
     rc=$?
     # We expect a return code of '0' because the run name should be output.
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Did not find any runs with requestor '$requestor' in output"
         exit 1
-    fi  
+    fi
 
-    success "galasactl runs get with age parameter with just from value and requestor '$requestor' returned results okay." 
+    success "galasactl runs get with age parameter with just from value and requestor '$requestor' returned results okay."
 }
 
 #--------------------------------------------------------------------------
@@ -874,17 +875,17 @@ function runs_get_check_result_parameter {
 
     output_file="runs-get-output.txt"
     $cmd | tee $output_file
-    
+
     grep -q "result[ ]*:[ ]*${result}" $output_file
 
     rc=$?
-   
-    if [[ "${rc}" != "0" ]]; then 
+
+    if [[ "${rc}" != "0" ]]; then
         error "Did not find any runs with result '$result' in output"
         exit 1
-    fi  
+    fi
 
-    success "galasactl runs get with age parameter with just from value and result '$result' returned results okay." 
+    success "galasactl runs get with age parameter with just from value and result '$result' returned results okay."
 }
 
 #--------------------------------------------------------------------------
@@ -910,7 +911,7 @@ function launch_test_on_ecosystem_without_portfolio {
     # We expect a return code of '0' because the ecosystem should be able to run this test.
     # We have specified the flag --noexitcodeontestfailures so that we still receive a return code '0' even if the test fails,
     # as we are testing galasactl here, not the test itself
-    if [[ "${rc}" != "0" ]]; then 
+    if [[ "${rc}" != "0" ]]; then
         error "Failed to submit a test to a remote ecosystem."
         exit 1
     fi
@@ -935,7 +936,7 @@ function create_portfolio_with_unknown_test {
     $cmd
     rc=$?
     # We expect a return code of '1' because the ecosystem doesn't know about this testcase.
-    if [[ "${rc}" != "1" ]]; then 
+    if [[ "${rc}" != "1" ]]; then
         error "Failed to recognise an Unknown testcase."
         exit 1
     fi
@@ -962,7 +963,7 @@ function launch_test_from_unknown_portfolio {
     $cmd
     rc=$?
     # We expect a return code of '1' because the galasactl shouldn't be able to read this portfolio.
-    if [[ "${rc}" != "1" ]]; then 
+    if [[ "${rc}" != "1" ]]; then
         error "Failed to recognise a non-existent portfolio."
         exit 1
     fi
@@ -977,12 +978,12 @@ function test_runs_commands {
     launch_test_on_ecosystem_with_portfolio
 
     # Query the result ... setting RUN_NAME to hold the one which galasa allocated
-    get_result_with_runname 
+    get_result_with_runname
     runs_get_check_summary_format_output  $RUN_NAME
     runs_get_check_details_format_output  $RUN_NAME
     runs_get_check_raw_format_output  $RUN_NAME
 
-    # Query the result with the age parameter 
+    # Query the result with the age parameter
     runs_get_check_raw_format_output_with_from_and_to $RUN_NAME
     runs_get_check_raw_format_output_with_just_from $RUN_NAME
 


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1473 and https://github.com/galasa-dev/projectmanagement/issues/1820

Changes:
- Now that authentication is mandatory, this PR removes the temporary code that was previously used to fall back to sending unauthenticated requests to the API server if a user could not authenticate with the ecosystem.
  - Instead, an error will be returned informing the user that they will need to authenticate with the ecosystem.
- Changed the `requestor` value used in the ecosystem tests to use my ID temporarily to get the main builds passing again
- Fixed an issue where the "Authorization" header was not being set when running `galasactl resources` commands, causing 401 errors when contacting an API server requiring authentication