### PR TITLE
error from getcatalog is not lost now

### DIFF
--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -7,6 +7,7 @@ package errors
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 )
@@ -62,6 +63,7 @@ func NewGalasaError(msgType *MessageType, params ...interface{}) *GalasaError {
 	galasaError.msgType = msgType
 	galasaError.message = message
 
+	log.Println(message)
 	if galasaError.msgType.IsStackTraceWanted {
 		LogStackTrace()
 	}
@@ -103,7 +105,7 @@ var (
 	GALASA_ERROR_SUBMIT_REPORT_JUNIT_WRITE_FAIL           = NewMessageType("GAL1015E: Failed to  write test report junit results file %s. Reason is %s", 1015, STACK_TRACE_WANTED)
 	GALASA_ERROR_EMPTY_PORTFOLIO                          = NewMessageType("GAL1016E: There are no tests in the test porfolio %s", 1016, STACK_TRACE_WANTED)
 	GALASA_ERROR_TESTS_FAILED                             = NewMessageType("GAL1017E: Not all runs passed. %v failed.", 1017, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_NO_TESTS_SELECTED                        = NewMessageType("GAL1018E: No tests were selected.", 1018, STACK_TRACE_WANTED)
+	GALASA_ERROR_NO_TESTS_SELECTED                        = NewMessageType("GAL1018E: No tests were selected.", 1018, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_PREPARE_INVALID_OVERRIDE                 = NewMessageType("GAL1019E: Invalid override '%v'", 1019, STACK_TRACE_WANTED)
 	GALASA_ERROR_OPEN_LOG_FILE_FAILED                     = NewMessageType("GAL1020E: Failed to open log file '%s' for writing. Reason is %s", 1020, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_OPEN_PORTFOLIO_FILE_FAILED               = NewMessageType("GAL1021E: Failed to open portfolio file '%s' for reading. Reason is %s", 1021, STACK_TRACE_WANTED)
@@ -230,7 +232,8 @@ var (
 	GALASA_ERROR_FAILED_TO_COMPILE_PROPERTY_FIELD_REGEX = NewMessageType("GAL1141E: Unable to compile the regex pattern for Galasa Property field '%s'. Reason: '%s'", 1141, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_INVALID_PROPERTY_FIELD_FORMAT          = NewMessageType("GAL1142E: The %s field value, '%s', provided does not match formatting requirements. "+
 		"The %s field value must start with a character in the 'a-z' or 'A-Z' range, followed by any characters in the 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore) ranges only.", 1142, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_QUERY_RUNS_NON_OK_STATUS = NewMessageType("GAL1143E: Could not query run results. Server returned a non-200 code (%s)", 1143, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_QUERY_RUNS_NON_OK_STATUS         = NewMessageType("GAL1143E: Could not query run results. Server returned a non-200 code (%s)", 1143, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_GET_TEST_CATALOG_CONTENTS_FAILED = NewMessageType("GAL1144E: Could not use url '%s' to retrieve the contents of the test catalog from stream '%s'. Http error from the Galasa server is '%v'", 1144, STACK_TRACE_NOT_WANTED)
 
 	// Warnings...
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'pre-release' repository is '%s'", 2000, STACK_TRACE_WANTED)

--- a/pkg/launcher/remoteLauncher.go
+++ b/pkg/launcher/remoteLauncher.go
@@ -132,7 +132,7 @@ func (launcher *RemoteLauncher) GetStreams() ([]string, error) {
 // When passed an array of GalasaProperty objects, extract the stream names from them.
 func getStreamNamesFromProperties(properties []galasaapi.GalasaProperty) ([]string, error) {
 	var err error
-	var streams []string = make([]string,0)
+	var streams []string = make([]string, 0)
 	for _, property := range properties {
 		propertyNamePtr := property.GetMetadata().Name
 
@@ -168,7 +168,7 @@ func (launcher *RemoteLauncher) GetTestCatalog(stream string) (TestCatalog, erro
 			var resp *http.Response
 			resp, err = http.Get(*cpsProperty.Value)
 			if err != nil {
-				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_PROPERTY_GET_FAILED, *cpsProperty.Value, stream, err)
+				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_GET_TEST_CATALOG_CONTENTS_FAILED, *cpsProperty.Value, stream, err)
 			} else {
 				defer resp.Body.Close()
 
@@ -188,5 +188,5 @@ func (launcher *RemoteLauncher) GetTestCatalog(stream string) (TestCatalog, erro
 		}
 	}
 
-	return testCatalog, nil
+	return testCatalog, err
 }

--- a/pkg/launcher/remoteLauncher_test.go
+++ b/pkg/launcher/remoteLauncher_test.go
@@ -6,8 +6,13 @@
 package launcher
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/galasaapi"
 	"github.com/stretchr/testify/assert"
 )
@@ -53,4 +58,37 @@ func TestProcessingEmptyPropertiesListExtractsZeroStreamsOk(t *testing.T) {
 	assert.Equal(t, 0, len(streams))
 }
 
+func TestGetTestCatalogHttpErrorGetsReported(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("URL arrived at the mock test server: %s\n", r.RequestURI)
+		switch r.RequestURI {
+		case "/cps/namespace/framework/prefix/test.stream.myStream/suffix/location":
 
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			name := "mycpsPropName"
+			value := "a duff value" // This is intentionally duff, which will cause an HTTP error when the production code tries to GET using this as a URL.
+			payload := galasaapi.CpsProperty{
+				Name:  &name,
+				Value: &value,
+			}
+			payloadBytes, _ := json.Marshal(payload)
+			w.Write(payloadBytes)
+
+			fmt.Printf("mock server sending payload: %s\n", string(payloadBytes))
+
+		}
+	}))
+	defer server.Close()
+
+	apiServerUrl := server.URL
+	apiClient := api.InitialiseAPI(apiServerUrl)
+
+	launcher := NewRemoteLauncher(apiServerUrl, apiClient)
+
+	_, err := launcher.GetTestCatalog("myStream")
+
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "GAL1144E") // Failed to get the test catalog.
+}


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

## Why ?
This PR is to fix issue [httpGet in remoteLauncher fails and no error message is logged.
#1824](https://github.com/galasa-dev/projectmanagement/issues/1824)