### PR TITLE
CLI supplies a JWT to a local launched test if framework.config.store bootstrap value starts with galasacps

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,10 @@ The galasactl tool can be configured to communicate with that CPS.
 To do this, assuming `https://myhost/api/bootstrap` can be used to 
 communicate with the remote server, add the following to your `bootstrap.properties` file, 
 ```
-// https://myhost/api is the location of the Galasa REST API endpoints.
+# Tell the galasactl tool that local tests should use the REST API to get shared configuration properties from a remote server.
+# https://myhost/api is the location of the Galasa REST API endpoints.
 framework.config.store=galasacps://myhost/api
 framework.extra.bundles=dev.galasa.cps.rest
 ```
+
+The user must perform a `galasactl auth login` to the same ecosystem before trying to launch a local test.

--- a/README.md
+++ b/README.md
@@ -620,3 +620,16 @@ So, invoke the `galasactl` without installing on your local machine, using the d
 ```
 docker run harbor.galasa.dev/galasadev/galasa-cli-amd64:main galasactl --version
 ```
+
+## Running a test locally, but using shared configuration properties on a remote Galasa server
+This configuration is supported. An ecosystem can be set up with CPS (configuration properties store) properties.
+
+The galasactl tool can be configured to communicate with that CPS.
+
+To do this, assuming `https://myhost/api/bootstrap` can be used to 
+communicate with the remote server, add the following to your `bootstrap.properties` file, 
+```
+// https://myhost/api is the location of the Galasa REST API endpoints.
+framework.config.store=galasacps://myhost/api
+framework.extra.bundles=dev.galasa.cps.rest
+```

--- a/docs/generated/errors-list.md
+++ b/docs/generated/errors-list.md
@@ -137,6 +137,7 @@ The `galasactl` tool can generate the following errors:
 - GAL1141E: Unable to compile the regex pattern for Galasa Property field '{}'. Reason: '{}'
 - GAL1142E: The {} field value, '{}', provided does not match formatting requirements. The {} field value must start with a character in the 'a-z' or 'A-Z' range, followed by any characters in the 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore) ranges only.
 - GAL1143E: Could not query run results. Server returned a non-200 code ({})
+- GAL1144E: Could not use url '{}' to retrieve the contents of the test catalog from stream '{}'. Http error from the Galasa server is '{}'
 - GAL1225E: Failed to open file '{}' cause: {}. Check that this file exists, and that you have read permissions.
 - GAL1226E: Internal failure. Contents of gzip could be read, but not decoded. New gzip reader failed: file: {} error: {}
 - GAL1227E: Internal failure. Contents of gzip could not be decoded. {} error: {}

--- a/pkg/auth/authLogin.go
+++ b/pkg/auth/authLogin.go
@@ -28,7 +28,7 @@ func Login(apiServerUrl string, fileSystem files.FileSystem, galasaHome utils.Ga
 		var jwt string
 		jwt, err = GetJwtFromRestApi(apiServerUrl, authProperties)
 		if err == nil {
-			err = WriteBearerTokenJsonFile(fileSystem, galasaHome, jwt)
+			err = utils.WriteBearerTokenJsonFile(fileSystem, galasaHome, jwt)
 		}
 	}
 	return err
@@ -93,14 +93,14 @@ func GetBearerToken(
 	timeService utils.TimeService,
 	env utils.Environment,
 ) (string, error) {
-	bearerToken, err := GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
+	bearerToken, err := utils.GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
 	if err != nil {
 		// Attempt to log in
 		log.Printf("Logging in to the Galasa Ecosystem at '%s'", apiServerUrl)
 		err = Login(apiServerUrl, fileSystem, galasaHome, env)
 		if err == nil {
 			log.Printf("Logged in to the Galasa Ecosystem at '%s' OK", apiServerUrl)
-			bearerToken, err = GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
+			bearerToken, err = utils.GetBearerTokenFromTokenJsonFile(fileSystem, galasaHome, timeService)
 		}
 	}
 	return bearerToken, err

--- a/pkg/launcher/jvmLauncher_test.go
+++ b/pkg/launcher/jvmLauncher_test.go
@@ -50,6 +50,10 @@ var (
     }`
 )
 
+const (
+	BLANK_JWT = ""
+)
+
 func NewMockLauncherParams() (
 	props.JavaProperties,
 	*utils.MockEnv,
@@ -510,6 +514,7 @@ func TestCommandIncludesTraceWhenTraceIsEnabled(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, cmd)
@@ -545,7 +550,7 @@ func TestCommandDoesNotIncludeTraceWhenTraceIsDisabled(t *testing.T) {
 		overridesFilePath,
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
-		isDebugEnabled, debugPort, debugMode,
+		isDebugEnabled, debugPort, debugMode, BLANK_JWT,
 	)
 
 	assert.NotNil(t, cmd)
@@ -583,6 +588,7 @@ func TestCommandSyntaxContainsJavaHomeUnixSlashes(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, cmd)
@@ -622,6 +628,7 @@ func TestCommandSyntaxContainsJavaHomeWindowsSlashes(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, cmd)
@@ -696,6 +703,7 @@ func TestCommandIncludesGALASA_HOMESystemProperty(t *testing.T) {
 		isDebugEnabled,
 		debugPort,
 		debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, cmd)
@@ -732,6 +740,7 @@ func TestCommandIncludesFlagsFromBootstrapProperties(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, cmd)
@@ -770,6 +779,7 @@ func TestCommandIncludesTwoFlagsFromBootstrapProperties(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, cmd)
@@ -808,6 +818,7 @@ func TestCommandIncludesDefaultDebugPortAndMode(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, command)
@@ -847,6 +858,7 @@ func TestCommandDrawsValidDebugPortFromBootstrap(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, command)
@@ -886,6 +898,7 @@ func TestCommandDrawsInvalidDebugPortFromBootstrap(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, err)
@@ -925,6 +938,7 @@ func TestCommandDrawsValidDebugModeFromBootstrap(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, command)
@@ -970,6 +984,7 @@ func TestCommandDrawsInvalidDebugModeFromBootstrap(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, err)
@@ -1007,6 +1022,7 @@ func TestCommandDrawsValidDebugModeListenFromCommandLine(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, command)
@@ -1050,6 +1066,7 @@ func TestCommandDrawsValidDebugModeAttachFromCommandLine(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, command)
@@ -1093,6 +1110,7 @@ func TestCommandDrawsInvalidDebugModeFromCommandLine(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	assert.NotNil(t, err)
@@ -1132,6 +1150,7 @@ func TestLocalMavenNotSetDefaults(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	// Then...
@@ -1172,6 +1191,7 @@ func TestLocalMavenSet(t *testing.T) {
 		"", // No Gherkin URL supplied
 		isTraceEnabled,
 		isDebugEnabled, debugPort, debugMode,
+		BLANK_JWT,
 	)
 
 	// Then...

--- a/pkg/utils/bearerTokenFile.go
+++ b/pkg/utils/bearerTokenFile.go
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package auth
+package utils
 
 import (
 	"encoding/json"
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/galasa-dev/cli/pkg/files"
-	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/golang-jwt/jwt/v5"
 
 	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
@@ -31,7 +30,7 @@ const (
 //	{
 //	  "jwt": "<bearer-token-here>"
 //	}
-func WriteBearerTokenJsonFile(fileSystem files.FileSystem, galasaHome utils.GalasaHome, jwt string) error {
+func WriteBearerTokenJsonFile(fileSystem files.FileSystem, galasaHome GalasaHome, jwt string) error {
 	bearerTokenFilePath := filepath.Join(galasaHome.GetNativeFolderPath(), "bearer-token.json")
 
 	log.Printf("Writing bearer token to file '%s'", bearerTokenFilePath)
@@ -47,7 +46,7 @@ func WriteBearerTokenJsonFile(fileSystem files.FileSystem, galasaHome utils.Gala
 }
 
 // Gets the JWT from the bearer-token.json file if it exists, errors if the file does not exist or if the token is invalid
-func GetBearerTokenFromTokenJsonFile(fileSystem files.FileSystem, galasaHome utils.GalasaHome, timeService utils.TimeService) (string, error) {
+func GetBearerTokenFromTokenJsonFile(fileSystem files.FileSystem, galasaHome GalasaHome, timeService TimeService) (string, error) {
 	var err error = nil
 	var bearerToken string = ""
 	var bearerTokenJsonContents string = ""
@@ -81,7 +80,7 @@ func GetBearerTokenFromTokenJsonFile(fileSystem files.FileSystem, galasaHome uti
 }
 
 // Checks whether a given bearer token is valid or not, returning true if it is valid and false otherwise
-func IsBearerTokenValid(bearerTokenString string, timeService utils.TimeService) bool {
+func IsBearerTokenValid(bearerTokenString string, timeService TimeService) bool {
 	var err error = nil
 	var bearerToken *jwt.Token
 

--- a/pkg/utils/bearerTokenFile_test.go
+++ b/pkg/utils/bearerTokenFile_test.go
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package auth
+package utils
 
 import (
 	"errors"
@@ -12,15 +12,14 @@ import (
 	"time"
 
 	"github.com/galasa-dev/cli/pkg/files"
-	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWriteBearerTokenJsonFileWritesJwtJsonToFile(t *testing.T) {
 	// Given...
 	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+	mockEnvironment := NewMockEnv()
+	mockGalasaHome, _ := NewGalasaHome(mockFileSystem, mockEnvironment, "")
 
 	jwtJsonToWrite := `{"jwt":"blah"}`
 
@@ -37,8 +36,8 @@ func TestWriteBearerTokenJsonFileWritesJwtJsonToFile(t *testing.T) {
 func TestWriteBearerTokenJsonWithFailingWriteOperationReturnsError(t *testing.T) {
 	// Given...
 	mockFileSystem := files.NewOverridableMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+	mockEnvironment := NewMockEnv()
+	mockGalasaHome, _ := NewGalasaHome(mockFileSystem, mockEnvironment, "")
 
 	mockFileSystem.VirtualFunction_WriteTextFile = func(path string, contents string) error {
 		return errors.New("simulating a failed write operation")
@@ -57,16 +56,16 @@ func TestWriteBearerTokenJsonWithFailingWriteOperationReturnsError(t *testing.T)
 func TestGetBearerTokenFromTokenJsonFileReturnsBearerToken(t *testing.T) {
 	// Given...
 	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+	mockEnvironment := NewMockEnv()
+	mockGalasaHome, _ := NewGalasaHome(mockFileSystem, mockEnvironment, "")
 
 	// This is a dummy JWT that expires 1 hour after the Unix epoch
 	expectedToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjM2MDB9._j3Fchdx5IIqgGrdEGWXHxdgVyoBEyoD2-IBvhlxF1s"
 	mockCurrentTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockCurrentTime)
+	mockTimeService := NewOverridableMockTimeService(mockCurrentTime)
 
 	mockFileSystem.WriteTextFile(
-		mockGalasaHome.GetNativeFolderPath() + "/bearer-token.json",
+		mockGalasaHome.GetNativeFolderPath()+"/bearer-token.json",
 		fmt.Sprintf(`{"jwt":"%s"}`, expectedToken))
 
 	// When...
@@ -80,16 +79,16 @@ func TestGetBearerTokenFromTokenJsonFileReturnsBearerToken(t *testing.T) {
 func TestGetBearerTokenFromTokenJsonFileWithExpiredTokenReturnsError(t *testing.T) {
 	// Given...
 	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
+	mockEnvironment := NewMockEnv()
+	mockGalasaHome, _ := NewGalasaHome(mockFileSystem, mockEnvironment, "")
 
 	// This is a dummy JWT that expires 1 second after the Unix epoch
 	expectedToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjF9.2H0EJnt58ApysedXcvNUAy6FhgBIbDmPfq9d79qF4yQ"
 	mockTime := time.UnixMilli(0)
-	mockTimeService := utils.NewOverridableMockTimeService(mockTime)
+	mockTimeService := NewOverridableMockTimeService(mockTime)
 
 	mockFileSystem.WriteTextFile(
-		mockGalasaHome.GetNativeFolderPath() + "/bearer-token.json",
+		mockGalasaHome.GetNativeFolderPath()+"/bearer-token.json",
 		fmt.Sprintf(`{"jwt":"%s"}`, expectedToken))
 
 	// When...
@@ -103,9 +102,9 @@ func TestGetBearerTokenFromTokenJsonFileWithExpiredTokenReturnsError(t *testing.
 func TestGetBearerTokenFromTokenJsonFileWithMissingTokenFileReturnsError(t *testing.T) {
 	// Given...
 	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockTimeService := utils.NewMockTimeService()
+	mockEnvironment := NewMockEnv()
+	mockGalasaHome, _ := NewGalasaHome(mockFileSystem, mockEnvironment, "")
+	mockTimeService := NewMockTimeService()
 
 	// When...
 	_, err := GetBearerTokenFromTokenJsonFile(mockFileSystem, mockGalasaHome, mockTimeService)
@@ -118,12 +117,12 @@ func TestGetBearerTokenFromTokenJsonFileWithMissingTokenFileReturnsError(t *test
 func TestGetBearerTokenFromTokenJsonFileWithBadContentsReturnsError(t *testing.T) {
 	// Given...
 	mockFileSystem := files.NewMockFileSystem()
-	mockEnvironment := utils.NewMockEnv()
-	mockGalasaHome, _ := utils.NewGalasaHome(mockFileSystem, mockEnvironment, "")
-	mockTimeService := utils.NewMockTimeService()
+	mockEnvironment := NewMockEnv()
+	mockGalasaHome, _ := NewGalasaHome(mockFileSystem, mockEnvironment, "")
+	mockTimeService := NewMockTimeService()
 
 	mockFileSystem.WriteTextFile(
-		mockGalasaHome.GetNativeFolderPath() + "/bearer-token.json",
+		mockGalasaHome.GetNativeFolderPath()+"/bearer-token.json",
 		"notabearertoken")
 
 	// When...


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

## Why change ?

See 
[Local test run to be able to use remote CPS #1813](https://github.com/galasa-dev/projectmanagement/issues/1813)

## What changed
- The CLI looks at the bootstrap properties.
- If the framework.config.store value starts with 'galasacps' then the CLI gets the JWT (or fails if the user isn't logged-in).
- The JWT is passed to the launched JVM via a system property `GALASA_JWT`.

