### PR TITLE
bumped galsaa-boot version to 0.34.0 to match commons-compress changes in framework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@
 // into the code, so the code knows what versions of galasa it should be 
 // dealing with. Do not mess with the `def {variableName}` part of hte following 
 // lines, only change the versions we rely upon.
-def galasaBootJarVersion = '0.31.0'
+def galasaBootJarVersion = '0.34.0'
 def galasaFrameworkVersion = '0.34.0'
 
 // Right now, the REST interface spec is always the same version as the galasa framework bundles.


### PR DESCRIPTION
## Why?

This change is needed in order to be able to boot from galasa-boot-0.34.0.jar which has been updated during the changes for the commons-compress upgrade.