### PR TITLE
Change requestor to galasadelivery ID

### DIFF
--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -835,8 +835,7 @@ function runs_get_check_raw_format_output_with_older_to_than_from_age {
 
 #--------------------------------------------------------------------------
 function runs_get_check_requestor_parameter {
-    # Temporarily set the requestor to Eamonn's ID until the pipelines are changed to use a functional ID
-    requestor="eamonn.mansour@ibm.com"
+    requestor="galasadelivery@ibm.com"
     h2 "Performing runs get with details format providing a from age and requestor as $requestor..."
 
     cd ${BASEDIR}/temp


### PR DESCRIPTION
## Why?
Resolves main build failures now that the Galasadelivery's ID is used in the GALASA_TOKEN property in automation.