### PR TITLE
Use /auth/tokens route to create tokens instead of /auth

### DIFF
--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -139,7 +139,7 @@ func (authenticator *authenticatorImpl) getJwtFromRestApi(apiServerUrl string, a
 
 		var tokenResponse *galasaapi.TokenResponse
 		var httpResponse *http.Response
-		tokenResponse, httpResponse, err = apiClient.AuthenticationAPIApi.PostAuthenticate(context).
+		tokenResponse, httpResponse, err = apiClient.AuthenticationAPIApi.CreateToken(context).
 			AuthProperties(authProperties).
 			ClientApiVersion(restApiVersion).
 			Execute()

--- a/pkg/auth/authenticator_test.go
+++ b/pkg/auth/authenticator_test.go
@@ -31,7 +31,7 @@ func NewAuthServletMock(t *testing.T, status int, mockResponse string) *httptest
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 
-		if strings.Contains(request.URL.Path, "/auth") {
+		if strings.Contains(request.URL.Path, "/auth/tokens") {
 			requestBody, err := io.ReadAll(request.Body)
 			assert.Nil(t, err, "Error reading request body")
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1865

## Changes
- Updated the OpenAPI client method used to contact the `/auth/tokens` endpoint to create new auth tokens