### PR TITLE
Bump maven plugin to 0.34.0

### DIFF
--- a/pkg/embedded/templates/projectCreate/parent-project/pom.xml
+++ b/pkg/embedded/templates/projectCreate/parent-project/pom.xml
@@ -122,7 +122,7 @@
 				<plugin>
 					<groupId>dev.galasa</groupId>
 					<artifactId>galasa-maven-plugin</artifactId>
-					<version>0.33.0</version>
+					<version>0.34.0</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
## Why?
Follow-on from changes in https://github.com/galasa-dev/maven/pull/118

Note: Builds for this PR will fail until the above PR is merged

## Changes
- Bumped the Galasa maven plugin to 0.34.0 in the pom.xml template for `galasactl project create` commands