### PR TITLE
Update help text for --tokenid flag in `auth tokens delete` and add `-v` shorthand for `--value` in the properties set command

### DIFF
--- a/docs/generated/galasactl_auth_tokens_delete.md
+++ b/docs/generated/galasactl_auth_tokens_delete.md
@@ -14,7 +14,7 @@ galasactl auth tokens delete [flags]
 
 ```
   -h, --help             Displays the options for the 'auth tokens delete' command.
-      --tokenid string   The ID of the token to be deleted.
+      --tokenid string   The ID of the token to be revoked.
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_properties_set.md
+++ b/docs/generated/galasactl_properties_set.md
@@ -16,7 +16,7 @@ galasactl properties set [flags]
   -h, --help               Displays the options for the 'properties set' command.
   -n, --name string        A mandatory field indicating the name of a property in the namespace.The first character of the name must be in the 'a'-'z' or 'A'-'Z' ranges, and following characters can be 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore)
   -s, --namespace string   A mandatory flag that describes the container for a collection of properties.The first character of the namespace must be in the 'a'-'z' range, and following characters can be 'a'-'z' or '0'-'9'
-      --value string       A mandatory flag indicating the value of the property you want to create. Empty values and values with spaces must be put in quotation marks.
+  -v, --value string       A mandatory flag indicating the value of the property you want to create. Empty values and values with spaces must be put in quotation marks.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cmd/authTokensDelete.go
+++ b/pkg/cmd/authTokensDelete.go
@@ -86,7 +86,7 @@ func (cmd *AuthTokensDeleteCommand) createCobraCmd(
 		},
 	}
 
-	authDeleteTokensCobraCmd.Flags().StringVar(&cmd.values.tokenId, "tokenid", "", "The ID of the token to be deleted.")
+	authDeleteTokensCobraCmd.Flags().StringVar(&cmd.values.tokenId, "tokenid", "", "The ID of the token to be revoked.")
 	authDeleteTokensCobraCmd.MarkFlagRequired("tokenid")
 
 	authTokensCommand.CobraCommand().AddCommand(authDeleteTokensCobraCmd)
@@ -109,7 +109,7 @@ func (cmd *AuthTokensDeleteCommand) executeAuthTokensDelete(
 	if err == nil {
 		rootCmdValues.isCapturingLogs = true
 
-		log.Println("Galasa CLI - Delete/Revoke a token from the ecosystem")
+		log.Println("Galasa CLI - Revoke a token from the ecosystem")
 
 		// Get the ability to query environment variables.
 		env := factory.GetEnvironment()

--- a/pkg/cmd/propertiesSet.go
+++ b/pkg/cmd/propertiesSet.go
@@ -91,7 +91,7 @@ func (cmd *PropertiesSetCommand) createCobraCommand(
 		},
 	}
 
-	propertiesSetCobraCmd.PersistentFlags().StringVar(&cmd.values.propertyValue, "value", "", "A mandatory flag indicating the value of the property you want to create. "+
+	propertiesSetCobraCmd.PersistentFlags().StringVarP(&cmd.values.propertyValue, "value", "v", "", "A mandatory flag indicating the value of the property you want to create. "+
 		"Empty values and values with spaces must be put in quotation marks.")
 	propertiesSetCobraCmd.MarkPersistentFlagRequired("value")
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1729
And changes made in https://github.com/galasa-dev/cli/pull/154

## Changes
- Changed the mention of "deleting" a token to "revoking" a token for consistency with the `auth tokens delete` documentation
- Added missing shorthand `-v` flag for `properties set` since all other flags have shorthand equivalents but `--value` (e.g. `--name` has `-n`, `--namespace` has `-s`)