### PR TITLE
added bootstrap property commented-out for documentation

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -540,6 +540,10 @@ function run_test_locally_using_galasactl {
 
     unset GALASA_BOOTSTRAP
 
+    rm -f results.junit
+    rm -f results.yaml
+    rm -f results.json
+
     cmd="${BASEDIR}/bin/${galasactl_command} runs submit local \
     --obr mvn:${OBR_GROUP_ID}/${OBR_ARTIFACT_ID}/${OBR_VERSION}/obr \
     --class ${BUNDLE}/${JAVA_CLASS} \
@@ -549,6 +553,7 @@ function run_test_locally_using_galasactl {
     --requesttype MikeCLI \
     --poll 10 \
     --progress 1 \
+    --reportjunit results.junit --reportyaml results.yaml --reportjson results.json  \
     --log ${LOG_FILE}"
 
     # --reportjson myreport.json \

--- a/pkg/embedded/templates/galasahome/bootstrap.properties
+++ b/pkg/embedded/templates/galasahome/bootstrap.properties
@@ -35,3 +35,8 @@
 #   Can be overridden using the --debugPort parameter on the 'galasactl runs submit local' command.
 #   Defaults to 2970 if the value is neither set on the command-line or in the bootstrap properties.
 # 
+#
+# framework.request.type.LOCAL.prefix=L - only used when running local tests.
+#   Indicates which single-character prefix should be used as part of a test run name to indicate that the test is a local one.
+#   The default is 'L'.
+#


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Someone asked how to change the prefix of the run name for a local test.
The answer is to set a property into the bootstrap.properties file.

- Added a comment which documents this property so it's easier for people to find (if they have used `galasactl local init`
