### PR TITLE
issue-1927-resources-defects

### DIFF
--- a/pkg/resources/resourcesApplier_test.go
+++ b/pkg/resources/resourcesApplier_test.go
@@ -181,39 +181,6 @@ func TestCanApplyValidMultipleResources(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestCanApplyEmptyValidResource(t *testing.T) {
-	// Given
-	expectedJsonArrivingInServlet := `{
-    "action": "apply",
-    "data": [
-        null
-    ]
-}`
-
-	mockServlet := NewMockServlet(t, nil, http.StatusOK, []byte(expectedJsonArrivingInServlet))
-	mockservletUrl := mockServlet.getUrl()
-	mockBearerToken := "my-bearer-token"
-
-	yamlToApply := ""
-
-	action := "apply"
-
-	fs := files.NewOverridableMockFileSystem()
-	filePath := "/my/resources.yaml"
-	fs.WriteTextFile(filePath, yamlToApply)
-
-	// When
-	err := ApplyResources(
-		action,
-		filePath,
-		fs,
-		mockservletUrl,
-		mockBearerToken,
-	)
-
-	// Then
-	assert.Nil(t, err)
-}
 
 func TestUnauthorizedResponseStatusFromServerShowsUnauthorizedError(t *testing.T) {
 	// Given
@@ -509,36 +476,3 @@ func TestCanDeleteValidMultipleResources(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestCanDeleteEmptyValidResource(t *testing.T) {
-	// Given
-	expectedJsonArrivingInServlet := `{
-    "action": "delete",
-    "data": [
-        null
-    ]
-}`
-
-	mockServlet := NewMockServlet(t, nil, http.StatusOK, []byte(expectedJsonArrivingInServlet))
-	mockservletUrl := mockServlet.getUrl()
-	mockBearerToken := "my-bearer-token"
-
-	yamlToApply := ""
-
-	action := "delete"
-
-	fs := files.NewOverridableMockFileSystem()
-	filePath := "/my/resources.yaml"
-	fs.WriteTextFile(filePath, yamlToApply)
-
-	// When
-	err := ApplyResources(
-		action,
-		filePath,
-		fs,
-		mockservletUrl,
-		mockBearerToken,
-	)
-
-	// Then
-	assert.Nil(t, err)
-}

--- a/pkg/resources/resourcesIO.go
+++ b/pkg/resources/resourcesIO.go
@@ -73,15 +73,19 @@ func yamlToByteArray(inputYaml string, action string) ([]byte, error) {
 
 	for _, partYaml := range parts {
 
-		var parsedData interface{}
-
-		err = yaml.Unmarshal([]byte(partYaml), &parsedData)
-		if err != nil {
-			log.Printf("Unable to unmarshal yaml data to retrieve yaml content")
-			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_UNABLE_TO_UNMARSHAL_YAML, err, partYaml)
-			break
+		if len(strings.TrimSpace(partYaml)) == 0 { 
+			// yaml section is empty
+			log.Printf("Yaml section '%s' does not contain any data. This will be added to the request",partYaml)
 		} else {
-			parsedParts = append(parsedParts, parsedData)
+			var parsedData interface{}
+			err = yaml.Unmarshal([]byte(partYaml), &parsedData)
+			if err != nil {
+				log.Printf("Unable to unmarshal yaml data to retrieve yaml content")
+				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_UNABLE_TO_UNMARSHAL_YAML, err, partYaml)
+				break
+			} else {
+				parsedParts = append(parsedParts, parsedData)
+			}
 		}
 	}
 

--- a/pkg/resources/resourcesIO_test.go
+++ b/pkg/resources/resourcesIO_test.go
@@ -7,14 +7,14 @@
 package resources
 
 import (
-	"testing"
+  "testing"
 
-	"github.com/galasa-dev/cli/pkg/files"
-	"github.com/stretchr/testify/assert"
+  "github.com/galasa-dev/cli/pkg/files"
+  "github.com/stretchr/testify/assert"
 )
 
 var (
-	validResourcesYamlFileContentSingleProperty = `apiVersion: galasa-dev/v1alpha1
+  validResourcesYamlFileContentSingleProperty = `apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
 metadata:
   name: filling
@@ -22,7 +22,7 @@ metadata:
 data:
   value: custard`
 
-	validResourcesYamlFileContentMultipleProperties = `apiVersion: galasa-dev/v1alpha1
+  validResourcesYamlFileContentMultipleProperties = `apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
 metadata:
   name: filling
@@ -46,7 +46,7 @@ metadata:
 data:
   value: custard3`
 
-	invalidResourcesYamlFileContentSingleProperty = `apiVersion: galasa-dev/v1alpha1
+  invalidResourcesYamlFileContentSingleProperty = `apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
 metadata:
      name: filling
@@ -55,7 +55,7 @@ data:
     value: custard
 `
 
-	invalidResourcesYamlFileContentMultipleProperties = `  apiVersion: galasa-dev/v1alpha1
+  invalidResourcesYamlFileContentMultipleProperties = `  apiVersion: galasa-dev/v1alpha1
   kind: GalasaProperty
   metadata:
     name: PropertyName
@@ -81,180 +81,180 @@ data:
 )
 
 func TestValidFileYamlPathReturnsOk(t *testing.T) {
-	//Given
-	fileSystem := files.NewOverridableMockFileSystem()
-	fileName := "validFilePath.yaml"
-	fileSystem.WriteTextFile(fileName, validResourcesYamlFileContentSingleProperty)
+  //Given
+  fileSystem := files.NewOverridableMockFileSystem()
+  fileName := "validFilePath.yaml"
+  fileSystem.WriteTextFile(fileName, validResourcesYamlFileContentSingleProperty)
 
-	//When
-	err := validateFilePathExists(fileSystem, fileName)
+  //When
+  err := validateFilePathExists(fileSystem, fileName)
 
-	//Then
-	assert.Nil(t, err)
+  //Then
+  assert.Nil(t, err)
 }
 
 func TestValidFileYmlPathReturnsOk(t *testing.T) {
-	//Given
-	fileSystem := files.NewOverridableMockFileSystem()
-	fileName := "validFilePath.yml"
-	fileSystem.WriteTextFile(fileName, validResourcesYamlFileContentSingleProperty)
+  //Given
+  fileSystem := files.NewOverridableMockFileSystem()
+  fileName := "validFilePath.yml"
+  fileSystem.WriteTextFile(fileName, validResourcesYamlFileContentSingleProperty)
 
-	//When
-	err := validateFilePathExists(fileSystem, fileName)
+  //When
+  err := validateFilePathExists(fileSystem, fileName)
 
-	//Then
-	assert.Nil(t, err)
+  //Then
+  assert.Nil(t, err)
 }
 
 func TestInvalidFilePathYamlReturnsError(t *testing.T) {
-	//Given
-	fileSystem := files.NewOverridableMockFileSystem()
-	fileName := "invalidFilePath.yaml"
+  //Given
+  fileSystem := files.NewOverridableMockFileSystem()
+  fileName := "invalidFilePath.yaml"
 
-	//When
-	err := validateFilePathExists(fileSystem, fileName)
+  //When
+  err := validateFilePathExists(fileSystem, fileName)
 
-	//Then
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "GAL1109E")
-	assert.Contains(t, err.Error(), "no such file or directory")
+  //Then
+  assert.NotNil(t, err)
+  assert.Contains(t, err.Error(), "GAL1109E")
+  assert.Contains(t, err.Error(), "no such file or directory")
 }
 
 func TestInvalidFilePathYmlReturnsError(t *testing.T) {
-	//Given
-	fileSystem := files.NewOverridableMockFileSystem()
-	fileName := "invalidFilePath.yml"
+  //Given
+  fileSystem := files.NewOverridableMockFileSystem()
+  fileName := "invalidFilePath.yml"
 
-	//When
-	err := validateFilePathExists(fileSystem, fileName)
+  //When
+  err := validateFilePathExists(fileSystem, fileName)
 
-	//Then
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "GAL1109E")
-	assert.Contains(t, err.Error(), "no such file or directory")
+  //Then
+  assert.NotNil(t, err)
+  assert.Contains(t, err.Error(), "GAL1109E")
+  assert.Contains(t, err.Error(), "no such file or directory")
 }
 
 func TestValidFilePathInvalidFileTypeReturnsError(t *testing.T) {
-	//Given
-	fileSystem := files.NewOverridableMockFileSystem()
-	fileName := "invalidFileType.js"
-	fileSystem.WriteTextFile(fileName, validResourcesYamlFileContentSingleProperty)
+  //Given
+  fileSystem := files.NewOverridableMockFileSystem()
+  fileName := "invalidFileType.js"
+  fileSystem.WriteTextFile(fileName, validResourcesYamlFileContentSingleProperty)
 
-	//When
-	err := validateFilePathExists(fileSystem, fileName)
+  //When
+  err := validateFilePathExists(fileSystem, fileName)
 
-	//Then
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "GAL1109E")
-	assert.Contains(t, err.Error(), "not a yaml file")
+  //Then
+  assert.NotNil(t, err)
+  assert.Contains(t, err.Error(), "GAL1109E")
+  assert.Contains(t, err.Error(), "not a yaml file")
 }
 
 func TestGetYamlFileContentReturnsOk(t *testing.T) {
-	//Given
-	fileSystem := files.NewOverridableMockFileSystem()
-	fileName := "validFilePath.yaml"
-	fileSystem.WriteTextFile(fileName, validResourcesYamlFileContentMultipleProperties)
+  //Given
+  fileSystem := files.NewOverridableMockFileSystem()
+  fileName := "validFilePath.yaml"
+  fileSystem.WriteTextFile(fileName, validResourcesYamlFileContentMultipleProperties)
 
-	//When
-	fileContent, err := getYamlFileContent(fileSystem, fileName)
+  //When
+  fileContent, err := getYamlFileContent(fileSystem, fileName)
 
-	//Then
-	assert.Nil(t, err)
-	assert.NotNil(t, fileContent)
-	assert.Equal(t, validResourcesYamlFileContentMultipleProperties, string(fileContent))
+  //Then
+  assert.Nil(t, err)
+  assert.NotNil(t, fileContent)
+  assert.Equal(t, validResourcesYamlFileContentMultipleProperties, string(fileContent))
 }
 
 func TestGetYmlFileContentReturnsOk(t *testing.T) {
-	//Given
-	fileSystem := files.NewOverridableMockFileSystem()
-	fileName := "validFilePath.yaml"
-	fileSystem.WriteTextFile(fileName, validResourcesYamlFileContentMultipleProperties)
+  //Given
+  fileSystem := files.NewOverridableMockFileSystem()
+  fileName := "validFilePath.yaml"
+  fileSystem.WriteTextFile(fileName, validResourcesYamlFileContentMultipleProperties)
 
-	//When
-	fileContent, err := getYamlFileContent(fileSystem, fileName)
+  //When
+  fileContent, err := getYamlFileContent(fileSystem, fileName)
 
-	//Then
-	assert.Nil(t, err)
-	assert.NotNil(t, fileContent)
-	assert.Equal(t, validResourcesYamlFileContentMultipleProperties, string(fileContent))
+  //Then
+  assert.Nil(t, err)
+  assert.NotNil(t, fileContent)
+  assert.Equal(t, validResourcesYamlFileContentMultipleProperties, string(fileContent))
 }
 
 func TestGetYamlFileContentFromNonExistentPathReturnsError(t *testing.T) {
-	//Given
-	fileSystem := files.NewOverridableMockFileSystem()
-	fileName := "invalidFilePath.yaml"
+  //Given
+  fileSystem := files.NewOverridableMockFileSystem()
+  fileName := "invalidFilePath.yaml"
 
-	//When
-	fileContent, err := getYamlFileContent(fileSystem, fileName)
+  //When
+  fileContent, err := getYamlFileContent(fileSystem, fileName)
 
-	//Then
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "GAL1110E")
-	assert.Equal(t, "", fileContent)
+  //Then
+  assert.NotNil(t, err)
+  assert.Contains(t, err.Error(), "GAL1110E")
+  assert.Equal(t, "", fileContent)
 }
 
 func TestSplitByRegexSeparatorSimpleCase(t *testing.T) {
-	//When
-	result := splitByRegexSeparator("a-b", "-")
+  //When
+  result := splitByRegexSeparator("a-b", "-")
 
-	//Then
-	assert.Equal(t, 2, len(result))
-	assert.Equal(t, "a", result[0])
-	assert.Equal(t, "b", result[1])
+  //Then
+  assert.Equal(t, 2, len(result))
+  assert.Equal(t, "a", result[0])
+  assert.Equal(t, "b", result[1])
 }
 
 func TestSplitYamlWithSimpleSeparator(t *testing.T) {
-	//When
-	result := splitYamlIntoParts("a\n---\nb")
+  //When
+  result := splitYamlIntoParts("a\n---\nb")
 
-	//Then
-	assert.Equal(t, 2, len(result))
-	assert.Equal(t, "a", result[0])
-	assert.Equal(t, "b", result[1])
+  //Then
+  assert.Equal(t, 2, len(result))
+  assert.Equal(t, "a", result[0])
+  assert.Equal(t, "b", result[1])
 }
 
 func TestSplitYamlLongSeparator(t *testing.T) {
-	//When
-	result := splitYamlIntoParts("a\n---------\nb")
+  //When
+  result := splitYamlIntoParts("a\n---------\nb")
 
-	//Then
-	assert.Equal(t, 2, len(result))
-	assert.Equal(t, "a", result[0])
-	assert.Equal(t, "b", result[1])
+  //Then
+  assert.Equal(t, 2, len(result))
+  assert.Equal(t, "a", result[0])
+  assert.Equal(t, "b", result[1])
 }
 
 func TestCanDynamicallyParseJsonSingleItemInvalidYamlReturnsError(t *testing.T) {
-	//Given
-	inputYaml := invalidResourcesYamlFileContentSingleProperty
-	action := "apply"
+  //Given
+  inputYaml := invalidResourcesYamlFileContentSingleProperty
+  action := "apply"
 
-	//When
-	_, err := yamlToByteArray(inputYaml, action)
+  //When
+  _, err := yamlToByteArray(inputYaml, action)
 
-	//Then
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "GAL1111E:")
+  //Then
+  assert.NotNil(t, err)
+  assert.Contains(t, err.Error(), "GAL1111E:")
 }
 
 func TestCanDynamicallyParseJsonMultipleItemsInvalidYamlReturnsError(t *testing.T) {
-	//Given
-	inputYaml := invalidResourcesYamlFileContentMultipleProperties
-	action := "apply"
+  //Given
+  inputYaml := invalidResourcesYamlFileContentMultipleProperties
+  action := "apply"
 
-	//When
-	_, err := yamlToByteArray(inputYaml, action)
+  //When
+  _, err := yamlToByteArray(inputYaml, action)
 
-	//Then
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "GAL1111E:")
+  //Then
+  assert.NotNil(t, err)
+  assert.Contains(t, err.Error(), "GAL1111E:")
 }
 
 func TestCanDynamicallyParseJsonSingleItemReturnsOk(t *testing.T) {
-	//Given
-	inputYaml := validResourcesYamlFileContentSingleProperty
-	action := "apply"
+  //Given
+  inputYaml := validResourcesYamlFileContentSingleProperty
+  action := "apply"
 
-	jsonStr := `{
+  jsonStr := `{
     "action": "apply",
     "data": [
         {
@@ -271,20 +271,20 @@ func TestCanDynamicallyParseJsonSingleItemReturnsOk(t *testing.T) {
     ]
 }`
 
-	//When
-	jsonBytes, err := yamlToByteArray(inputYaml, action)
+  //When
+  jsonBytes, err := yamlToByteArray(inputYaml, action)
 
-	//Then
-	assert.Nil(t, err, "Failed when it should have worked. err: %v", err)
-	assert.Equal(t, string(jsonBytes), jsonStr)
+  //Then
+  assert.Nil(t, err, "Failed when it should have worked. err: %v", err)
+  assert.Equal(t, string(jsonBytes), jsonStr)
 }
 
 func TestCanDynamicallyParseJsonMultipleItemsReturnsOk(t *testing.T) {
-	//Given
-	inputYaml := validResourcesYamlFileContentMultipleProperties
-	action := "create"
+  //Given
+  inputYaml := validResourcesYamlFileContentMultipleProperties
+  action := "create"
 
-	jsonStr := `{
+  jsonStr := `{
     "action": "create",
     "data": [
         {
@@ -323,17 +323,17 @@ func TestCanDynamicallyParseJsonMultipleItemsReturnsOk(t *testing.T) {
     ]
 }`
 
-	//When
-	jsonBytes, err := yamlToByteArray(inputYaml, action)
+  //When
+  jsonBytes, err := yamlToByteArray(inputYaml, action)
 
-	//Then
-	assert.Nil(t, err, "Failed when it should have worked. err: %v", err)
-	assert.Equal(t, string(jsonBytes), jsonStr)
+  //Then
+  assert.Nil(t, err, "Failed when it should have worked. err: %v", err)
+  assert.Equal(t, string(jsonBytes), jsonStr)
 }
 
 func TestCanDynamicallyParseJsonTwoItemsLongSeparatorReturnsOk(t *testing.T) {
-	//Given
-	inputYaml := `apiVersion: galasa-dev/v1alpha1
+  //Given
+  inputYaml := `apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
 metadata:
   name: filling
@@ -349,9 +349,9 @@ metadata:
 data:
   value: custard2
 `
-	action := "update"
+  action := "update"
 
-	jsonStr := `{
+  jsonStr := `{
     "action": "update",
     "data": [
         {
@@ -378,17 +378,17 @@ data:
         }
     ]
 }`
-	//When
-	jsonBytes, err := yamlToByteArray(inputYaml, action)
+  //When
+  jsonBytes, err := yamlToByteArray(inputYaml, action)
 
-	//Then
-	assert.Nil(t, err, "Failed when it should have worked. err: %v", err)
-	assert.Equal(t, string(jsonBytes), jsonStr)
+  //Then
+  assert.Nil(t, err, "Failed when it should have worked. err: %v", err)
+  assert.Equal(t, string(jsonBytes), jsonStr)
 }
 
 func TestCanDynamicallyParseJsonSingleItemWithAList(t *testing.T) {
-	//Given
-	inputYaml := `apiVersion: galasa-dev/v1alpha1
+  //Given
+  inputYaml := `apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
 metadata:
   - name: filling
@@ -396,9 +396,9 @@ metadata:
 data:
   value: custard
 `
-	action := "update"
+  action := "update"
 
-	jsonStr := `{
+  jsonStr := `{
     "action": "update",
     "data": [
         {
@@ -418,10 +418,67 @@ data:
         }
     ]
 }`
-	//When
-	jsonBytes, err := yamlToByteArray(inputYaml, action)
+  //When
+  jsonBytes, err := yamlToByteArray(inputYaml, action)
 
-	//Then
-	assert.Nil(t, err, "Failed when it should have worked. err: %v", err)
-	assert.Equal(t, string(jsonBytes), jsonStr)
+  //Then
+  assert.Nil(t, err, "Failed when it should have worked. err: %v", err)
+  assert.Equal(t, string(jsonBytes), jsonStr)
+}
+
+func TestCanDynamicallyParseJsonTwoItemsLongWithNullStartReturnsOk(t *testing.T) {
+  //Given
+  inputYaml := `
+---
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaProperty
+metadata:
+  name: filling
+  namespace: doughnuts
+data:
+  value: custard
+---
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaProperty
+metadata:
+  name: filling2
+  namespace: doughnuts2
+data:
+ value: custard2`
+
+  action :="apply"
+  jsonStr := `{
+    "action": "apply",
+    "data": [
+        {
+            "apiVersion": "galasa-dev/v1alpha1",
+            "data": {
+                "value": "custard"
+            },
+            "kind": "GalasaProperty",
+            "metadata": {
+                "name": "filling",
+                "namespace": "doughnuts"
+            }
+        },
+        {
+            "apiVersion": "galasa-dev/v1alpha1",
+            "data": {
+                "value": "custard2"
+            },
+            "kind": "GalasaProperty",
+            "metadata": {
+                "name": "filling2",
+                "namespace": "doughnuts2"
+            }
+        }
+    ]
+}`
+
+  //When
+  jsonBytes, err := yamlToByteArray(inputYaml, action)
+
+  //Then
+  assert.Nil(t, err, "Failed when it should have worked. err: %v", err)
+  assert.Equal(t, string(jsonBytes), jsonStr)
 }


### PR DESCRIPTION
## Why?

This change is to correct the missing validation for null and empty json objects in the /resources API endpoint callout