### PR TITLE
mcobbett 1889 rest cps cache

### DIFF
--- a/pkg/embedded/templates/galasahome/cps.properties
+++ b/pkg/embedded/templates/galasahome/cps.properties
@@ -74,12 +74,4 @@
 # Example:
 # framework.continue.on.test.failure=true
 
-#-------------------------------------------------------------------------
-# framework.cps.rest.cache.is.enabled
-# The CPS over REST feature allows a local client to draw CPS properties from a remote Galasa service.
-# It has a local cache of properties which can be turned on using the `framework.cps.rest.cache.is.enabled` property.
-# Values:
-# - `true` - enables caching of CPS properties on the client-side, with an agressive cache-priming which loads all
-#    CPS properties into the cache at the start.
-# - `false` - the caching will be disabled.
-# Default value if missing from the CPS: `false`
+

--- a/pkg/embedded/templates/galasahome/cps.properties
+++ b/pkg/embedded/templates/galasahome/cps.properties
@@ -73,3 +73,13 @@
 #
 # Example:
 # framework.continue.on.test.failure=true
+
+#-------------------------------------------------------------------------
+# framework.cps.rest.cache.is.enabled
+# The CPS over REST feature allows a local client to draw CPS properties from a remote Galasa service.
+# It has a local cache of properties which can be turned on using the `framework.cps.rest.cache.is.enabled` property.
+# Values:
+# - `true` - enables caching of CPS properties on the client-side, with an agressive cache-priming which loads all
+#    CPS properties into the cache at the start.
+# - `false` - the caching will be disabled.
+# Default value if missing from the CPS: `false`

--- a/pkg/embedded/templates/galasahome/overrides.properties
+++ b/pkg/embedded/templates/galasahome/overrides.properties
@@ -16,3 +16,12 @@
 #
 # framework.continue.on.test.failure=true
 #
+#-------------------------------------------------------------------------
+# framework.cps.rest.cache.is.enabled
+# The CPS over REST feature allows a local client to draw CPS properties from a remote Galasa service.
+# It has a local cache of properties which can be turned on using the `framework.cps.rest.cache.is.enabled` property.
+# Values:
+# - `true` - enables caching of CPS properties on the client-side, with an aggressive cache-priming which loads all
+#    CPS properties into the cache at the start.
+# - `false` - the caching will be disabled.
+# Default value if missing from the CPS: `false`


### PR DESCRIPTION
# Why ?
See issue [#1899](https://github.com/galasa-dev/projectmanagement/issues/1889)

- Added extra property to the generated cps.properties (commented-out) which turns on/off caching.
- Added more tests which try with and without a cache.

