### PR TITLE
updated properties set command to respond with Server errors in error messages

### DIFF
--- a/pkg/properties/propertiesGet_test.go
+++ b/pkg/properties/propertiesGet_test.go
@@ -296,8 +296,8 @@ func CheckNamespace(namespace string) (int, string) {
 	case "invalidnamespace":
 		statusCode = 404
 		namespaceProperties = `{
-			error_code: 5016,
-			error_message: "GAL5016E: Error occured when trying to access namespace 'invalidnamespace'. The Namespace provided is invalid."
+			"error_code": 5016,
+			"error_message": "GAL5016E: Error occured when trying to access namespace 'invalidnamespace'. The Namespace provided is invalid."
 		}`
 	}
 

--- a/pkg/properties/propertiesSet_test.go
+++ b/pkg/properties/propertiesSet_test.go
@@ -122,7 +122,7 @@ func TestUpdatePropertyWithInvalidNamespaceAndInvalidPropertyNameReturnsError(t 
 
 	//Then
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "GAL1098E:")
+	assert.ErrorContains(t, err, "GAL1100E:")
 }
 
 // --------
@@ -163,7 +163,7 @@ func TestUpdatePropertyWithInvalidNamespaceAndValidNameReturnsError(t *testing.T
 
 	//Then
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "GAL1098E")
+	assert.Contains(t, err.Error(), "GAL1100E")
 }
 
 func TestSetNoNamespaceReturnsError(t *testing.T) {


### PR DESCRIPTION
## Why?

This is to ensure that the error message from the server is being displayed to the user properly along with the status code