### PR TITLE
updated templates to support gradle 8.x and bumped up boot jar version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@
 // into the code, so the code knows what versions of galasa it should be 
 // dealing with. Do not mess with the `def {variableName}` part of hte following 
 // lines, only change the versions we rely upon.
-def galasaBootJarVersion = '0.34.0'
+def galasaBootJarVersion = '0.36.0'
 def galasaFrameworkVersion = '0.36.0'
 
 // Right now, the REST interface spec is always the same version as the galasa framework bundles.

--- a/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
@@ -2,8 +2,8 @@
 plugins {
     id 'base'
     id 'maven-publish'
-    id 'dev.galasa.obr' version '0.33.0'
-    id 'dev.galasa.testcatalog' version '0.33.0'
+    id 'dev.galasa.obr' version '0.36.0'
+    id 'dev.galasa.testcatalog' version '0.36.0'
 }
 
 // Set the variables which will control what the built OSGi bundle will be called
@@ -20,6 +20,12 @@ dependencies {
 
 def testcatalog = file('build/testcatalog.json')
 def obrFile = file('build/galasa.obr')
+
+
+tasks.withType(PublishToMavenLocal) { task ->
+    task.dependsOn genobr
+    task.dependsOn mergetestcat
+}
 
 // Tell gradle to publish the built OBR as a maven artifact on the 
 // local maven repository.

--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
@@ -3,7 +3,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'dev.galasa.tests' version '0.33.0'
+    id 'dev.galasa.tests' version '0.36.0'
     id 'biz.aQute.bnd.builder' version '6.4.0'
 }
 


### PR DESCRIPTION
[1652](https://github.com/galasa-dev/projectmanagement/issues/1652)

To support the latest versions of gradle for building galasa