### PR TITLE
Update runs get to use cursor-based pagination

### DIFF
--- a/pkg/runs/runsDownload_test.go
+++ b/pkg/runs/runsDownload_test.go
@@ -250,7 +250,6 @@ func WriteMockRasRunsResponse(
 
 	writer.Write([]byte(fmt.Sprintf(`
 	{
-		"nextCursor": "",
 		"pageSize": 1,
 		"amountOfRuns": %d,
 		"runs":[ %s ]

--- a/pkg/runs/runsDownload_test.go
+++ b/pkg/runs/runsDownload_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -237,10 +236,7 @@ func WriteMockRasRunsResponse(
 	writer.Header().Set("Content-Type", "application/json")
 
 	values := req.URL.Query()
-	pageRequestedStr := values.Get("page")
 	runNameQueryParameter := values.Get("runname")
-	pageRequested, _ := strconv.Atoi(pageRequestedStr)
-	assert.Equal(t, pageRequested, 1)
 
 	assert.Equal(t, runNameQueryParameter, runName)
 
@@ -254,9 +250,8 @@ func WriteMockRasRunsResponse(
 
 	writer.Write([]byte(fmt.Sprintf(`
 	{
-		"pageNumber": 1,
+		"nextCursor": "",
 		"pageSize": 1,
-		"numPages": 1,
 		"amountOfRuns": %d,
 		"runs":[ %s ]
 	}`, len(runResultStrings), combinedRunResultStrings)))

--- a/pkg/runs/runsGet.go
+++ b/pkg/runs/runsGet.go
@@ -233,7 +233,7 @@ func GetRunsFromRestApi(
 			var runData *galasaapi.RunResults
 			var httpResponse *http.Response
 			log.Printf("Requesting page '%d' ", pageNumberWanted)
-			apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion)
+			apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion).IncludeCursor("true")
 			if fromAgeMins != 0 {
 				apicall = apicall.From(fromTime)
 			}
@@ -272,6 +272,7 @@ func GetRunsFromRestApi(
 					// Add all the runs into our set of results.
 					// Note: The ... syntax means 'all of the array', so they all get appended at once.
 					results = append(results, runsOnThisPage...)
+					log.Print("APPENDING ")
 
 					// Have we processed the last page ?
 					if !runData.HasNextCursor() || pageCursor == runData.GetNextCursor() {

--- a/pkg/runs/runsGet.go
+++ b/pkg/runs/runsGet.go
@@ -222,7 +222,7 @@ func GetRunsFromRestApi(
 	var pageNumberWanted int32 = 1
 	gotAllResults := false
 	var restApiVersion string
-	var pageCursor string = ""
+	var pageCursor string
 
 	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 
@@ -233,7 +233,7 @@ func GetRunsFromRestApi(
 			var runData *galasaapi.RunResults
 			var httpResponse *http.Response
 			log.Printf("Requesting page '%d' ", pageNumberWanted)
-			apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion).IncludeCursor("true")
+			apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion)
 			if fromAgeMins != 0 {
 				apicall = apicall.From(fromTime)
 			}
@@ -273,8 +273,8 @@ func GetRunsFromRestApi(
 					// Note: The ... syntax means 'all of the array', so they all get appended at once.
 					results = append(results, runsOnThisPage...)
 
-					// If the page cursor is the same, then we've gone through all pages
-					if pageCursor == runData.GetNextCursor() || runData.GetNextCursor() == "" {
+					// Have we processed the last page ?
+					if pageCursor == runData.GetNextCursor() || !runData.HasNextCursor() {
 						gotAllResults = true
 					} else {
 						pageCursor = runData.GetNextCursor()

--- a/pkg/runs/runsGet.go
+++ b/pkg/runs/runsGet.go
@@ -272,7 +272,6 @@ func GetRunsFromRestApi(
 					// Add all the runs into our set of results.
 					// Note: The ... syntax means 'all of the array', so they all get appended at once.
 					results = append(results, runsOnThisPage...)
-					log.Print("APPENDING ")
 
 					// Have we processed the last page ?
 					if !runData.HasNextCursor() || pageCursor == runData.GetNextCursor() {

--- a/pkg/runs/runsGet.go
+++ b/pkg/runs/runsGet.go
@@ -255,7 +255,7 @@ func GetRunsFromRestApi(
 			if pageCursor != "" {
 				apicall = apicall.Cursor(pageCursor)
 			}
-			apicall = apicall.Sort("to:desc")
+			apicall = apicall.Sort("from:desc")
 			runData, httpResponse, err = apicall.Execute()
 
 			if err != nil {
@@ -274,7 +274,7 @@ func GetRunsFromRestApi(
 					results = append(results, runsOnThisPage...)
 
 					// Have we processed the last page ?
-					if !runData.HasNextCursor() || pageCursor == runData.GetNextCursor() {
+					if !runData.HasNextCursor() || len(runsOnThisPage) < int(runData.GetPageSize()) {
 						gotAllResults = true
 					} else {
 						pageCursor = runData.GetNextCursor()

--- a/pkg/runs/runsGet.go
+++ b/pkg/runs/runsGet.go
@@ -274,7 +274,7 @@ func GetRunsFromRestApi(
 					results = append(results, runsOnThisPage...)
 
 					// Have we processed the last page ?
-					if pageCursor == runData.GetNextCursor() || !runData.HasNextCursor() {
+					if !runData.HasNextCursor() || pageCursor == runData.GetNextCursor() {
 						gotAllResults = true
 					} else {
 						pageCursor = runData.GetNextCursor()

--- a/pkg/runs/runsGet.go
+++ b/pkg/runs/runsGet.go
@@ -222,6 +222,7 @@ func GetRunsFromRestApi(
 	var pageNumberWanted int32 = 1
 	gotAllResults := false
 	var restApiVersion string
+	var pageCursor string = ""
 
 	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 
@@ -232,7 +233,7 @@ func GetRunsFromRestApi(
 			var runData *galasaapi.RunResults
 			var httpResponse *http.Response
 			log.Printf("Requesting page '%d' ", pageNumberWanted)
-			apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion)
+			apicall := apiClient.ResultArchiveStoreAPIApi.GetRasSearchRuns(context).ClientApiVersion(restApiVersion).IncludeCursor("true")
 			if fromAgeMins != 0 {
 				apicall = apicall.From(fromTime)
 			}
@@ -251,7 +252,9 @@ func GetRunsFromRestApi(
 			if shouldGetActive {
 				apicall = apicall.Status(activeStatusNames)
 			}
-			apicall = apicall.Page(pageNumberWanted)
+			if pageCursor != "" {
+				apicall = apicall.Cursor(pageCursor)
+			}
 			apicall = apicall.Sort("to:desc")
 			runData, httpResponse, err = apicall.Execute()
 
@@ -270,10 +273,11 @@ func GetRunsFromRestApi(
 					// Note: The ... syntax means 'all of the array', so they all get appended at once.
 					results = append(results, runsOnThisPage...)
 
-					// Have we processed the last page ?
-					if pageNumberWanted == runData.GetNumPages() {
+					// If the page cursor is the same, then we've gone through all pages
+					if pageCursor == runData.GetNextCursor() || runData.GetNextCursor() == "" {
 						gotAllResults = true
 					} else {
+						pageCursor = runData.GetNextCursor()
 						pageNumberWanted++
 					}
 				}

--- a/pkg/runs/runsGet_test.go
+++ b/pkg/runs/runsGet_test.go
@@ -86,7 +86,6 @@ const (
 
 	EMPTY_RUNS_RESPONSE = `
 		{
-			"nextCursor": "",
 			"pageSize": 1,
 			"amountOfRuns": 0,
 			"runs":[]


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1921

## Changes
- Instead of iterating through page numbers, `runs get` now uses the cursor provided in responses from `/ras/runs` to go through pages of run results