### PR TITLE
CLI should handle long and multi-line property values better.

### DIFF
--- a/pkg/propertiesformatter/propertyFormatter.go
+++ b/pkg/propertiesformatter/propertyFormatter.go
@@ -37,6 +37,8 @@ const (
 	//namespaces display
 	HEADER_NAMESPACE      = "namespace"
 	HEADER_NAMESPACE_TYPE = "type"
+
+	PROPERTY_VALUE_MAX_VISIBLE_LENGTH = 60
 )
 
 type PropertyFormatter interface {
@@ -57,6 +59,19 @@ func calculateMaxLengthOfEachColumn(table [][]string) []int {
 		}
 	}
 	return columnLengths
+}
+
+func substituteNewLines(originalPropValue string) string {
+	newLinesReplacedValue := strings.Replace(originalPropValue, "\n", "\\n", -1)
+	return newLinesReplacedValue
+}
+
+func cropExtraLongValue(originalPropValue string) string {
+	croppedValue := originalPropValue
+	if len(originalPropValue) > PROPERTY_VALUE_MAX_VISIBLE_LENGTH {
+		croppedValue = originalPropValue[:PROPERTY_VALUE_MAX_VISIBLE_LENGTH] + `...(cropped)`
+	}
+	return croppedValue
 }
 
 func writeFormattedTableToStringBuilder(table [][]string, buff *strings.Builder, columnLengths []int) {

--- a/pkg/propertiesformatter/propertyFormatter_test.go
+++ b/pkg/propertiesformatter/propertyFormatter_test.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package propertiesformatter
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLongPropertyGetsCropped(t *testing.T) {
+	// For...
+	original := "012345678901234567890123456789012345678901234567890123456789-this-is-over-long"
+	expectedPropertyValue := "012345678901234567890123456789012345678901234567890123456789...(cropped)"
+
+	croppedValue := cropExtraLongValue(original)
+	// Then...
+	assert.Equal(t, croppedValue, expectedPropertyValue)
+}
+
+func TestShortPropertyGetsUnaffectedByCropping(t *testing.T) {
+	// For...
+	original := "this-is-short-enough-not-to-be-cropped"
+	expectedPropertyValue := original
+
+	croppedValue := cropExtraLongValue(original)
+	// Then...
+	assert.Equal(t, croppedValue, expectedPropertyValue)
+}
+
+func TestShortPropertyWithNewLinesGetsReplacedBySlashN(t *testing.T) {
+	// For...
+	original := "this-is-a-value\nspread-over-multiple\nlines"
+	expectedPropertyValue := "this-is-a-value\nspread-over-multiple\nlines"
+
+	croppedValue := cropExtraLongValue(original)
+	log.Print("original:" + original)
+	log.Print("cropped:" + croppedValue)
+	// Then...
+	assert.Equal(t, croppedValue, expectedPropertyValue)
+}

--- a/pkg/propertiesformatter/rawFormatter.go
+++ b/pkg/propertiesformatter/rawFormatter.go
@@ -29,7 +29,7 @@ func (*PropertyRawFormatter) GetName() string {
 }
 
 func (*PropertyRawFormatter) FormatProperties(cpsProperties []galasaapi.GalasaProperty) (string, error) {
-	var result string = ""
+	result := ""
 	buff := strings.Builder{}
 	var err error
 
@@ -40,7 +40,7 @@ func (*PropertyRawFormatter) FormatProperties(cpsProperties []galasaapi.GalasaPr
 
 		buff.WriteString(namespace + "|" +
 			name + "|" +
-			value + "\n")
+			substituteNewLines(value) + "\n")
 	}
 
 	result = buff.String()
@@ -48,7 +48,7 @@ func (*PropertyRawFormatter) FormatProperties(cpsProperties []galasaapi.GalasaPr
 }
 
 func (*PropertyRawFormatter) FormatNamespaces(namespaces []galasaapi.Namespace) (string, error) {
-	var result string = ""
+	result := ""
 	buff := strings.Builder{}
 	var err error
 

--- a/pkg/propertiesformatter/summaryFormatter.go
+++ b/pkg/propertiesformatter/summaryFormatter.go
@@ -48,7 +48,7 @@ func (*PropertySummaryFormatter) FormatProperties(cpsProperties []galasaapi.Gala
 			value := *property.Data.Value
 
 			line = append(line, namespace)
-			line = append(line, name, value)
+			line = append(line, name, cropExtraLongValue(substituteNewLines(value)))
 			table = append(table, line)
 		}
 

--- a/pkg/propertiesformatter/yamlFormatter.go
+++ b/pkg/propertiesformatter/yamlFormatter.go
@@ -47,6 +47,8 @@ func (*PropertyYamlFormatter) FormatProperties(cpsProperties []galasaapi.GalasaP
 		yamlRepresentationBytes, err = yaml.Marshal(property)
 		if err == nil {
 			yamlStr := string(yamlRepresentationBytes)
+
+			// TODO: Can anyone please explain why we do this substitution ? Wworried that if the value the user supplies has 'apiversion' inside it will get corrupted...
 			yamlStr = strings.ReplaceAll(yamlStr, "apiversion", "apiVersion")
 			propertyString += yamlStr
 		}

--- a/pkg/propertiesformatter/yamlFormatter.go
+++ b/pkg/propertiesformatter/yamlFormatter.go
@@ -31,7 +31,6 @@ func (*PropertyYamlFormatter) GetName() string {
 }
 
 func (*PropertyYamlFormatter) FormatProperties(cpsProperties []galasaapi.GalasaProperty) (string, error) {
-	var result string = ""
 	var err error
 	buff := strings.Builder{}
 	//totalProperties := len(cpsProperties)
@@ -48,7 +47,10 @@ func (*PropertyYamlFormatter) FormatProperties(cpsProperties []galasaapi.GalasaP
 		if err == nil {
 			yamlStr := string(yamlRepresentationBytes)
 
-			// TODO: Can anyone please explain why we do this substitution ? Wworried that if the value the user supplies has 'apiversion' inside it will get corrupted...
+			// The generated bean serialises in json as 'apiVersion' which is correct. In yaml it serialises as 'apiversion' (incorrect)
+			// So this is a hack to correct that failure.
+			// Note: This will corrupt any value string which also has 'apiversion' inside it !
+			// TODO: The fix is to change the bean and add a 'yaml' annotation so it gets rendered correctly. Golang has yaml annotations, but does the generator support them ?
 			yamlStr = strings.ReplaceAll(yamlStr, "apiversion", "apiVersion")
 			propertyString += yamlStr
 		}
@@ -56,6 +58,6 @@ func (*PropertyYamlFormatter) FormatProperties(cpsProperties []galasaapi.GalasaP
 		buff.WriteString(propertyString)
 	}
 
-	result = buff.String()
+	result := buff.String()
 	return result, err
 }


### PR DESCRIPTION
# Why ?
In order to cope with some .md markdown text we need the set/get properties to work well with properties which have newlines inside.

- super-long values can be set, but when displayed in summary view they get cropped with a `...(cropped)` string at the end. Newlines are replaced with `\n`.
- raw format shows new lines replaced with `\n`
- yaml format creates decent yaml, and accepts yaml with multiple-line input such as this:
```
piVersion: galasa-dev/v1alpha1
kind: GalasaProperty
metadata:
    namespace: mcobbett6
    name: markdown.test.1
data:
    value: |-
        # This is the title
        This is a line of text in the this is a longer description
        which spans multiple lines and 

        And happends to be very long.

        Here is an example of a list
        - one
        - two
        - three
        
        And a [link here](https://galasa.dev)
```