### PR TITLE
JVM launching -D parameters should be passed before the -jar parameter to have any effect

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -105,6 +105,16 @@
         "type": "Secret Keyword",
         "verified_result": null
       }
+    ],
+    "pkg/launcher/jvmLauncher_test.go": [
+      {
+        "hashed_secret": "c042bdfc4bc5516ec716afe9e85c173b614ff9f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 824,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
     ]
   },
   "version": "0.13.1+ibm.62.dss",

--- a/pkg/launcher/jvmLauncher.go
+++ b/pkg/launcher/jvmLauncher.go
@@ -667,13 +667,20 @@ func getCommandSyntax(
 
 		args = appendArgsBootstrapJvmLaunchOptions(args, bootstrapProperties)
 
-		args = append(args, "-jar")
-		args = append(args, bootJarPath)
-
+		// Note: Any -D properties are options for the JVM, so must appear before the -jar parameter.
+		// Parameters after the -jar parameter get passed into the 'main' of the launched java program.
 		args = append(args, "-Dfile.encoding=UTF-8")
 
 		nativeGalasaHomeFolderPath := galasaHome.GetNativeFolderPath()
 		args = append(args, `-DGALASA_HOME="`+nativeGalasaHomeFolderPath+`"`)
+
+		// If there is a jwt, pass it through.
+		if jwt != "" {
+			args = append(args, "-DGALASA_JWT="+jwt)
+		}
+
+		args = append(args, "-jar")
+		args = append(args, bootJarPath)
 
 		// --localmaven file://${M2_PATH}/repository/
 		// Note: URLs always have forward-slashes
@@ -725,10 +732,6 @@ func getCommandSyntax(
 			args = append(args, "--trace")
 		}
 
-		// If there is a jwt, pass it through.
-		if jwt != "" {
-			args = append(args, "-DGALASA_JWT="+jwt)
-		}
 	}
 
 	return cmd, args, err


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Overrides not being set properly. In my environment, it's because the `GALASA_HOME` environment variable, or the `--galasahome` parameter on `galasactl` is not being passed correctly to the JVM.
 
See the story driving this investigation here: https://github.com/galasa-dev/projectmanagement/issues/1916
