### PR TITLE
Change the CLI's base image to ubuntu so it has bash

### DIFF
--- a/dockerfiles/dockerfile.galasactl
+++ b/dockerfiles/dockerfile.galasactl
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/alpine:3.18.5
+FROM harbor.galasa.dev/docker_proxy_cache/library/ubuntu:20.04
 
 ARG platform
 


### PR DESCRIPTION
`bash` is needed to be able to run the CLI testing scripts from within the galasactl docker images. alpine does not have bash available, just sh.