### PR TITLE
Install ca certs into galasactl images

### DIFF
--- a/dockerfiles/dockerfile.galasactl
+++ b/dockerfiles/dockerfile.galasactl
@@ -1,5 +1,7 @@
 FROM harbor.galasa.dev/docker_proxy_cache/library/ubuntu:20.04
 
+RUN apt-get install -y ca-certificates
+
 ARG platform
 
 RUN addgroup galasa && \ 


### PR DESCRIPTION
Currently it cannot verify the cert of development.galasa.dev - Ubuntu image which is now used as the base image might not have this already set up.