### PR TITLE
mcobbett exit immediately when all tests done

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -121,7 +121,7 @@
         "hashed_secret": "c042bdfc4bc5516ec716afe9e85c173b614ff9f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 824,
+        "line_number": 829,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -170,6 +170,7 @@ func (cmd *RunsSubmitCommand) executeSubmit(
 			if err == nil {
 
 				timeService := factory.GetTimeService()
+				timedSleeper := utils.NewRealTimedSleeper()
 				var launcherInstance launcher.Launcher
 
 				// The launcher we are going to use to start/monitor tests.
@@ -190,7 +191,7 @@ func (cmd *RunsSubmitCommand) executeSubmit(
 
 						var console = factory.GetStdOutConsole()
 
-						submitter := runs.NewSubmitter(galasaHome, fileSystem, launcherInstance, timeService, env, console, images.NewImageExpanderNullImpl())
+						submitter := runs.NewSubmitter(galasaHome, fileSystem, launcherInstance, timeService, timedSleeper, env, console, images.NewImageExpanderNullImpl())
 
 						err = submitter.ExecuteSubmitRuns(cmd.values, cmd.values.TestSelectionFlagValues)
 					}

--- a/pkg/cmd/runsSubmitLocal.go
+++ b/pkg/cmd/runsSubmitLocal.go
@@ -187,6 +187,7 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 			if err == nil {
 
 				timeService := utils.NewRealTimeService()
+				timedSleeper := utils.NewRealTimedSleeper()
 
 				// the submit is targetting a local JVM
 				embeddedFileSystem := embedded.GetReadOnlyFileSystem()
@@ -205,7 +206,7 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 						factory,
 						bootstrapData.Properties, embeddedFileSystem,
 						cmd.values.runsSubmitLocalCmdParams,
-						processFactory, galasaHome, timeService)
+						processFactory, galasaHome, timedSleeper)
 
 					if err == nil {
 						var console = factory.GetStdOutConsole()
@@ -219,6 +220,7 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 							fileSystem,
 							launcherInstance,
 							timeService,
+							timedSleeper,
 							env,
 							console,
 							expander,

--- a/pkg/cmd/runsSubmitLocal.go
+++ b/pkg/cmd/runsSubmitLocal.go
@@ -205,7 +205,7 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 						factory,
 						bootstrapData.Properties, embeddedFileSystem,
 						cmd.values.runsSubmitLocalCmdParams,
-						processFactory, galasaHome)
+						processFactory, galasaHome, timeService)
 
 					if err == nil {
 						var console = factory.GetStdOutConsole()

--- a/pkg/launcher/jvmLauncher.go
+++ b/pkg/launcher/jvmLauncher.go
@@ -116,6 +116,7 @@ const (
 
 // NewJVMLauncher creates a JVM launcher. Primes it with references to services
 // which can be used to launch JVM servers.
+// We get the caller's timer service so we can interrupt the caller when we are done.
 func NewJVMLauncher(
 	factory spi.Factory,
 	bootstrapProps props.JavaProperties,
@@ -123,6 +124,8 @@ func NewJVMLauncher(
 	runsSubmitLocalCmdParams *RunsSubmitLocalCmdParameters,
 	processFactory ProcessFactory,
 	galasaHome spi.GalasaHome,
+	timeService spi.TimeService,
+
 ) (*JvmLauncher, error) {
 
 	var (
@@ -132,7 +135,6 @@ func NewJVMLauncher(
 
 	env := factory.GetEnvironment()
 	fileSystem := factory.GetFileSystem()
-	timeService := factory.GetTimeService()
 
 	javaHome := env.GetEnv("JAVA_HOME")
 

--- a/pkg/launcher/jvmLauncher_test.go
+++ b/pkg/launcher/jvmLauncher_test.go
@@ -110,7 +110,7 @@ func TestCanCreateAJVMLauncher(t *testing.T) {
 	launcher, err := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embedded.GetReadOnlyFileSystem(),
-		jvmLaunchParams, mockProcessFactory, galasaHome,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService,
 	)
 	if err != nil {
 		assert.Fail(t, "Constructor should not have failed but it did. error:%s", err.Error())
@@ -159,7 +159,7 @@ func TestCantCreateAJVMLauncherIfJVMHomeNotSet(t *testing.T) {
 	launcher, err := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embedded.GetReadOnlyFileSystem(),
-		jvmLaunchParams, mockProcessFactory, galasaHome,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService,
 	)
 	if err == nil {
 		assert.Fail(t, "Constructor should have failed but it did not.")
@@ -192,7 +192,7 @@ func TestCanCreateJvmLauncher(t *testing.T) {
 	launcher, err := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embedded.GetReadOnlyFileSystem(),
-		jvmLaunchParams, mockProcessFactory, galasaHome,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService,
 	)
 
 	if err != nil {
@@ -215,7 +215,7 @@ func TestCanLaunchLocalJvmTest(t *testing.T) {
 	launcher, err := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embeddedReadOnlyFS,
-		jvmLaunchParams, mockProcessFactory, galasaHome,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService,
 	)
 
 	if err != nil {
@@ -276,7 +276,7 @@ func TestCanGetRunGroupStatus(t *testing.T) {
 	launcher, err := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embedded.GetReadOnlyFileSystem(),
-		jvmLaunchParams, mockProcessFactory, galasaHome,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService,
 	)
 	if err != nil {
 		assert.Fail(t, "Launcher should have launched command OK")
@@ -424,7 +424,7 @@ func TestBadlyFormedObrFromProfileInfoCausesError(t *testing.T) {
 	launcher, _ := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embeddedReadOnlyFS,
-		jvmLaunchParams, mockProcessFactory, galasaHome)
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService)
 
 	isTraceEnabled := true
 	var overrides map[string]interface{} = make(map[string]interface{})
@@ -465,7 +465,7 @@ func TestNoObrsFromParameterOrProfileCausesError(t *testing.T) {
 	launcher, _ := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embeddedReadOnlyFS,
-		jvmLaunchParams, mockProcessFactory, galasaHome)
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService)
 
 	isTraceEnabled := true
 	var overrides map[string]interface{} = make(map[string]interface{})
@@ -1379,7 +1379,7 @@ func TestCanLaunchLocalJvmGherkinTest(t *testing.T) {
 	launcher, err := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embeddedReadOnlyFS,
-		jvmLaunchParams, mockProcessFactory, galasaHome,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService,
 	)
 
 	if err != nil {
@@ -1427,7 +1427,7 @@ func TestBadGherkinURLSuffixReturnsError(t *testing.T) {
 	launcher, err := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embeddedReadOnlyFS,
-		jvmLaunchParams, mockProcessFactory, galasaHome,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService,
 	)
 	if err != nil {
 		assert.Fail(t, "JVM launcher should have been creatable.")
@@ -1469,7 +1469,7 @@ func TestBadGherkinURLPrefixReutrnsError(t *testing.T) {
 	launcher, err := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embeddedReadOnlyFS,
-		jvmLaunchParams, mockProcessFactory, galasaHome,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService,
 	)
 
 	if err != nil {
@@ -1664,7 +1664,7 @@ func TestGetRunsByIdReturnsOk(t *testing.T) {
 	launcher, _ := NewJVMLauncher(
 		mockFactory,
 		bootstrapProps, embeddedReadOnlyFS,
-		jvmLaunchParams, mockProcessFactory, galasaHome,
+		jvmLaunchParams, mockProcessFactory, galasaHome, timeService,
 	)
 
 	isTraceEnabled := true

--- a/pkg/launcher/jvmLauncher_test.go
+++ b/pkg/launcher/jvmLauncher_test.go
@@ -1628,6 +1628,7 @@ func TestCreateRunFromLocalTestValidRasFolderPathReturnsOk(t *testing.T) {
 	assert.Equal(t, "dev.galasa.examples.banking.account", run.TestStructure.GetBundle())
 	assert.Equal(t, "Passed", run.TestStructure.GetResult())
 	assert.Equal(t, "simpleSampleTest", run.GetTestStructure().Methods[0].GetMethodName())
+	assert.Equal(t, "finished", run.TestStructure.GetStatus())
 }
 
 func TestCreateRunFromLocalTestInvalidRasFolderPathReturnsError(t *testing.T) {

--- a/pkg/launcher/localTest.go
+++ b/pkg/launcher/localTest.go
@@ -43,7 +43,7 @@ type LocalTest struct {
 	testRun *galasaapi.TestRun
 
 	// A time service. When a significant event occurs, we interrupt it.
-	timeService spi.TimeService
+	mainPollLoopSleeper spi.TimedSleeper
 
 	// The file system the local test deposits results onto.
 	// We use this to read the results back to find out if it passed/failed. ...etc.
@@ -55,7 +55,7 @@ type LocalTest struct {
 
 // A structure which tells us all we know about a JVM process we launched.
 func NewLocalTest(
-	timeService spi.TimeService,
+	mainPollLoopSleeper spi.TimedSleeper,
 	fileSystem spi.FileSystem,
 	processFactory ProcessFactory,
 ) *LocalTest {
@@ -66,7 +66,7 @@ func NewLocalTest(
 	localTest.stderr = bytes.NewBuffer([]byte{})
 	localTest.runId = ""
 	localTest.testRun = nil
-	localTest.timeService = timeService
+	localTest.mainPollLoopSleeper = mainPollLoopSleeper
 	localTest.fileSystem = fileSystem
 	localTest.processFactory = processFactory
 
@@ -197,7 +197,7 @@ func (localTest *LocalTest) waitForCompletion() error {
 	close(localTest.reportingChannel)
 
 	msg := fmt.Sprintf("Test run %s completed.", localTest.runId)
-	localTest.timeService.Interrupt(msg)
+	localTest.mainPollLoopSleeper.Interrupt(msg)
 
 	return err
 }

--- a/pkg/properties/propertiesGet.go
+++ b/pkg/properties/propertiesGet.go
@@ -49,7 +49,7 @@ func GetProperties(
 			chosenFormatter, err = validateOutputFormatFlagValue(propertiesOutputFormat, validPropertyFormatters)
 			if err == nil {
 				var cpsProperty []galasaapi.GalasaProperty
-				cpsProperty, err = getCpsPropertiesFromRestApi(namespace, name, prefix, suffix, infix, apiClient, console)
+				cpsProperty, err = getCpsPropertiesFromRestApi(namespace, name, prefix, suffix, infix, apiClient)
 
 				log.Printf("GetProperties - Galasa Properties collected: %s", getCpsPropertyArrayAsString(cpsProperty))
 				if err == nil {
@@ -77,7 +77,6 @@ func getCpsPropertiesFromRestApi(
 	suffix string,
 	infix string,
 	apiClient *galasaapi.APIClient,
-	console spi.Console,
 ) ([]galasaapi.GalasaProperty, error) {
 
 	var err error

--- a/pkg/runs/runsDownload_test.go
+++ b/pkg/runs/runsDownload_test.go
@@ -467,7 +467,6 @@ func TestRunsDownloadExistingFileForceOverwritesMultipleArtifactsToFileSystem(t 
 	mockFileSystem.WriteTextFile(runName+separator+"artifacts"+separator+"dummy.txt", "dummy text file")
 	mockFileSystem.WriteTextFile(runName+dummyRunLog.path, "dummy log")
 
-
 	// When...
 	err := DownloadArtifacts(runName, forceDownload, mockFileSystem, mockTimeService, mockConsole, apiClient, ".")
 
@@ -513,7 +512,6 @@ func TestRunsDownloadExistingFileNoForceReturnsError(t *testing.T) {
 	separator := string(os.PathSeparator)
 	mockFileSystem.WriteTextFile(runName+separator+"dummy.txt", "dummy text file")
 	mockFileSystem.WriteTextFile(runName+separator+"run.log", "dummy log")
-
 
 	// When...
 	err := DownloadArtifacts(runName, forceDownload, mockFileSystem, mockTimeService, mockConsole, apiClient, ".")
@@ -771,7 +769,7 @@ func TestRunsDownloadMultipleSetsOfUnrelatedReRunsWithCorrectOrderFolders(t *tes
 	apiServerUrl := server.URL
 	apiClient := api.InitialiseAPI(apiServerUrl)
 	mockTimeService := utils.NewMockTimeService()
-	mockTimeService.Sleep(time.Second)
+	mockTimeService.AdvanceClock(time.Second)
 
 	// When...
 	err := DownloadArtifacts(runName, forceDownload, mockFileSystem, mockTimeService, mockConsole, apiClient, ".")

--- a/pkg/runs/submitter.go
+++ b/pkg/runs/submitter.go
@@ -27,13 +27,14 @@ import (
 )
 
 type Submitter struct {
-	galasaHome  spi.GalasaHome
-	fileSystem  spi.FileSystem
-	launcher    launcher.Launcher
-	timeService spi.TimeService
-	env         spi.Environment
-	console     spi.Console
-	expander    images.ImageExpander
+	galasaHome   spi.GalasaHome
+	fileSystem   spi.FileSystem
+	launcher     launcher.Launcher
+	timeService  spi.TimeService
+	timedSleeper spi.TimedSleeper
+	env          spi.Environment
+	console      spi.Console
+	expander     images.ImageExpander
 }
 
 func NewSubmitter(
@@ -41,6 +42,7 @@ func NewSubmitter(
 	fileSystem spi.FileSystem,
 	launcher launcher.Launcher,
 	timeService spi.TimeService,
+	timedSleeper spi.TimedSleeper,
 	env spi.Environment,
 	console spi.Console,
 	expander images.ImageExpander,
@@ -50,6 +52,7 @@ func NewSubmitter(
 	instance.fileSystem = fileSystem
 	instance.launcher = launcher
 	instance.timeService = timeService
+	instance.timedSleeper = timedSleeper
 	instance.env = env
 	instance.console = console
 	instance.expander = expander
@@ -198,7 +201,7 @@ func (submitter *Submitter) executeSubmitRuns(
 		// Only sleep if there are runs in progress but not yet finished.
 		if len(submittedRuns) > 0 || len(rerunRuns) > 0 {
 			log.Printf("Sleeping for the poll interval of %v seconds\n", params.PollIntervalSeconds)
-			submitter.timeService.Sleep(pollInterval)
+			submitter.timedSleeper.Sleep(pollInterval)
 			log.Printf("Awake from poll interval sleep of %v seconds\n", params.PollIntervalSeconds)
 		}
 	}

--- a/pkg/runs/submitter.go
+++ b/pkg/runs/submitter.go
@@ -386,7 +386,11 @@ func (submitter *Submitter) runsFetchCurrentStatus(
 
 			// now check to see if it is finished
 			if currentRun.GetStatus() == "finished" {
+
 				finishedRuns[runName] = checkRun
+
+				checkRun.Status = *currentRun.Status
+
 				delete(submittedRuns, runName)
 
 				result := "unknown"
@@ -421,9 +425,9 @@ func (submitter *Submitter) runsFetchCurrentStatus(
 				}
 
 				if checkRun.GherkinUrl != "" {
-					log.Printf("Run %v has finished(%v) - %v\n", runName, result, checkRun.GherkinFeature)
+					log.Printf("Run %v has finished(%v) - %v (Gherkin)\n", runName, result, checkRun.GherkinFeature)
 				} else {
-					log.Printf("Run %v has finished(%v) - %v/%v/%v\n", runName, result, checkRun.Stream, checkRun.Bundle, checkRun.Class)
+					log.Printf("Run %v has finished(%v) - %v/%v/%v - %s\n", runName, result, checkRun.Stream, checkRun.Bundle, checkRun.Class, currentRun.GetStatus())
 				}
 			} else {
 				// Check to see if there was a status change

--- a/pkg/runs/submitter_test.go
+++ b/pkg/runs/submitter_test.go
@@ -22,6 +22,7 @@ func TestCanWriteAndReadBackThrottleFile(t *testing.T) {
 	env := utils.NewMockEnv()
 	mockLauncher := launcher.NewMockLauncher()
 	mockTimeService := utils.NewMockTimeService()
+	timedSleeper := utils.NewRealTimedSleeper()
 
 	galasaHome, _ := utils.NewGalasaHome(mockFileSystem, env, "")
 
@@ -32,6 +33,7 @@ func TestCanWriteAndReadBackThrottleFile(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		timedSleeper,
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -74,6 +76,7 @@ func TestReadBackThrottleFileFailsIfNoThrottleFileThere(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -105,6 +108,7 @@ func TestReadBackThrottleFileFailsIfFileContainsInvalidInt(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -132,6 +136,7 @@ func TestUpdateThrottleFromFileIfDifferentChangesValueWhenDifferent(t *testing.T
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -159,6 +164,7 @@ func TestUpdateThrottleFromFileIfDifferentDoesntChangeIfFileMissing(t *testing.T
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -195,6 +201,7 @@ func TestOverridesReadFromOverridesFile(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -234,6 +241,7 @@ func TestOverridesFileSpecifiedButDoesNotExist(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -268,6 +276,7 @@ func TestOverrideFileCorrectedWhenDefaultedAndOverridesFileNotExists(t *testing.
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -312,6 +321,7 @@ func TestOverrideFileCorrectedWhenDefaultedAndNoOverridesFileDoesExist(t *testin
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -343,6 +353,7 @@ func TestOverridesWithDashFileDontReadFromAnyFile(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -394,6 +405,7 @@ func TestValidateAndCorrectParametersSetsDefaultOverrideFile(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -447,6 +459,7 @@ func TestLocalLaunchCanUseAPortfolioOk(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -466,7 +479,7 @@ func TestLocalLaunchCanUseAPortfolioOk(t *testing.T) {
 		assert.Equal(t, obrName, launchesRecorded[0].ObrFromPortfolio)
 		assert.Equal(t, bundleName+"/"+className, launchesRecorded[0].ClassName)
 	}
-	assert.Contains(t, console.ReadText(), bundleName + "/" + className)
+	assert.Contains(t, console.ReadText(), bundleName+"/"+className)
 }
 
 func TestSubmitRunwithGherkinFile(t *testing.T) {
@@ -488,6 +501,7 @@ func TestSubmitRunwithGherkinFile(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -532,6 +546,7 @@ func TestGetPortfolioReturnsGherkinPortfolio(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -572,6 +587,7 @@ func TestGetReadyRunsFromPortfolioReturnsGherkinReadyRuns(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),
@@ -621,6 +637,7 @@ func TestSubmitRunsFromGherkinPortfolioOutputsFeatureNames(t *testing.T) {
 		mockFileSystem,
 		mockLauncher,
 		mockTimeService,
+		utils.NewRealTimedSleeper(),
 		env,
 		console,
 		images.NewImageExpanderNullImpl(),

--- a/pkg/spi/timeService.go
+++ b/pkg/spi/timeService.go
@@ -8,7 +8,5 @@ package spi
 import "time"
 
 type TimeService interface {
-	Sleep(duration time.Duration)
 	Now() time.Time
-	Interrupt(message string)
 }

--- a/pkg/spi/timedSleeper.go
+++ b/pkg/spi/timedSleeper.go
@@ -1,0 +1,16 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package spi
+
+import "time"
+
+// An encapsulation of code where one thread sleeps waiting for an event, but will timeout,
+// and another thread interrupts the sleeper.
+// This allows unit tests to simulate the interrupt easier in mock code without using separate threads.
+type TimedSleeper interface {
+	Sleep(duration time.Duration)
+	Interrupt(message string)
+}

--- a/pkg/utils/timeService.go
+++ b/pkg/utils/timeService.go
@@ -35,34 +35,6 @@ func NewRealTimeService() spi.TimeService {
 // 	log.Printf("timeService: %v stack trace : %s", *ts, buf[:bytesInStackTrace])
 // }
 
-const (
-	SECONDS_BETWEEN_INTERRUPTED_CHECKS  = 3
-	DURATION_BETWEEN_INTERRUPTED_CHECKS = SECONDS_BETWEEN_INTERRUPTED_CHECKS * time.Second
-)
-
-// Interrupts any timer sleeping.
-func (ts *timeService) Interrupt(message string) {
-	log.Printf("timeService: %v Interrupting the timing service sleeping. %s\n", *ts, message)
-	// ts.logStackTrace()
-	ts.interruptEventChannel <- "INTERRUPT: " + message
-}
-
-// Sleep for a bit. Waking up if anything calls the interrupt method.
-func (ts *timeService) Sleep(duration time.Duration) {
-
-	log.Printf("timeService: %v : sleep entered\n", *ts)
-	timer := time.After(duration)
-
-	select {
-	case msg := <-ts.interruptEventChannel:
-		log.Printf("timeService: %v : received interrupt message %s\n", *ts, msg)
-	case <-timer:
-		log.Printf("timeService: %v : sleep timed out\n", *ts)
-		// ts.logStackTrace()
-	}
-	// log.Printf("timeService: %v : sleep exiting\n", *ts)
-}
-
 // Retrieves the current time, with the location set to UTC.
 func (ts *timeService) Now() time.Time {
 	return time.Now().UTC()

--- a/pkg/utils/timeService.go
+++ b/pkg/utils/timeService.go
@@ -23,8 +23,6 @@ func NewRealTimeService() spi.TimeService {
 	}
 	log.Printf("timeService: %v created\n", service)
 
-	// service.logStackTrace()
-
 	return &service
 }
 

--- a/pkg/utils/timeService.go
+++ b/pkg/utils/timeService.go
@@ -28,13 +28,6 @@ func NewRealTimeService() spi.TimeService {
 	return &service
 }
 
-// func (ts *timeService) logStackTrace() {
-// 	// Print the stack trace.
-// 	buf := make([]byte, 1<<16)
-// 	bytesInStackTrace := runtime.Stack(buf, true)
-// 	log.Printf("timeService: %v stack trace : %s", *ts, buf[:bytesInStackTrace])
-// }
-
 // Retrieves the current time, with the location set to UTC.
 func (ts *timeService) Now() time.Time {
 	return time.Now().UTC()

--- a/pkg/utils/timeServiceMock.go
+++ b/pkg/utils/timeServiceMock.go
@@ -19,7 +19,7 @@ func NewMockTimeServiceAsMock(now time.Time) *MockTimeService {
 	return &MockTimeService{MockNow: now}
 }
 
-func NewMockTimeService() spi.TimeService {
+func NewMockTimeService() *MockTimeService {
 	return NewMockTimeServiceAsMock(time.Now())
 }
 
@@ -27,12 +27,7 @@ func NewOverridableMockTimeService(now time.Time) spi.TimeService {
 	return NewMockTimeServiceAsMock(now)
 }
 
-func (ts *MockTimeService) Interrupt(message string) {
-	// The mock timing service doesn't know how to be interrupted.
-}
-
-func (ts *MockTimeService) Sleep(duration time.Duration) {
-	// Do not sleep. Just advance the mock now time.
+func (ts *MockTimeService) AdvanceClock(duration time.Duration) {
 	ts.MockNow.Add(duration)
 }
 

--- a/pkg/utils/timedSleeper.go
+++ b/pkg/utils/timedSleeper.go
@@ -28,15 +28,12 @@ func NewRealTimedSleeper() spi.TimedSleeper {
 	}
 	log.Printf("timeService: %v created\n", service)
 
-	// service.logStackTrace()
-
 	return &service
 }
 
 // Interrupts any timer sleeping.
 func (ts *realTimedSleeper) Interrupt(message string) {
 	log.Printf("timeService: %v Interrupting the timing service sleeping. %s\n", *ts, message)
-	// ts.logStackTrace()
 	ts.interruptEventChannel <- "INTERRUPT: " + message
 }
 
@@ -51,7 +48,5 @@ func (ts *realTimedSleeper) Sleep(duration time.Duration) {
 		log.Printf("timeService: %v : received interrupt message %s\n", *ts, msg)
 	case <-timer:
 		log.Printf("timeService: %v : sleep timed out\n", *ts)
-		// ts.logStackTrace()
 	}
-	// log.Printf("timeService: %v : sleep exiting\n", *ts)
 }

--- a/pkg/utils/timedSleeper.go
+++ b/pkg/utils/timedSleeper.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package utils
+
+import (
+	"log"
+	"time"
+
+	"github.com/galasa-dev/cli/pkg/spi"
+)
+
+type realTimedSleeper struct {
+	interruptEventChannel chan string
+}
+
+const (
+	SECONDS_BETWEEN_INTERRUPTED_CHECKS  = 3
+	DURATION_BETWEEN_INTERRUPTED_CHECKS = SECONDS_BETWEEN_INTERRUPTED_CHECKS * time.Second
+)
+
+func NewRealTimedSleeper() spi.TimedSleeper {
+	service := realTimedSleeper{
+		// The interrupt channel has enough capacity for 100 events before anything blocks.
+		interruptEventChannel: make(chan string, 100),
+	}
+	log.Printf("timeService: %v created\n", service)
+
+	// service.logStackTrace()
+
+	return &service
+}
+
+// Interrupts any timer sleeping.
+func (ts *realTimedSleeper) Interrupt(message string) {
+	log.Printf("timeService: %v Interrupting the timing service sleeping. %s\n", *ts, message)
+	// ts.logStackTrace()
+	ts.interruptEventChannel <- "INTERRUPT: " + message
+}
+
+// Sleep for a bit. Waking up if anything calls the interrupt method.
+func (ts *realTimedSleeper) Sleep(duration time.Duration) {
+
+	log.Printf("timeService: %v : sleep entered\n", *ts)
+	timer := time.After(duration)
+
+	select {
+	case msg := <-ts.interruptEventChannel:
+		log.Printf("timeService: %v : received interrupt message %s\n", *ts, msg)
+	case <-timer:
+		log.Printf("timeService: %v : sleep timed out\n", *ts)
+		// ts.logStackTrace()
+	}
+	// log.Printf("timeService: %v : sleep exiting\n", *ts)
+}

--- a/test-scripts/run-single-test-remotely.sh
+++ b/test-scripts/run-single-test-remotely.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+export ORIGINAL_DIR=$(pwd)
+cd "${BASEDIR}"
+
+# export GALASA_HOME=${BASEDIR}/../temp/home
+
+# galasactl runs submit \
+# --class dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu \
+# --stream inttests \
+# --throttle 1 \
+# --poll 10 \
+# --progress 1 \
+# --noexitcodeontestfailures \
+# --log - \
+# --overridefile /Users/mcobbett/builds/galasa/code/src/github.com/galasa-dev/cli/temp/home/overrides.properties
+
+
+galasactl runs submit \
+--class dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu \
+--stream inttests \
+--throttle 1 \
+--poll 10 \
+--progress 1 \
+--noexitcodeontestfailures \
+--log - \
+--overridefile /Users/mcobbett/builds/galasa/code/src/github.com/galasa-dev/cli/temp/home/overrides.properties
+
+# galasactl runs prepare --portfolio my.portfolio --class dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu --stream inttests
+# galasactl runs submit --portfolio my.portfolio --log -

--- a/test-scripts/run-single-test-remotely.sh
+++ b/test-scripts/run-single-test-remotely.sh
@@ -9,20 +9,13 @@
 # Where is this script executing from ?
 BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
 export ORIGINAL_DIR=$(pwd)
-cd "${BASEDIR}"
 
-# export GALASA_HOME=${BASEDIR}/../temp/home
 
-# galasactl runs submit \
-# --class dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu \
-# --stream inttests \
-# --throttle 1 \
-# --poll 10 \
-# --progress 1 \
-# --noexitcodeontestfailures \
-# --log - \
-# --overridefile /Users/mcobbett/builds/galasa/code/src/github.com/galasa-dev/cli/temp/home/overrides.properties
+mkdir -p ${BASEDIR}/../temp/home
+cd ${BASEDIR}/../temp/home
+export GALASA_HOME=$(pwd)
 
+cd "${BASEDIR}/.."
 
 galasactl runs submit \
 --class dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu \
@@ -32,7 +25,7 @@ galasactl runs submit \
 --progress 1 \
 --noexitcodeontestfailures \
 --log - \
---overridefile /Users/mcobbett/builds/galasa/code/src/github.com/galasa-dev/cli/temp/home/overrides.properties
+--overridefile ${GALASA_HOME}/overrides.properties
 
 # galasactl runs prepare --portfolio my.portfolio --class dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu --stream inttests
 # galasactl runs submit --portfolio my.portfolio --log -


### PR DESCRIPTION
# Why ?
While investigating https://github.com/galasa-dev/projectmanagement/issues/2009 I noted that the CLI tool didn't exit the moment the last test completed. 
It used to but at some point it stopped doing that.

It turns out that 2 timer services were being created. One thread went to sleep on one, and the other thread woke up on the other. So the interrupt event never woke the sleeping thread.

Solution: Use a single sleep service, and separate the sleeper service from the time service so it's less likely in the future.

Also, using the golang select... and time.After(delay) is the recommended way of doing this stuff as of Golang 1.23. What I've coded does work, but prior to 1.23 may result in a timer resource leakage.

We need to uplift the golang requirement to 1.23 next to avoid any resource leakage.

- **Use timer service to wake up outer loop**
- **run status was never being reported properly for local runs. Only result was being copied over into the reported structure.**
- **Separated out the time service from the sleeper service.**
