### PR TITLE
Bump galasa-boot to 0.38.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@
 // into the code, so the code knows what versions of galasa it should be 
 // dealing with. Do not mess with the `def {variableName}` part of hte following 
 // lines, only change the versions we rely upon.
-def galasaBootJarVersion = '0.37.0'
+def galasaBootJarVersion = '0.38.0'
 def galasaFrameworkVersion = '0.38.0'
 
 // Right now, the REST interface spec is always the same version as the galasa framework bundles.


### PR DESCRIPTION
## Why?
Related to https://github.com/galasa-dev/galasa/pull/15

Note: Builds for this PR will fail until https://github.com/galasa-dev/galasa/pull/15 is delivered