### PR TITLE
set-version.sh should set version of boot jar also

### DIFF
--- a/pkg/cmd/projectCreate.go
+++ b/pkg/cmd/projectCreate.go
@@ -696,9 +696,10 @@ func createOBRFolderBuildGradle(fileGenerator *utils.FileGenerator, targetOBRFol
 	featureNames []string, forceOverwrite bool) error {
 
 	type OBRGradleParameters struct {
-		Parent      GradleCoordinates
-		Coordinates GradleCoordinates
-		Modules     []GradleCoordinates
+		Parent        GradleCoordinates
+		Coordinates   GradleCoordinates
+		Modules       []GradleCoordinates
+		GalasaVersion string
 	}
 
 	buildGradleTemplateParameters := OBRGradleParameters{
@@ -712,12 +713,19 @@ func createOBRFolderBuildGradle(fileGenerator *utils.FileGenerator, targetOBRFol
 			GroupId: packageName, Name: packageName + "." + featureName}
 	}
 
-	targetFile := utils.GeneratedFileDef{
-		FileType:                 "gradle",
-		TargetFilePath:           targetOBRFolderPath + "/build.gradle",
-		EmbeddedTemplateFilePath: "templates/projectCreate/parent-project/obr-project/build.gradle.template",
-		TemplateParameters:       buildGradleTemplateParameters}
+	var galasaVersion string
+	var err error
+	galasaVersion, err = embedded.GetGalasaVersion()
+	if err == nil {
+		buildGradleTemplateParameters.GalasaVersion = galasaVersion
 
-	err := fileGenerator.CreateFile(targetFile, forceOverwrite, true)
+		targetFile := utils.GeneratedFileDef{
+			FileType:                 "gradle",
+			TargetFilePath:           targetOBRFolderPath + "/build.gradle",
+			EmbeddedTemplateFilePath: "templates/projectCreate/parent-project/obr-project/build.gradle.template",
+			TemplateParameters:       buildGradleTemplateParameters}
+
+		err = fileGenerator.CreateFile(targetFile, forceOverwrite, true)
+	}
 	return err
 }

--- a/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/obr-project/build.gradle.template
@@ -1,9 +1,19 @@
+{{/*	
+	This template expects the following parameters:
+
+	type OBRGradleParameters struct {
+		Parent      GradleCoordinates
+		Coordinates GradleCoordinates
+		Modules     []GradleCoordinates
+        GalasaVersion string
+	}
+*/}}   
 // This section tells gradle which gradle plugins to use to build this project.
 plugins {
     id 'base'
     id 'maven-publish'
-    id 'dev.galasa.obr' version '0.36.0'
-    id 'dev.galasa.testcatalog' version '0.36.0'
+    id 'dev.galasa.obr' version '{{.GalasaVersion}}'
+    id 'dev.galasa.testcatalog' version '{{.GalasaVersion}}'
 }
 
 // Set the variables which will control what the built OSGi bundle will be called

--- a/pkg/embedded/templates/projectCreate/parent-project/pom.xml
+++ b/pkg/embedded/templates/projectCreate/parent-project/pom.xml
@@ -122,7 +122,7 @@
 				<plugin>
 					<groupId>dev.galasa</groupId>
 					<artifactId>galasa-maven-plugin</artifactId>
-					<version>0.34.0</version>
+					<version>{{.GalasaVersion}}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
+++ b/pkg/embedded/templates/projectCreate/parent-project/test-project/build.gradle.template
@@ -1,9 +1,23 @@
+{{/*	
+	This template expects the following parameters:
 
+	type ParentPomParameters struct {
+		Coordinates MavenCoordinates
+
+		// Version of Galasa we are targetting
+		GalasaVersion string
+
+		IsOBRRequired    bool
+		ObrName          string
+		ChildModuleNames []string
+		IsDevelopment    bool 
+	}
+*/}}
 // This section tells gradle which gradle plugins to use to build this project.
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'dev.galasa.tests' version '0.36.0'
+    id 'dev.galasa.tests' version '{{.GalasaVersion}}'
     id 'biz.aQute.bnd.builder' version '6.4.0'
 }
 

--- a/set-version.sh
+++ b/set-version.sh
@@ -24,7 +24,6 @@ export ORIGINAL_DIR=$(pwd)
 cd "${BASEDIR}/.."
 WORKSPACE_DIR=$(pwd)
 
-
 #-----------------------------------------------------------------------------------------                   
 #
 # Set Colors
@@ -110,7 +109,10 @@ function update_gradle_version {
     info "Using temporary file $temp_file"
     info "Updating file $source_file"
 
-    cat $source_file | sed "s/galasaFrameworkVersion[ ]*=.*$/galasaFrameworkVersion = '$component_version'/1" > $temp_file
+    cat $source_file \
+    | sed "s/galasaFrameworkVersion[ ]*=.*$/galasaFrameworkVersion = '$component_version'/1" \
+    | sed "s/galasaBootJarVersion[ ]*=.*$/galasaBootJarVersion = '$component_version'/1" \
+    > $temp_file
     rc=$?; if [[ "${rc}" != "0" ]]; then error "Failed to set version into $source_file file."; exit 1; fi
     cp $temp_file ${source_file}
     rc=$?; if [[ "${rc}" != "0" ]]; then error "Failed to overwrite new version of $source_file file."; exit 1; fi


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Every release will bump the version of the maven and gradle files up we need to use.

Similarly, a different version of the galasa BOM needs to be referred to in test code.

- [ ] Templatest changed
- [ ] Galasa version threaded down into templates
- [ ] Unit test added.