### PR TITLE
Use httpd:alpine image in galasactl-executables dockerfile

### DIFF
--- a/dockerfiles/dockerfile.galasactl-executables
+++ b/dockerfiles/dockerfile.galasactl-executables
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:2.4.59
+FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:alpine
 
 RUN rm -v /usr/local/apache2/htdocs/*
 COPY dockerfiles/httpdconf/base-httpd.conf /usr/local/apache2/conf/httpd.conf


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2057

httpd:2.4.59 contains several vulnerabilities, so switching over to use httpd:alpine instead.