### PR TITLE
massive amounts of duplicates shown by formatter due to labels being duplicated

### DIFF
--- a/pkg/runs/runsConverter.go
+++ b/pkg/runs/runsConverter.go
@@ -19,8 +19,6 @@ func orderFormattableTests(formattableTest []runsformatter.FormattableTest) []ru
 	//get slice of all result labels in ordered form
 	orderedResultLabels := getAvailableResultLabelsinOrder(formattableTest)
 
-	log.Printf("orderFormattableTests: ordered result labels: '%v': %v\n", len(orderedResultLabels), orderedResultLabels)
-
 	//formattableTest runs grouped by results
 	//map["passed"] = [run1, run2, ...]
 	runsGroupedByResultsMap := make(map[string][]runsformatter.FormattableTest)
@@ -30,12 +28,10 @@ func orderFormattableTests(formattableTest []runsformatter.FormattableTest) []ru
 
 	//append tests in order
 	for _, result := range orderedResultLabels {
-		log.Printf("Gathering test results under the '%v' label\n", result)
 		orderedFormattableTest = append(orderedFormattableTest, runsGroupedByResultsMap[result]...)
-		log.Printf("Now there are %v results in total\n", len(orderedFormattableTest))
 	}
 
-	log.Printf("Returning %v test results\n", len(orderedFormattableTest))
+	// log.Printf("Returning %v test results\n", len(orderedFormattableTest))
 	return orderedFormattableTest
 }
 

--- a/pkg/runs/runsConverter_test.go
+++ b/pkg/runs/runsConverter_test.go
@@ -436,3 +436,41 @@ func TestGherkinRunReturnsCorrectFormattableTestly(t *testing.T) {
 	assert.Equal(t, "Passed", output.Result)
 	assert.Equal(t, "myStatus", output.Status)
 }
+
+func TestGetAvailableResultLabelsInOrderWithNo2ExtraLabels(t *testing.T) {
+	testRun1 := runsformatter.FormattableTest{
+		Name:   "",
+		Bundle: "",
+		Status: "myStatus",
+		Result: "Passed",
+	}
+	testRun2 := runsformatter.FormattableTest{
+		Name:   "",
+		Bundle: "",
+		Status: "myStatus",
+		Result: "MyWeirdResultCode",
+	}
+	testRun3 := runsformatter.FormattableTest{
+		Name:   "",
+		Bundle: "",
+		Status: "myStatus",
+		Result: "MyWeirdResultalternativeCode",
+	}
+	testRun4 := runsformatter.FormattableTest{
+		Name:   "",
+		Bundle: "",
+		Status: "myStatus",
+		Result: "MyWeirdResultalternativeCode",
+	}
+	testRun5 := runsformatter.FormattableTest{
+		Name:   "",
+		Bundle: "",
+		Status: "myStatus",
+		Result: "MyWeirdResultalternativeCode",
+	}
+	testRunsArray := [5]runsformatter.FormattableTest{testRun1, testRun2, testRun3, testRun4, testRun5}
+	labelsGotBack := getAvailableResultLabelsinOrder(testRunsArray[:])
+
+	assert.NotEmpty(t, labelsGotBack)
+	assert.Equal(t, 7, len(labelsGotBack))
+}

--- a/pkg/runs/runsGet.go
+++ b/pkg/runs/runsGet.go
@@ -191,9 +191,7 @@ func GetRunDetailsFromRasSearchRuns(runs []galasaapi.Run, apiClient *galasaapi.A
 
 					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_QUERY_RUNS_NON_OK_STATUS, strconv.Itoa(httpResponse.StatusCode))
 				} else {
-					log.Printf("Adding those details into the list of runs. Length")
 					runsDetails = append(runsDetails, *details)
-					log.Printf("Now there are %v runs\n", len(runsDetails))
 				}
 			}
 		}

--- a/pkg/runs/runsGet.go
+++ b/pkg/runs/runsGet.go
@@ -89,11 +89,14 @@ func GetRuns(
 			if err == nil {
 				// Some formatters need extra fields filled-in so they can be displayed.
 				if chosenFormatter.IsNeedingMethodDetails() {
+					log.Println("This type of formatter needs extra detail about each run to display")
 					runJson, err = GetRunDetailsFromRasSearchRuns(runJson, apiClient)
 				}
 
 				if err == nil {
 					var outputText string
+
+					log.Printf("There are %v results to display in total.\n", len(runJson))
 
 					//convert galsaapi.Runs tests into formattable data
 					formattableTest := FormattableTestFromGalasaApi(runJson, apiServerUrl)
@@ -179,6 +182,7 @@ func GetRunDetailsFromRasSearchRuns(runs []galasaapi.Run, apiClient *galasaapi.A
 
 		for _, run := range runs {
 			runid := run.GetRunId()
+			log.Printf("Getting details for run %v\n", runid)
 			details, httpResponse, err = apiClient.ResultArchiveStoreAPIApi.GetRasRunById(context, runid).ClientApiVersion(restApiVersion).Execute()
 			if err != nil {
 				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_QUERY_RUNS_FAILED, err.Error())
@@ -187,7 +191,9 @@ func GetRunDetailsFromRasSearchRuns(runs []galasaapi.Run, apiClient *galasaapi.A
 
 					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_QUERY_RUNS_NON_OK_STATUS, strconv.Itoa(httpResponse.StatusCode))
 				} else {
+					log.Printf("Adding those details into the list of runs. Length")
 					runsDetails = append(runsDetails, *details)
+					log.Printf("Now there are %v runs\n", len(runsDetails))
 				}
 			}
 		}
@@ -267,11 +273,17 @@ func GetRunsFromRestApi(
 					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_QUERY_RUNS_FAILED, errString)
 				} else {
 
+					log.Printf("HTTP status was OK")
+
 					// Copy the results from this page into our bigger list of results.
 					runsOnThisPage := runData.GetRuns()
+					log.Printf("runsOnThisPage: %v", len(runsOnThisPage))
+
 					// Add all the runs into our set of results.
 					// Note: The ... syntax means 'all of the array', so they all get appended at once.
 					results = append(results, runsOnThisPage...)
+
+					log.Printf("total runs: %v", len(results))
 
 					// Have we processed the last page ?
 					if !runData.HasNextCursor() || len(runsOnThisPage) < int(runData.GetPageSize()) {
@@ -284,6 +296,8 @@ func GetRunsFromRestApi(
 			}
 		}
 	}
+
+	log.Printf("total runs returned: %v", len(results))
 
 	return results, err
 }

--- a/pkg/runs/submitter.go
+++ b/pkg/runs/submitter.go
@@ -200,9 +200,9 @@ func (submitter *Submitter) executeSubmitRuns(
 
 		// Only sleep if there are runs in progress but not yet finished.
 		if len(submittedRuns) > 0 || len(rerunRuns) > 0 {
-			log.Printf("Sleeping for the poll interval of %v seconds\n", params.PollIntervalSeconds)
+			// log.Printf("Sleeping for the poll interval of %v seconds\n", params.PollIntervalSeconds)
 			submitter.timedSleeper.Sleep(pollInterval)
-			log.Printf("Awake from poll interval sleep of %v seconds\n", params.PollIntervalSeconds)
+			// log.Printf("Awake from poll interval sleep of %v Gathering test results under theseconds\n", params.PollIntervalSeconds)
 		}
 	}
 

--- a/pkg/runsformatter/summaryFormatter.go
+++ b/pkg/runsformatter/summaryFormatter.go
@@ -5,7 +5,10 @@
  */
 package runsformatter
 
-import "strings"
+import (
+	"log"
+	"strings"
+)
 
 // -----------------------------------------------------
 // Summary format.
@@ -29,11 +32,13 @@ func (*SummaryFormatter) IsNeedingMethodDetails() bool {
 }
 
 func (*SummaryFormatter) FormatRuns(testResultsData []FormattableTest) (string, error) {
-	var result string = ""
+	var result string
 	var err error
 	buff := strings.Builder{}
 	totalResults := len(testResultsData)
 	resultCountsMap := initialiseResultMap()
+
+	log.Printf("Formatter passed %v runs to show.\n", len(testResultsData))
 
 	if totalResults > 0 {
 		var table [][]string

--- a/pkg/utils/timedSleeper.go
+++ b/pkg/utils/timedSleeper.go
@@ -40,13 +40,13 @@ func (ts *realTimedSleeper) Interrupt(message string) {
 // Sleep for a bit. Waking up if anything calls the interrupt method.
 func (ts *realTimedSleeper) Sleep(duration time.Duration) {
 
-	log.Printf("timeService: %v : sleep entered\n", *ts)
+	// log.Printf("timeService: %v : sleep entered\n", *ts)
 	timer := time.After(duration)
 
 	select {
 	case msg := <-ts.interruptEventChannel:
 		log.Printf("timeService: %v : received interrupt message %s\n", *ts, msg)
 	case <-timer:
-		log.Printf("timeService: %v : sleep timed out\n", *ts)
+		// log.Printf("timeService: %v : sleep timed out\n", *ts)
 	}
 }

--- a/test-galasactl-ecosystem.sh
+++ b/test-galasactl-ecosystem.sh
@@ -102,8 +102,13 @@ export GALASA_TEST_RUN_GET_EXPECTED_NUMBER_ARTIFACT_RUNNING_COUNT="10"
 CALLED_BY_MAIN="true"
 # Bootstrap is in the $bootstrap variable.
 
+
+
 source ${BASEDIR}/test-scripts/calculate-galasactl-executables.sh
 calculate_galasactl_executable
+
+source ${BASEDIR}/test-scripts/auth-tests.sh --bootstrap "${bootstrap}"
+auth_tests
 
 source ${BASEDIR}/test-scripts/runs-tests.sh --bootstrap "${bootstrap}"
 test_runs_commands
@@ -114,8 +119,7 @@ properties_tests
 source ${BASEDIR}/test-scripts/resources-tests.sh --bootstrap "${bootstrap}"
 resources_tests
 
-source ${BASEDIR}/test-scripts/auth-tests.sh --bootstrap "${bootstrap}"
-auth_tests
+
 
 # Test the hybrid configuration where the local test runs locally, but
 # draws it's CPS properties from a remote ecosystem via a REST extension.

--- a/test-scripts/auth-tests.sh
+++ b/test-scripts/auth-tests.sh
@@ -110,32 +110,6 @@ function auth_tokens_get_all_tokens_without_loginId {
 
 }
 
-function auth_tokens_get_with_missing_loginId_throws_error {
-
-    h2 "Performing auth tokens get with loginId: get..."
-    loginId=""
-
-    cmd="${BINARY_LOCATION} auth tokens get \
-    --user $loginId \
-    --bootstrap $bootstrap \
-    --log -
-    "
-
-    info "Command is: $cmd"
-
-    output_file="$ORIGINAL_DIR/temp/auth-get-output.txt"
-    set -o pipefail # Fail everything if anything in the pipeline fails. Else we are just checking the 'tee' return code.
-    $cmd | tee $output_file
-
-    rc=$?
-    if [[ "${rc}" != "1" ]]; then 
-        error "Failed to get access tokens due to missing login ID. Bad Request"
-        exit 1
-    fi
-
-    success "galasactl auth tokens get command correctly threw an error due to missing loginId"
-
-}
 
 function auth_tokens_get_all_tokens_by_loginId {
 
@@ -172,7 +146,6 @@ function auth_tokens_get_all_tokens_by_loginId {
 
 function auth_tests {
     auth_tokens_get_all_tokens_without_loginId
-    auth_tokens_get_with_missing_loginId_throws_error
     auth_tokens_get_all_tokens_by_loginId
 }
 

--- a/test-scripts/auth-tests.sh
+++ b/test-scripts/auth-tests.sh
@@ -92,7 +92,7 @@ function auth_tokens_get_all_tokens_without_loginId {
     "
 
     info "Command is: $cmd"
-
+    mkdir -p $ORIGINAL_DIR/temp
     output_file="$ORIGINAL_DIR/temp/auth-get-output.txt"
     $cmd | tee $output_file
     rc=$?
@@ -125,6 +125,7 @@ function auth_tokens_get_all_tokens_by_loginId {
     "
 
     info "Command is: $cmd"
+    mkdir -p $ORIGINAL_DIR/temp
     output_file="$ORIGINAL_DIR/temp/auth-get-output.txt"
 
     $cmd | tee $output_file

--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -834,7 +834,7 @@ function runs_get_check_raw_format_output_with_older_to_than_from_age {
 
 #--------------------------------------------------------------------------
 function runs_get_check_requestor_parameter {
-    requestor="galasadelivery@ibm.com"
+    requestor="Galasadelivery@ibm.com"
     h2 "Performing runs get with details format providing a from age and requestor as $requestor..."
 
     cd ${BASEDIR}/temp


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
https://github.com/galasa-dev/projectmanagement/issues/2049

The actual problem: The formatter thought '' (blank) was a custom label for the results.
If there were 30 tests with a '' result label, those 30 tests were shown 30 times.

Unit test added to verify that custom labels only get returned once.

Seems to work much better now.