### PR TITLE
Change secret names to non Galasa specific so relevant for forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,8 +116,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: galasa-team
-          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
+          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
   
       - name: Extract metadata for galasactl image
         id: metadata-galasactl
@@ -197,8 +197,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: galasa-team
-          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
+          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
 
       - name: Extract metadata for galasactl-ibm-testing image
         id: meta


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2085

Using secret names that are specific to the Galasa team means that when users fork this repository and set secrets in their forked repository, they have to set it to the same name which being Galasa specific, doesn't make sense. Updating the secret names to be more general so it makes sense for forked repos. Also removing the hard coded use of the `galasa-team` user as forks won't/shouldn't use this user.