### PR TITLE
Iss2084 - Use Platform versions for CLI dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,9 @@ $(GENERATED_BUILD_PROPERTIES_FILE) : VERSION pkg/embedded/templates/version Make
 	# Turn the contents of VERSION file into a properties file value.
 	cat VERSION | sed "s/^/galasactl.version = /1" >> $@ ; echo "" >> $@
 	# Add the `galasa.boot.jar.version` property based on the build.gradle value.
-	cat build.gradle | grep "def galasaBootJarVersion" | cut -f2 -d\' | sed "s/^/galasa.boot.jar.version = /" >> $@
+	cat build.gradle | grep "def galasaVersion" | cut -f2 -d\' | sed "s/^/galasa.boot.jar.version = /" >> $@
 	# Add the `galasa.framework.version` property based on the build.gradle value.
-	cat build.gradle | grep "def galasaFrameworkVersion" | cut -f2 -d\' | sed "s/^/galasa.framework.version = /" >> $@
+	cat build.gradle | grep "def galasaVersion" | cut -f2 -d\' | sed "s/^/galasa.framework.version = /" >> $@
 	# Add the `galasactl.rest.api.version` property based on the build/dependencies/openapi.yaml value.
 	echo "" >> $@
 	echo "# version of the rest api that is compiled and the client is expecting from the ecosystem." >> $@

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -58,7 +58,7 @@ EOF
 
 #--------------------------------------------------------------------------
 function read_boot_jar_version {
-    export BOOT_JAR_VERSION=$(cat ${BASEDIR}/build.gradle | grep "galasaBootJarVersion[ ]*=" | cut -f2 -d"'" )
+    export BOOT_JAR_VERSION=$(cat ${BASEDIR}/build.gradle | grep "galasaVersion[ ]*=" | cut -f2 -d"'" )
     info "Boot jar version is $BOOT_JAR_VERSION"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,15 +10,12 @@
 //   So we need to get hold of a generator tool so we can 
 //
 
-// Note: The following versions are picked up by the build process and fed
+// Note: The following version is picked up by the build process and fed
 // into the code, so the code knows what versions of galasa it should be 
-// dealing with. Do not mess with the `def {variableName}` part of hte following 
+// dealing with. Do not mess with the `def {variableName}` part of the following 
 // lines, only change the versions we rely upon.
-def galasaBootJarVersion = '0.39.0'
-def galasaFrameworkVersion = '0.39.0'
 
-// Right now, the REST interface spec is always the same version as the galasa framework bundles.
-def galasaOpenApiYamlVersion = galasaFrameworkVersion
+def galasaVersion = '0.39.0'
 
 repositories {
     gradlePluginPortal()
@@ -30,15 +27,18 @@ repositories {
 }
 apply plugin: 'java'
 dependencies {
+    // Use dev.galasa.platform to obtain the versions
+    implementation platform('dev.galasa:dev.galasa.platform:0.39.0')
     // We need the galasa-boot jar so we can launch tests in a local JVM
-    implementation 'dev.galasa:galasa-boot:' + galasaBootJarVersion
+    implementation 'dev.galasa:galasa-boot'
     // We need the openapi generator to turn a yaml file into go client stubs, 
     // so we can call the api server REST services
     // https://mvnrepository.com/artifact/org.openapitools/openapi-generator
-    implementation 'org.openapitools:openapi-generator-cli:6.6.0'
+    implementation 'org.openapitools:openapi-generator-cli'
 
     // Download the openapi.yaml specification for the REST APIs.
-    compileOnly group: "dev.galasa", name: "dev.galasa.framework.api.openapi", version: "$galasaOpenApiYamlVersion", ext: "yaml"
+    // The REST interface spec is always the same version as the Galasa version.
+    compileOnly group: "dev.galasa", name: "dev.galasa.framework.api.openapi", ext: "yaml"
 }
 
 
@@ -53,7 +53,7 @@ task downloadRawDependencies(type: Copy) {
 task downloadDependencies(type: Copy) {
     // Rename the complex openapi.yaml file into something easier to use elsewhere.
     // So the path to the new file is build/dependencies/openapi.yaml
-    from "build/dependencies/dev.galasa.framework.api.openapi-${galasaOpenApiYamlVersion}.yaml"
+    from "build/dependencies/dev.galasa.framework.api.openapi-${galasaVersion}.yaml"
     into "build/dependencies"
     rename { fileName -> "openapi.yaml" }
     dependsOn downloadRawDependencies
@@ -63,7 +63,7 @@ task downloadDependencies(type: Copy) {
 task installJarsIntoTemplates(type: Copy) {
     // We want to embed some files into the executable.
     // Copy the files into the go templates folder.
-    from layout.buildDirectory.file("dependencies/galasa-boot-"+galasaBootJarVersion+".jar")
+    from layout.buildDirectory.file("dependencies/galasa-boot-"+galasaVersion+".jar")
     into layout.buildDirectory.dir("../pkg/embedded/templates/galasahome/lib")
     dependsOn downloadDependencies
 }

--- a/set-galasa-boot-version.sh
+++ b/set-galasa-boot-version.sh
@@ -103,7 +103,7 @@ function update_build_gradle_version {
     info "Using temporary file $temp_file"
     info "Updating file $source_file"
 
-    cat $source_file | sed "s/galasaBootJarVersion[ ]*=.*$/galasaBootJarVersion = '$component_version'/1" > $temp_file
+    cat $source_file | sed "s/galasaVersion[ ]*=.*$/galasaVersion = '$component_version'/1" > $temp_file
     rc=$?; if [[ "${rc}" != "0" ]]; then error "Failed to set version into $source_file file."; exit 1; fi
     cp $temp_file ${source_file}
     rc=$?; if [[ "${rc}" != "0" ]]; then error "Failed to overwrite new version of $source_file file."; exit 1; fi

--- a/set-version.sh
+++ b/set-version.sh
@@ -110,8 +110,8 @@ function update_gradle_version {
     info "Updating file $source_file"
 
     cat $source_file \
-    | sed "s/galasaFrameworkVersion[ ]*=.*$/galasaFrameworkVersion = '$component_version'/1" \
-    | sed "s/galasaBootJarVersion[ ]*=.*$/galasaBootJarVersion = '$component_version'/1" \
+    | sed "s/galasaVersion[ ]*=.*$/galasaVersion = '$component_version'/1" \
+    | sed "s/dev.galasa.platform:.*$/dev.galasa.platform:$component_version')/1" \
     > $temp_file
     rc=$?; if [[ "${rc}" != "0" ]]; then error "Failed to set version into $source_file file."; exit 1; fi
     cp $temp_file ${source_file}

--- a/test-locally.sh
+++ b/test-locally.sh
@@ -195,7 +195,7 @@ export TEST_OBR_VERSION=0.0.1-SNAPSHOT
 
 
 # Could get this bootjar from https://development.galasa.dev/main/maven-repo/obr/dev/galasa/galasa-boot/0.27.0/
-export BOOT_JAR_VERSION=$(cat ${BASEDIR}/build.gradle | grep "galasaBootJarVersion" | head -1 | cut -f2 -d"'")
+export BOOT_JAR_VERSION=$(cat ${BASEDIR}/build.gradle | grep "galasaVersion" | head -1 | cut -f2 -d"'")
 
 export OBR_VERSION=$(cat ${BASEDIR}/VERSION)
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2084

- Remove hard coded versions from the CLI's dependencies as it should get them from dev.galasa.platform.
- Now that all Galasa versions are kept the same, replaced "galasaBootJarVersion" and "galasaFrameworkVersion" with just one "galasaVersion"
- Updated Makefile, build locally, test locally, and set version scripts to support the above change
- Add upgrade of the dev.galasa.platform into the set-version script

**Important**: The build of this PR will fail until https://github.com/galasa-dev/galasa/pull/118 is merged and has been deployed, as the CLI won't be able to find its artifacts in the Platform yet.