### PR TITLE
Log messages may have CRLF or LF or CR characters. All converted to \n prior to logging to console

### DIFF
--- a/pkg/launcher/jvmOutputProcessor.go
+++ b/pkg/launcher/jvmOutputProcessor.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"regexp"
 	"strings"
+
+	"github.com/galasa-dev/cli/pkg/utils"
 )
 
 // JVMOutputProcessor Sometjing which pretends to be an io.Writer interface implementation,
@@ -74,10 +76,16 @@ func (processor *JVMOutputProcessor) Write(bytesToWrite []byte) (int, error) {
 		// "d.g.f.FrameworkInitialisation - Allocated Run Name U525 to this run"
 		stringToSearch := string(bytesToWrite)
 		jvmStringNoTrailingNewline := strings.TrimSpace(stringToSearch)
+
+		// Golang doesn't like printing 0x0d characters, it would rather they are 0x0a characters instead.
+		// So for the purposes of echoing a log record to the terminal, do the conversion so it
+		// comes out correctly.
+		stringToLog := utils.StringWithNewLinesInsteadOfCRLFs(jvmStringNoTrailingNewline)
+
 		if processor.detectedRunId != "" {
-			log.Printf("JVM output: (runid:%s) : %s\n", processor.detectedRunId, jvmStringNoTrailingNewline)
+			log.Printf("JVM output: (runid:%s) : %s\n", processor.detectedRunId, stringToLog)
 		} else {
-			log.Printf("JVM output: %s\n", jvmStringNoTrailingNewline)
+			log.Printf("JVM output: %s\n", stringToLog)
 		}
 
 		isAlertable := false

--- a/pkg/utils/crlf.go
+++ b/pkg/utils/crlf.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package utils
+
+import (
+	"bytes"
+)
+
+// Walks throught the input string and converts :
+// 0x0d characters to 0x0a (NewLine) characters
+// 0x0d 0x0c (CR-LF) to 0x0a (NewLine) characters
+//
+// so that the entire string can be printed using Golang printf/println without
+// line endings being mangled.
+func StringWithNewLinesInsteadOfCRLFs(input string) string {
+
+	inputLength := len(input)
+
+	var buff bytes.Buffer = *bytes.NewBufferString("")
+	var inputIndex int
+
+	for inputIndex < inputLength {
+
+		thisChar := input[inputIndex]
+		var nextChar byte
+		if inputIndex+1 < inputLength {
+			nextChar = input[inputIndex+1]
+		}
+
+		var outChar byte
+		if (thisChar == '\r' && nextChar == '\f') || (thisChar == '\f' && nextChar == '\r') {
+			outChar = '\n'
+			inputIndex += 2
+		} else if thisChar == '\r' || thisChar == '\f' {
+			outChar = '\n'
+			inputIndex += 1
+		} else {
+			outChar = thisChar
+			inputIndex += 1
+		}
+
+		buff.WriteString(string(outChar))
+	}
+
+	output := buff.String()
+
+	return output
+}

--- a/pkg/utils/crlf_test.go
+++ b/pkg/utils/crlf_test.go
@@ -36,9 +36,23 @@ func TestCRLFtoLFReplacesSingleCRWithNewLine(t *testing.T) {
 	assert.Equal(t, expected, output)
 }
 
+func TestCRLFtoLFReplacesSingleCRAtEndOfLineWithNewLine(t *testing.T) {
+	input := "my test string\r"
+	expected := "my test string\n"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, expected, output)
+}
+
 func TestCRLFtoLFReplacesSingleCRLFWithNewLine(t *testing.T) {
 	input := "my test string\f\rwith multiple lines"
 	expected := "my test string\nwith multiple lines"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, expected, output)
+}
+
+func TestCRLFtoLFReplacesSingleCRLFAtEndOfLinbeWithNewLine(t *testing.T) {
+	input := "my test string\f\r"
+	expected := "my test string\n"
 	output := StringWithNewLinesInsteadOfCRLFs(input)
 	assert.Equal(t, expected, output)
 }
@@ -50,9 +64,23 @@ func TestCRLFtoLFReplacesSingleLFCRWithNewLine(t *testing.T) {
 	assert.Equal(t, expected, output)
 }
 
+func TestCRLFtoLFReplacesSingleAtEndOfLineLFCRWithNewLine(t *testing.T) {
+	input := "my test string\r\f"
+	expected := "my test string\n"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, expected, output)
+}
+
 func TestCRLFtoLFReplacesSinglCRWithNewLine(t *testing.T) {
 	input := "my test string\fwith multiple lines"
 	expected := "my test string\nwith multiple lines"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, expected, output)
+}
+
+func TestCRLFtoLFReplacesSinglCRAtEndOfLineWithNewLine(t *testing.T) {
+	input := "my test string\f"
+	expected := "my test string\n"
 	output := StringWithNewLinesInsteadOfCRLFs(input)
 	assert.Equal(t, expected, output)
 }

--- a/pkg/utils/crlf_test.go
+++ b/pkg/utils/crlf_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCRLFtoLFdoesNotCorruptANormalMultiLineString(t *testing.T) {
+	input := "my test string\nwith multiple lines"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, input, output)
+}
+
+func TestCRLFtoLFdoesNotCorruptANormalSingleLineString(t *testing.T) {
+	input := "my test string"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, input, output)
+}
+
+func TestCRLFtoLFdoesNotCorruptANormalSingleLineStringWithANewLine(t *testing.T) {
+	input := "my test string\n"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, input, output)
+}
+
+func TestCRLFtoLFReplacesSingleCRWithNewLine(t *testing.T) {
+	input := "my test string\rwith multiple lines"
+	expected := "my test string\nwith multiple lines"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, expected, output)
+}
+
+func TestCRLFtoLFReplacesSingleCRLFWithNewLine(t *testing.T) {
+	input := "my test string\f\rwith multiple lines"
+	expected := "my test string\nwith multiple lines"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, expected, output)
+}
+
+func TestCRLFtoLFReplacesSingleLFCRWithNewLine(t *testing.T) {
+	input := "my test string\r\fwith multiple lines"
+	expected := "my test string\nwith multiple lines"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, expected, output)
+}
+
+func TestCRLFtoLFReplacesSinglCRWithNewLine(t *testing.T) {
+	input := "my test string\fwith multiple lines"
+	expected := "my test string\nwith multiple lines"
+	output := StringWithNewLinesInsteadOfCRLFs(input)
+	assert.Equal(t, expected, output)
+}


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
See issues [log.info crops last line of input, but not in the run.log #2088](https://github.com/galasa-dev/projectmanagement/issues/2088)

When the string being logged has a CR, LF, or CRLF combination, it doesn't get written out as a /n by default.

