### PR TITLE
Add http status codes and causes to errors related to API server comms

### DIFF
--- a/pkg/api/bootstrap.go
+++ b/pkg/api/bootstrap.go
@@ -64,7 +64,7 @@ func (*RealUrlResolutionService) Get(url string) (string, error) {
 
 		statusCode := resp.StatusCode
 		if statusCode != http.StatusOK {
-			err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESP_UNEXPECTED_ERROR, err)
+			err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESP_UNEXPECTED_ERROR)
 		} else {
 			buffer := new(strings.Builder)
 			_, err = io.Copy(buffer, resp.Body)

--- a/pkg/api/bootstrap.go
+++ b/pkg/api/bootstrap.go
@@ -62,10 +62,17 @@ func (*RealUrlResolutionService) Get(url string) (string, error) {
 		// Make sure the http response is closed (eventually).
 		defer resp.Body.Close()
 
-		buffer := new(strings.Builder)
-		_, err = io.Copy(buffer, resp.Body)
-		if err == nil {
-			contents = buffer.String()
+		statusCode := resp.StatusCode
+		if statusCode != http.StatusOK {
+			err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESP_UNEXPECTED_ERROR, err)
+		} else {
+			buffer := new(strings.Builder)
+			_, err = io.Copy(buffer, resp.Body)
+			if err == nil {
+				contents = buffer.String()
+			} else {
+				err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_UNABLE_TO_READ_RESPONSE_BODY, err)
+			}
 		}
 	}
 	return contents, err
@@ -224,7 +231,7 @@ func loadBootstrapFromUrl(path string, defaultApiServerURL string,
 		bootstrapContents, err = urlResolutionService.Get(path)
 		if err != nil {
 			// Wrap any http error as a galasa error.
-			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_GET_BOOTSTRAP, path, err.Error())
+			err = galasaErrors.NewGalasaErrorWithCause(err, galasaErrors.GALASA_ERROR_FAILED_TO_GET_BOOTSTRAP, path, err.Error())
 		} else {
 			// read the lines and extract the properties
 			//	fmt.Printf("bootstrap contents:-\n%v\n", bootstrapString.String())

--- a/pkg/auth/authTokensGet.go
+++ b/pkg/auth/authTokensGet.go
@@ -56,11 +56,16 @@ func getAuthTokensFromRestApi(apiClient *galasaapi.APIClient, loginId string) ([
 
 		tokens, resp, err = apiCall.Execute()
 
+		var statusCode int
+		if resp != nil {
+			defer resp.Body.Close()
+			statusCode = resp.StatusCode
+		}
+
 		if err != nil {
 			log.Println("getAuthTokensFromRestApi - Failed to retrieve list of tokens from API server")
-			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RETRIEVING_TOKEN_LIST_FROM_API_SERVER, err.Error())
+			err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RETRIEVING_TOKEN_LIST_FROM_API_SERVER, err.Error())
 		} else {
-			defer resp.Body.Close()
 			authTokens = tokens.GetTokens()
 			log.Printf("getAuthTokensFromRestApi -  %v tokens collected", len(authTokens))
 		}

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -143,11 +143,17 @@ func (authenticator *authenticatorImpl) getJwtFromRestApi(apiServerUrl string, a
 			AuthProperties(authProperties).
 			ClientApiVersion(restApiVersion).
 			Execute()
+
+		var statusCode int
+		if httpResponse != nil {
+			defer httpResponse.Body.Close()
+			statusCode = httpResponse.StatusCode
+		}
+
 		if err != nil {
 			log.Println("Failed to retrieve bearer token from API server")
-			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RETRIEVING_BEARER_TOKEN_FROM_API_SERVER, err.Error())
+			err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RETRIEVING_BEARER_TOKEN_FROM_API_SERVER, err.Error())
 		} else {
-			defer httpResponse.Body.Close()
 			log.Println("Bearer token received from API server OK")
 			jwt = tokenResponse.GetJwt()
 		}

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -8,6 +8,7 @@ package errors
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -47,6 +48,11 @@ func NewMessageType(template string, ordinal int, isStackTraceWanted bool) *Mess
 type GalasaError struct {
 	msgType *MessageType
 	message string
+	httpStatus int
+}
+
+type GalasaCommsError interface {
+	isRetryRequired() bool
 }
 
 func (err *GalasaError) GetMessageType() *MessageType {
@@ -71,10 +77,21 @@ func NewGalasaError(msgType *MessageType, params ...interface{}) *GalasaError {
 	return galasaError
 }
 
+func NewGalasaErrorWithHttpStatusCode(httpStatusCode int, msgType *MessageType, params ...interface{}) *GalasaError {
+	err := NewGalasaError(msgType, params...)
+	err.httpStatus = httpStatusCode
+	return err
+}
+
 // Render a galasa error into a string, so the GalasaError structure can be used
 // as a normal error.
 func (err *GalasaError) Error() string {
 	return err.message
+}
+
+func (err *GalasaError) isRetryRequired() bool {
+	isRetryRequired := true 
+	return isRetryRequired 
 }
 
 const (

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -59,10 +59,6 @@ type GalasaError struct {
 	cause error
 }
 
-type GalasaCommsError interface {
-	isRetryRequired() bool
-}
-
 func (err *GalasaError) GetMessageType() *MessageType {
 	return err.msgType
 }

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -8,7 +8,6 @@ package errors
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"strconv"
 	"strings"
 )
@@ -57,6 +56,10 @@ type GalasaCommsError interface {
 
 func (err *GalasaError) GetMessageType() *MessageType {
 	return err.msgType
+}
+
+func (err *GalasaError) GetHttpStatusCode() int {
+	return err.httpStatus
 }
 
 // NewGalasaError creates a new GalasaError structure.

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -125,11 +125,6 @@ func (err *GalasaError) Error() string {
 	return err.message
 }
 
-func (err *GalasaError) isRetryRequired() bool {
-	isRetryRequired := true 
-	return isRetryRequired 
-}
-
 const (
 	STACK_TRACE_WANTED     = true
 	STACK_TRACE_NOT_WANTED = false
@@ -255,7 +250,7 @@ var (
 	GALASA_ERROR_UNABLE_TO_MARSHAL_INTO_JSON             = NewMessageType("GAL1112E: Error converting the parsed yaml content into a json payload for the http request. Reason: '%s'", 1112, STACK_TRACE_WANTED)
 	GALASA_ERROR_RESOURCES_RESP_BAD_REQUEST              = NewMessageType("GAL1113E: Failure reported by the Galasa Ecosystem. The Ecosystem believes there is a problem with this client program or the user input. Errors returned: '%s'", 1113, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_RESOURCES_RESP_SERVER_ERROR             = NewMessageType("GAL1114E: The resources operation failed due to a problem on the server. Collect a log with the --log option and contact your Galasa Ecosystem adminstrator.", 1114, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_RESOURCES_RESP_UNEXPECTED_ERROR         = NewMessageType("GAL1115E: An unexpected response was received from the Galasa Ecosystem. Collect a log with the --log option and contact your Galasa Ecosystem adminstrator.", 1115, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_RESP_UNEXPECTED_ERROR                   = NewMessageType("GAL1115E: An unexpected response was received from the Galasa Ecosystem. Collect a log with the --log option and contact your Galasa Ecosystem adminstrator.", 1115, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_UNABLE_TO_READ_RESPONSE_BODY            = NewMessageType("GAL1116E: Error reading the HTTP Response body. Reason: '%s'", 1116, STACK_TRACE_WANTED)
 	GALASA_ERROR_DELETE_PROPERTY_RESPONSE_PARSING        = NewMessageType("GAL1117E: The delete operation failed. Unable to process the error information returned from the server.", 1117, STACK_TRACE_WANTED)
 	GALASA_ERROR_RESOURCE_RESPONSE_PARSING               = NewMessageType("GAL1118E: The resource operation failed. Unable to process the error information returned from the server. Reason: '%s'", 1118, STACK_TRACE_WANTED)

--- a/pkg/errors/galasaAPIError.go
+++ b/pkg/errors/galasaAPIError.go
@@ -14,22 +14,6 @@ import (
 	"github.com/galasa-dev/cli/pkg/spi"
 )
 
-type WrappedGalasaError struct {
-	HttpStatusCode int
-	GalasaError error
-}
-
-func NewWrappedGalasaError(httpStatusCode int, galasaError error) *WrappedGalasaError {
-	return &WrappedGalasaError{
-		HttpStatusCode: httpStatusCode,
-		GalasaError: galasaError,
-	}
-}
-
-func (err *WrappedGalasaError) Error() string {
-	return err.GalasaError.Error()
-}
-
 type GalasaAPIError struct {
 	Code    int    `json:"error_code"`
 	Message string `json:"error_message"`

--- a/pkg/errors/galasaAPIError_test.go
+++ b/pkg/errors/galasaAPIError_test.go
@@ -7,6 +7,7 @@
 package errors
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,11 +19,12 @@ func TestGetApiErrorEmptyParsesInputOk(t *testing.T) {
 	bodyString := `{}`
 
 	bodyBytes := []byte(bodyString)
+	statusCode := http.StatusInternalServerError
 
 	var err error
 
 	// When
-	_, err = GetApiErrorFromResponse(bodyBytes)
+	_, err = GetApiErrorFromResponse(statusCode, bodyBytes)
 
 	// Then
 	assert.Nil(t, err, "GetApiErrorFromResponse, empty body failed with a non-nil error!")
@@ -37,12 +39,13 @@ func TestGetApiErrorSingleJsonObjectsParsesInputOk(t *testing.T) {
         }`
 
 	bodyBytes := []byte(bodyString)
+	statusCode := http.StatusInternalServerError
 
 	var parsedError *GalasaAPIError
 	var err error
 
 	// When
-	parsedError, err = GetApiErrorFromResponse(bodyBytes)
+	parsedError, err = GetApiErrorFromResponse(statusCode, bodyBytes)
 
 	// Then
 	assert.Nil(t, err, "NewGalasaApiErrorsArray failed with a non-nil error!")

--- a/pkg/launcher/remoteLauncher.go
+++ b/pkg/launcher/remoteLauncher.go
@@ -53,7 +53,10 @@ func (launcher *RemoteLauncher) GetRunsByGroup(groupName string) (*galasaapi.Tes
 	)
 	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 	if err == nil {
-		testRuns, _, err = launcher.apiClient.RunsAPIApi.GetRunsGroup(context.TODO(), groupName).ClientApiVersion(restApiVersion).Execute()
+		var httpResponse *http.Response
+		testRuns, httpResponse, err = launcher.apiClient.RunsAPIApi.GetRunsGroup(context.TODO(), groupName).ClientApiVersion(restApiVersion).Execute()
+
+		err = galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
 	}
 	return testRuns, err
 }
@@ -91,7 +94,10 @@ func (launcher *RemoteLauncher) SubmitTestRun(
 	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 
 	if err == nil {
-		resultGroup, _, err = launcher.apiClient.RunsAPIApi.PostSubmitTestRuns(context.TODO(), groupName).TestRunRequest(*testRunRequest).ClientApiVersion(restApiVersion).Execute()
+		var httpResponse *http.Response
+		resultGroup, httpResponse, err = launcher.apiClient.RunsAPIApi.PostSubmitTestRuns(context.TODO(), groupName).TestRunRequest(*testRunRequest).ClientApiVersion(restApiVersion).Execute()
+
+		err = galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
 	}
 	return resultGroup, err
 }
@@ -104,7 +110,10 @@ func (launcher *RemoteLauncher) GetRunsById(runId string) (*galasaapi.Run, error
 	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 
 	if err == nil {
+		var httpResponse *http.Response
 		rasRun, _, err = launcher.apiClient.ResultArchiveStoreAPIApi.GetRasRunById(context.TODO(), runId).ClientApiVersion(restApiVersion).Execute()
+
+		err = galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
 	}
 	return rasRun, err
 }
@@ -120,8 +129,11 @@ func (launcher *RemoteLauncher) GetStreams() ([]string, error) {
 
 	if err == nil {
 		var properties []galasaapi.GalasaProperty
-		properties, _, err = launcher.apiClient.ConfigurationPropertyStoreAPIApi.
+		var httpResponse *http.Response
+		properties, httpResponse, err = launcher.apiClient.ConfigurationPropertyStoreAPIApi.
 			QueryCpsNamespaceProperties(context.TODO(), "framework").Prefix("test.stream").Suffix("repo").ClientApiVersion(restApiVersion).Execute()
+
+		err = galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
 		if err == nil {
 
 			streams, err = getStreamNamesFromProperties(properties)

--- a/pkg/resources/resourcesApplier.go
+++ b/pkg/resources/resourcesApplier.go
@@ -103,7 +103,7 @@ func sendResourcesRequestToServer(payloadJsonToSend []byte, apiServerUrl string,
 					} else if statusCode == 500 {
 						err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESOURCES_RESP_SERVER_ERROR)
 					} else {
-						err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESOURCES_RESP_UNEXPECTED_ERROR)
+						err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESP_UNEXPECTED_ERROR)
 					}
 				} else {
 					err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_UNABLE_TO_READ_RESPONSE_BODY, err)

--- a/pkg/resources/resourcesApplier.go
+++ b/pkg/resources/resourcesApplier.go
@@ -94,19 +94,19 @@ func sendResourcesRequestToServer(payloadJsonToSend []byte, apiServerUrl string,
 						if err == nil {
 							errMessages := errorsFromServer.GetErrorMessages()
 							responseString := fmt.Sprint(strings.Join(errMessages, "\n"))
-							err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RESOURCES_RESP_BAD_REQUEST, responseString)
+							err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESOURCES_RESP_BAD_REQUEST, responseString)
 						} else {
-							err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RESOURCE_RESPONSE_PARSING, err)
+							err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESOURCE_RESPONSE_PARSING, err)
 						}
 					} else if statusCode == 401 {
-						err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RESOURCE_RESP_UNAUTHORIZED_OPERATION)
+						err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESOURCE_RESP_UNAUTHORIZED_OPERATION)
 					} else if statusCode == 500 {
-						err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RESOURCES_RESP_SERVER_ERROR)
+						err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESOURCES_RESP_SERVER_ERROR)
 					} else {
-						err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RESOURCES_RESP_UNEXPECTED_ERROR)
+						err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESOURCES_RESP_UNEXPECTED_ERROR)
 					}
 				} else {
-					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_UNABLE_TO_READ_RESPONSE_BODY, err)
+					err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_UNABLE_TO_READ_RESPONSE_BODY, err)
 				}
 
 			} else {

--- a/pkg/runs/runsReset.go
+++ b/pkg/runs/runsReset.go
@@ -89,24 +89,27 @@ func resetRun(runName string,
 			UpdateRunStatusRequest(*runStatusUpdateRequest).
 			ClientApiVersion(restApiVersion).Execute()
 
-		if (resp != nil) && (resp.StatusCode != http.StatusAccepted) {
+		if resp != nil {
 			defer resp.Body.Close()
+			statusCode := resp.StatusCode
+			if statusCode != http.StatusAccepted {
 
-			responseBody, err = io.ReadAll(resp.Body)
-			log.Printf("putRasRunStatusById Failed - HTTP Response - Status Code: '%v' Payload: '%v'\n", resp.StatusCode, string(responseBody))
-
-			if err == nil {
-				var errorFromServer *galasaErrors.GalasaAPIError
-				errorFromServer, err = galasaErrors.GetApiErrorFromResponse(responseBody)
+				responseBody, err = io.ReadAll(resp.Body)
+				log.Printf("putRasRunStatusById Failed - HTTP Response - Status Code: '%v' Payload: '%v'\n", statusCode, string(responseBody))
 
 				if err == nil {
-					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RESET_RUN_FAILED, runName, errorFromServer.Message)
-				} else {
-					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RESET_RUN_RESPONSE_PARSING)
-				}
+					var errorFromServer *galasaErrors.GalasaAPIError
+					errorFromServer, err = galasaErrors.GetApiErrorFromResponse(statusCode, responseBody)
 
-			} else {
-				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_UNABLE_TO_READ_RESPONSE_BODY, err.Error())
+					if err == nil {
+						err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESET_RUN_FAILED, runName, errorFromServer.Message)
+					} else {
+						err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RESET_RUN_RESPONSE_PARSING)
+					}
+
+				} else {
+					err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_UNABLE_TO_READ_RESPONSE_BODY, err.Error())
+				}
 			}
 		}
 

--- a/pkg/runs/submitter.go
+++ b/pkg/runs/submitter.go
@@ -337,7 +337,7 @@ func (submitter *Submitter) submitRun(
 		if err != nil {
 			log.Printf("Failed to submit test %v/%v - %v\n", nextRun.Bundle, nextRun.Class, err)
 			lostRuns[className] = &nextRun
-			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_SUBMIT_TEST, nextRun.Bundle, nextRun.Class, err.Error())
+			err = galasaErrors.NewGalasaErrorWithCause(err, galasaErrors.GALASA_ERROR_FAILED_TO_SUBMIT_TEST, nextRun.Bundle, nextRun.Class, err.Error())
 		} else {
 			if len(resultGroup.GetRuns()) < 1 {
 				log.Printf("Lost the run attempting to submit test %v/%v\n", nextRun.Bundle, nextRun.Class)
@@ -756,7 +756,7 @@ func (submitter *Submitter) checkIfGroupAlreadyInUse(groupName string) (bool, er
 	var uuidCheck *galasaapi.TestRuns
 	uuidCheck, err = submitter.launcher.GetRunsByGroup(groupName)
 	if err != nil {
-		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_SUBMIT_RUNS_GROUP_CHECK, groupName, err.Error())
+		err = galasaErrors.NewGalasaErrorWithCause(err, galasaErrors.GALASA_ERROR_SUBMIT_RUNS_GROUP_CHECK, groupName, err.Error())
 	} else {
 
 		if uuidCheck.Runs != nil && len(uuidCheck.Runs) > 0 {

--- a/pkg/spi/timeService.go
+++ b/pkg/spi/timeService.go
@@ -9,5 +9,4 @@ import "time"
 
 type TimeService interface {
 	Now() time.Time
-	Sleep(duration time.Duration)
 }

--- a/pkg/spi/timeService.go
+++ b/pkg/spi/timeService.go
@@ -9,4 +9,5 @@ import "time"
 
 type TimeService interface {
 	Now() time.Time
+	Sleep(duration time.Duration)
 }

--- a/pkg/users/usersGet.go
+++ b/pkg/users/usersGet.go
@@ -72,11 +72,16 @@ func getUserDataFromRestApi(
 
 		usersIn, resp, err = apiCall.Execute()
 
+		var statusCode int
+		if resp != nil {
+			defer resp.Body.Close()
+			statusCode = resp.StatusCode
+		}
+
 		if err != nil {
 			log.Println("getUserDataFromRestApi - Failed to retrieve list of users from API server")
-			err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_RETRIEVING_USER_LIST_FROM_API_SERVER, err.Error())
+			err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_RETRIEVING_USER_LIST_FROM_API_SERVER, err.Error())
 		} else {
-			defer resp.Body.Close()
 			users = usersIn
 			log.Printf("getUserDataFromRestApi -  %v users collected", len(users))
 		}


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2072

In order to capture errors related to rate limiting so that functions can be retried, the HTTP response code needs to be included in the GalasaError struct along with causes so that wrapped errors can also be identified properly.

## Changes
- Added status code and error cause to the GalasaError struct and updated existing error creation to include status codes and causes where available
- Revisited response body closure in commands
  - Runs get loops were not closing HTTP response bodies, so updated functions to make sure they are being closed