### PR TITLE
Add flags to allow commands to be retried if rate-limit-related errors occur

### DIFF
--- a/docs/generated/galasactl_auth.md
+++ b/docs/generated/galasactl_auth.md
@@ -9,7 +9,10 @@ Manages authentication with a Galasa ecosystem using access tokens, enabling sec
 ### Options
 
 ```
-  -h, --help   Displays the options for the 'auth' command.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                             Displays the options for the 'auth' command.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_auth.md
+++ b/docs/generated/galasactl_auth.md
@@ -9,10 +9,10 @@ Manages authentication with a Galasa ecosystem using access tokens, enabling sec
 ### Options
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help                             Displays the options for the 'auth' command.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                                  Displays the options for the 'auth' command.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_auth_login.md
+++ b/docs/generated/galasactl_auth_login.md
@@ -13,15 +13,17 @@ galasactl auth login [flags]
 ### Options
 
 ```
-  -b, --bootstrap string   Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help               Displays the options for the 'auth login' command.
+  -h, --help   Displays the options for the 'auth login' command.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_auth_login.md
+++ b/docs/generated/galasactl_auth_login.md
@@ -19,11 +19,11 @@ galasactl auth login [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_auth_logout.md
+++ b/docs/generated/galasactl_auth_logout.md
@@ -19,8 +19,11 @@ galasactl auth logout [flags]
 ### Options inherited from parent commands
 
 ```
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_auth_logout.md
+++ b/docs/generated/galasactl_auth_logout.md
@@ -19,11 +19,11 @@ galasactl auth logout [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_auth_tokens.md
+++ b/docs/generated/galasactl_auth_tokens.md
@@ -9,15 +9,17 @@ Allows interaction with a Galasa Ecosystem's auth store to query tokens and retr
 ### Options
 
 ```
-  -b, --bootstrap string   Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help               Displays the options for the 'auth tokens' command.
+  -h, --help   Displays the options for the 'auth tokens' command.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_auth_tokens.md
+++ b/docs/generated/galasactl_auth_tokens.md
@@ -15,11 +15,11 @@ Allows interaction with a Galasa Ecosystem's auth store to query tokens and retr
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_auth_tokens_delete.md
+++ b/docs/generated/galasactl_auth_tokens_delete.md
@@ -20,11 +20,11 @@ galasactl auth tokens delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_auth_tokens_delete.md
+++ b/docs/generated/galasactl_auth_tokens_delete.md
@@ -20,9 +20,11 @@ galasactl auth tokens delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_auth_tokens_get.md
+++ b/docs/generated/galasactl_auth_tokens_get.md
@@ -20,9 +20,11 @@ galasactl auth tokens get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_auth_tokens_get.md
+++ b/docs/generated/galasactl_auth_tokens_get.md
@@ -20,11 +20,11 @@ galasactl auth tokens get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_properties.md
+++ b/docs/generated/galasactl_properties.md
@@ -9,10 +9,10 @@ Allows interaction with the CPS to create, query and maintain properties in Gala
 ### Options
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help                             Displays the options for the 'properties' command.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                                  Displays the options for the 'properties' command.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_properties.md
+++ b/docs/generated/galasactl_properties.md
@@ -9,8 +9,10 @@ Allows interaction with the CPS to create, query and maintain properties in Gala
 ### Options
 
 ```
-  -b, --bootstrap string   Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help               Displays the options for the 'properties' command.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                             Displays the options for the 'properties' command.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_properties_delete.md
+++ b/docs/generated/galasactl_properties_delete.md
@@ -21,9 +21,11 @@ galasactl properties delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_properties_delete.md
+++ b/docs/generated/galasactl_properties_delete.md
@@ -21,11 +21,11 @@ galasactl properties delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_properties_get.md
+++ b/docs/generated/galasactl_properties_get.md
@@ -25,11 +25,11 @@ galasactl properties get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_properties_get.md
+++ b/docs/generated/galasactl_properties_get.md
@@ -25,9 +25,11 @@ galasactl properties get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_properties_namespaces.md
+++ b/docs/generated/galasactl_properties_namespaces.md
@@ -15,9 +15,11 @@ Allows interaction with the CPS to query namespaces in Galasa Ecosystem
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_properties_namespaces.md
+++ b/docs/generated/galasactl_properties_namespaces.md
@@ -15,11 +15,11 @@ Allows interaction with the CPS to query namespaces in Galasa Ecosystem
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_properties_namespaces_get.md
+++ b/docs/generated/galasactl_properties_namespaces_get.md
@@ -20,9 +20,11 @@ galasactl properties namespaces get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_properties_namespaces_get.md
+++ b/docs/generated/galasactl_properties_namespaces_get.md
@@ -20,11 +20,11 @@ galasactl properties namespaces get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_properties_set.md
+++ b/docs/generated/galasactl_properties_set.md
@@ -22,11 +22,11 @@ galasactl properties set [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_properties_set.md
+++ b/docs/generated/galasactl_properties_set.md
@@ -22,9 +22,11 @@ galasactl properties set [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_resources.md
+++ b/docs/generated/galasactl_resources.md
@@ -9,9 +9,11 @@ Allows interaction with the Resources endpoint to create and maintain resources 
 ### Options
 
 ```
-  -b, --bootstrap string   Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -f, --file string        The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
-  -h, --help               Displays the options for the 'resources' command.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -f, --file string                      The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
+  -h, --help                             Displays the options for the 'resources' command.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_resources.md
+++ b/docs/generated/galasactl_resources.md
@@ -9,11 +9,11 @@ Allows interaction with the Resources endpoint to create and maintain resources 
 ### Options
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -f, --file string                      The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
-  -h, --help                             Displays the options for the 'resources' command.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -f, --file string                           The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
+  -h, --help                                  Displays the options for the 'resources' command.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_resources_apply.md
+++ b/docs/generated/galasactl_resources_apply.md
@@ -19,10 +19,12 @@ galasactl resources apply [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -f, --file string         The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -f, --file string                      The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_resources_apply.md
+++ b/docs/generated/galasactl_resources_apply.md
@@ -19,12 +19,12 @@ galasactl resources apply [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -f, --file string                      The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -f, --file string                           The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_resources_create.md
+++ b/docs/generated/galasactl_resources_create.md
@@ -19,10 +19,12 @@ galasactl resources create [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -f, --file string         The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -f, --file string                      The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_resources_create.md
+++ b/docs/generated/galasactl_resources_create.md
@@ -19,12 +19,12 @@ galasactl resources create [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -f, --file string                      The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -f, --file string                           The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_resources_delete.md
+++ b/docs/generated/galasactl_resources_delete.md
@@ -19,10 +19,12 @@ galasactl resources delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -f, --file string         The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -f, --file string                      The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_resources_delete.md
+++ b/docs/generated/galasactl_resources_delete.md
@@ -19,12 +19,12 @@ galasactl resources delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -f, --file string                      The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -f, --file string                           The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_resources_update.md
+++ b/docs/generated/galasactl_resources_update.md
@@ -19,12 +19,12 @@ galasactl resources update [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -f, --file string                      The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -f, --file string                           The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_resources_update.md
+++ b/docs/generated/galasactl_resources_update.md
@@ -19,10 +19,12 @@ galasactl resources update [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -f, --file string         The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -f, --file string                      The file containing yaml definitions of resources to be applied manipulated by this command. This can be a fully-qualified path or path relative to the current directory.Example: my_resources.yaml
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs.md
+++ b/docs/generated/galasactl_runs.md
@@ -9,8 +9,10 @@ Assembles, submits and monitors test runs in Galasa Ecosystem
 ### Options
 
 ```
-  -b, --bootstrap string   Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help               Displays the options for the 'runs' command.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                             Displays the options for the 'runs' command.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_runs.md
+++ b/docs/generated/galasactl_runs.md
@@ -9,10 +9,10 @@ Assembles, submits and monitors test runs in Galasa Ecosystem
 ### Options
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help                             Displays the options for the 'runs' command.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                                  Displays the options for the 'runs' command.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_runs_cancel.md
+++ b/docs/generated/galasactl_runs_cancel.md
@@ -20,11 +20,11 @@ galasactl runs cancel [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_cancel.md
+++ b/docs/generated/galasactl_runs_cancel.md
@@ -20,9 +20,11 @@ galasactl runs cancel [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_delete.md
+++ b/docs/generated/galasactl_runs_delete.md
@@ -20,11 +20,11 @@ galasactl runs delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_delete.md
+++ b/docs/generated/galasactl_runs_delete.md
@@ -20,9 +20,11 @@ galasactl runs delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_download.md
+++ b/docs/generated/galasactl_runs_download.md
@@ -22,11 +22,11 @@ galasactl runs download [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_download.md
+++ b/docs/generated/galasactl_runs_download.md
@@ -22,9 +22,11 @@ galasactl runs download [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_get.md
+++ b/docs/generated/galasactl_runs_get.md
@@ -25,11 +25,11 @@ galasactl runs get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_get.md
+++ b/docs/generated/galasactl_runs_get.md
@@ -25,9 +25,11 @@ galasactl runs get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_prepare.md
+++ b/docs/generated/galasactl_runs_prepare.md
@@ -30,11 +30,11 @@ galasactl runs prepare [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_prepare.md
+++ b/docs/generated/galasactl_runs_prepare.md
@@ -30,9 +30,11 @@ galasactl runs prepare [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_reset.md
+++ b/docs/generated/galasactl_runs_reset.md
@@ -20,11 +20,11 @@ galasactl runs reset [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_reset.md
+++ b/docs/generated/galasactl_runs_reset.md
@@ -20,9 +20,11 @@ galasactl runs reset [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_submit.md
+++ b/docs/generated/galasactl_runs_submit.md
@@ -41,11 +41,11 @@ galasactl runs submit [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_submit.md
+++ b/docs/generated/galasactl_runs_submit.md
@@ -41,9 +41,11 @@ galasactl runs submit [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_submit_local.md
+++ b/docs/generated/galasactl_runs_submit_local.md
@@ -28,24 +28,24 @@ galasactl runs submit local [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -g, --group string                     the group name to assign the test runs to, if not provided, a psuedo unique id will be generated
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --noexitcodeontestfailures         set to true if you don't want an exit code to be returned from galasactl if a test fails
-      --override strings                 overrides to be sent with the tests (overrides in the portfolio will take precedence). Each override is of the form 'name=value'. Multiple instances of this flag can be used. For example --override=prop1=val1 --override=prop2=val2
-      --overridefile string              path to a properties file containing override properties. Defaults to overrides.properties in galasa home folder if that file exists. Overrides from --override options will take precedence over properties in this property file. A file path of '-' disables reading any properties file.
-      --poll int                         Optional. The interval time in seconds between successive polls of the test runs status. Defaults to 30 seconds. If less than 1, then default value is used. (default 30)
-      --progress int                     in minutes, how often the cli will report the overall progress of the test runs. A value of 0 or less disables progress reporting. (default 5)
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
-      --reportjson string                json file to record the final results in
-      --reportjunit string               junit xml file to record the final results in
-      --reportyaml string                yaml file to record the final results in
-      --requesttype string               the type of request, used to allocate a run name. Defaults to CLI. (default "CLI")
-      --throttle int                     how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 3)
-      --throttlefile string              a file where the current throttle is stored. Periodically the throttle value is read from the file used. Someone with edit access to the file can change it which dynamically takes effect. Long-running large portfolios can be throttled back to nothing (paused) using this mechanism (if throttle is set to 0). And they can be resumed (un-paused) if the value is set back. This facility can allow the tests to not show a failure when the system under test is taken out of service for maintainence.Optional. If not specified, no throttle file is used.
-      --trace                            Trace to be enabled on the test runs
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -g, --group string                          the group name to assign the test runs to, if not provided, a psuedo unique id will be generated
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --noexitcodeontestfailures              set to true if you don't want an exit code to be returned from galasactl if a test fails
+      --override strings                      overrides to be sent with the tests (overrides in the portfolio will take precedence). Each override is of the form 'name=value'. Multiple instances of this flag can be used. For example --override=prop1=val1 --override=prop2=val2
+      --overridefile string                   path to a properties file containing override properties. Defaults to overrides.properties in galasa home folder if that file exists. Overrides from --override options will take precedence over properties in this property file. A file path of '-' disables reading any properties file.
+      --poll int                              Optional. The interval time in seconds between successive polls of the test runs status. Defaults to 30 seconds. If less than 1, then default value is used. (default 30)
+      --progress int                          in minutes, how often the cli will report the overall progress of the test runs. A value of 0 or less disables progress reporting. (default 5)
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+      --reportjson string                     json file to record the final results in
+      --reportjunit string                    junit xml file to record the final results in
+      --reportyaml string                     yaml file to record the final results in
+      --requesttype string                    the type of request, used to allocate a run name. Defaults to CLI. (default "CLI")
+      --throttle int                          how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 3)
+      --throttlefile string                   a file where the current throttle is stored. Periodically the throttle value is read from the file used. Someone with edit access to the file can change it which dynamically takes effect. Long-running large portfolios can be throttled back to nothing (paused) using this mechanism (if throttle is set to 0). And they can be resumed (un-paused) if the value is set back. This facility can allow the tests to not show a failure when the system under test is taken out of service for maintainence.Optional. If not specified, no throttle file is used.
+      --trace                                 Trace to be enabled on the test runs
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_runs_submit_local.md
+++ b/docs/generated/galasactl_runs_submit_local.md
@@ -28,22 +28,24 @@ galasactl runs submit local [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string           Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string          Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -g, --group string               the group name to assign the test runs to, if not provided, a psuedo unique id will be generated
-  -l, --log string                 File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --noexitcodeontestfailures   set to true if you don't want an exit code to be returned from galasactl if a test fails
-      --override strings           overrides to be sent with the tests (overrides in the portfolio will take precedence). Each override is of the form 'name=value'. Multiple instances of this flag can be used. For example --override=prop1=val1 --override=prop2=val2
-      --overridefile string        path to a properties file containing override properties. Defaults to overrides.properties in galasa home folder if that file exists. Overrides from --override options will take precedence over properties in this property file. A file path of '-' disables reading any properties file.
-      --poll int                   Optional. The interval time in seconds between successive polls of the test runs status. Defaults to 30 seconds. If less than 1, then default value is used. (default 30)
-      --progress int               in minutes, how often the cli will report the overall progress of the test runs. A value of 0 or less disables progress reporting. (default 5)
-      --reportjson string          json file to record the final results in
-      --reportjunit string         junit xml file to record the final results in
-      --reportyaml string          yaml file to record the final results in
-      --requesttype string         the type of request, used to allocate a run name. Defaults to CLI. (default "CLI")
-      --throttle int               how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 3)
-      --throttlefile string        a file where the current throttle is stored. Periodically the throttle value is read from the file used. Someone with edit access to the file can change it which dynamically takes effect. Long-running large portfolios can be throttled back to nothing (paused) using this mechanism (if throttle is set to 0). And they can be resumed (un-paused) if the value is set back. This facility can allow the tests to not show a failure when the system under test is taken out of service for maintainence.Optional. If not specified, no throttle file is used.
-      --trace                      Trace to be enabled on the test runs
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -g, --group string                     the group name to assign the test runs to, if not provided, a psuedo unique id will be generated
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --noexitcodeontestfailures         set to true if you don't want an exit code to be returned from galasactl if a test fails
+      --override strings                 overrides to be sent with the tests (overrides in the portfolio will take precedence). Each override is of the form 'name=value'. Multiple instances of this flag can be used. For example --override=prop1=val1 --override=prop2=val2
+      --overridefile string              path to a properties file containing override properties. Defaults to overrides.properties in galasa home folder if that file exists. Overrides from --override options will take precedence over properties in this property file. A file path of '-' disables reading any properties file.
+      --poll int                         Optional. The interval time in seconds between successive polls of the test runs status. Defaults to 30 seconds. If less than 1, then default value is used. (default 30)
+      --progress int                     in minutes, how often the cli will report the overall progress of the test runs. A value of 0 or less disables progress reporting. (default 5)
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+      --reportjson string                json file to record the final results in
+      --reportjunit string               junit xml file to record the final results in
+      --reportyaml string                yaml file to record the final results in
+      --requesttype string               the type of request, used to allocate a run name. Defaults to CLI. (default "CLI")
+      --throttle int                     how many test runs can be submitted in parallel, 0 or less will disable throttling. 1 causes tests to be run sequentially. (default 3)
+      --throttlefile string              a file where the current throttle is stored. Periodically the throttle value is read from the file used. Someone with edit access to the file can change it which dynamically takes effect. Long-running large portfolios can be throttled back to nothing (paused) using this mechanism (if throttle is set to 0). And they can be resumed (un-paused) if the value is set back. This facility can allow the tests to not show a failure when the system under test is taken out of service for maintainence.Optional. If not specified, no throttle file is used.
+      --trace                            Trace to be enabled on the test runs
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_secrets.md
+++ b/docs/generated/galasactl_secrets.md
@@ -9,10 +9,10 @@ The parent command for operations to manipulate secrets in the Galasa service's 
 ### Options
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help                             Displays the options for the 'secrets' command.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                                  Displays the options for the 'secrets' command.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_secrets.md
+++ b/docs/generated/galasactl_secrets.md
@@ -9,8 +9,10 @@ The parent command for operations to manipulate secrets in the Galasa service's 
 ### Options
 
 ```
-  -b, --bootstrap string   Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help               Displays the options for the 'secrets' command.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                             Displays the options for the 'secrets' command.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_secrets_delete.md
+++ b/docs/generated/galasactl_secrets_delete.md
@@ -20,11 +20,11 @@ galasactl secrets delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_secrets_delete.md
+++ b/docs/generated/galasactl_secrets_delete.md
@@ -20,9 +20,11 @@ galasactl secrets delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_secrets_get.md
+++ b/docs/generated/galasactl_secrets_get.md
@@ -21,11 +21,11 @@ galasactl secrets get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_secrets_get.md
+++ b/docs/generated/galasactl_secrets_get.md
@@ -21,9 +21,11 @@ galasactl secrets get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_secrets_set.md
+++ b/docs/generated/galasactl_secrets_set.md
@@ -28,11 +28,11 @@ galasactl secrets set [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_secrets_set.md
+++ b/docs/generated/galasactl_secrets_set.md
@@ -28,9 +28,11 @@ galasactl secrets set [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_users.md
+++ b/docs/generated/galasactl_users.md
@@ -9,10 +9,10 @@ Allows interaction with the user servlet to return information about users.
 ### Options
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help                             Displays the options for the 'users' command.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                                  Displays the options for the 'users' command.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_users.md
+++ b/docs/generated/galasactl_users.md
@@ -9,8 +9,10 @@ Allows interaction with the user servlet to return information about users.
 ### Options
 
 ```
-  -b, --bootstrap string   Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-  -h, --help               Displays the options for the 'users' command.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+  -h, --help                             Displays the options for the 'users' command.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/generated/galasactl_users_delete.md
+++ b/docs/generated/galasactl_users_delete.md
@@ -20,9 +20,11 @@ galasactl users delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_users_delete.md
+++ b/docs/generated/galasactl_users_delete.md
@@ -20,11 +20,11 @@ galasactl users delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_users_get.md
+++ b/docs/generated/galasactl_users_get.md
@@ -20,9 +20,11 @@ galasactl users get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string    Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string   Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string          File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/generated/galasactl_users_get.md
+++ b/docs/generated/galasactl_users_get.md
@@ -20,11 +20,11 @@ galasactl users get [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --bootstrap string                 Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
-      --galasahome string                Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
-  -l, --log string                       File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
-      --rate-limit-retries int           The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
-      --rate-limit-retry-backoff float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
+  -b, --bootstrap string                      Bootstrap URL. Should start with 'http://' or 'file://'. If it starts with neither, it is assumed to be a fully-qualified path. If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties
+      --galasahome string                     Path to a folder where Galasa will read and write files and configuration settings. The default is '${HOME}/.galasa'. This overrides the GALASA_HOME environment variable which may be set instead.
+  -l, --log string                            File to which log information will be sent. Any folder referred to must exist. An existing file will be overwritten. Specify "-" to log to stderr. Defaults to not logging.
+      --rate-limit-retries int                The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. Defaults to 3 retries (default 3)
+      --rate-limit-retry-backoff-secs float   The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second. (default 1)
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/image v0.15.0
 	golang.org/x/text v0.15.0 // indirect

--- a/pkg/api/bootstrap.go
+++ b/pkg/api/bootstrap.go
@@ -134,7 +134,7 @@ func LoadBootstrap(
 	}
 
 	if err != nil {
-		err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_FAILED_TO_LOAD_BOOTSTRAP_FILE, path, err.Error())
+		err = galasaErrors.NewGalasaErrorWithCause(err, galasaErrors.GALASA_ERROR_FAILED_TO_LOAD_BOOTSTRAP_FILE, path, err.Error())
 	}
 
 	return bootstrap, err

--- a/pkg/api/commsRetrier.go
+++ b/pkg/api/commsRetrier.go
@@ -57,10 +57,10 @@ func (retrier *CommsRetrier) ExecuteCommandWithRateLimitRetries(
             // Try to convert the error received from the command into an API error
             galasaError, isGalasaError := err.(galasaErrors.GalasaCommsError)
             if isGalasaError && galasaError.IsRetryRequired() {
-				log.Printf("Rate limit exceeded on attempt %v/%v", attempt, maxAttempts)
+				log.Printf("Rate limit exceeded on attempt %v/%v", (attempt + 1), maxAttempts)
 				
 				if (attempt + 1) < maxAttempts {
-					log.Printf("Retrying in %v seconds", retryBackoffSeconds)
+					log.Printf("Retrying in %v second(s)", retryBackoffSeconds)
 					timeService.Sleep(time.Duration(retryBackoffSeconds) * time.Second)
 					isDone = false
 					attempt++

--- a/pkg/api/commsRetrier.go
+++ b/pkg/api/commsRetrier.go
@@ -21,14 +21,18 @@ var (
 	}
 )
 
-type CommsRetrier struct {
+type CommsRetrierImpl struct {
 	maxAttempts int
 	retryBackoffSeconds float64
 	timeService spi.TimeService
 }
 
-func NewCommsRetrier(maxAttempts int, retryBackoffSeconds float64, timeService spi.TimeService) *CommsRetrier {
-	return &CommsRetrier{
+type CommsRetrier interface {
+	ExecuteCommandWithRateLimitRetries(commandExecutionFunc func() error) error
+}
+
+func NewCommsRetrier(maxAttempts int, retryBackoffSeconds float64, timeService spi.TimeService) CommsRetrier {
+	return &CommsRetrierImpl{
 		maxAttempts: maxAttempts,
 		retryBackoffSeconds: retryBackoffSeconds,
 		timeService: timeService,
@@ -37,7 +41,7 @@ func NewCommsRetrier(maxAttempts int, retryBackoffSeconds float64, timeService s
 
 // ExecuteCommandWithRateLimitRetries keeps trying until we've tried enough, it worked, 
 // or it's failed too many times with rate limit issues.
-func (retrier *CommsRetrier) ExecuteCommandWithRateLimitRetries(
+func (retrier *CommsRetrierImpl) ExecuteCommandWithRateLimitRetries(
     commandExecutionFunc func() error,
 ) error {
     var err error

--- a/pkg/api/commsRetrier.go
+++ b/pkg/api/commsRetrier.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package api
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
+	"github.com/galasa-dev/cli/pkg/spi"
+)
+
+var (
+	RATE_LIMIT_STATUS_CODES_MAP = map[int]struct{}{
+		http.StatusServiceUnavailable: {},
+		http.StatusTooManyRequests: {},
+	}
+)
+
+type CommsRetrier struct {
+	maxAttempts int
+	retryBackoffSeconds float64
+	timeService spi.TimeService
+}
+
+func NewCommsRetrier(maxAttempts int, retryBackoffSeconds float64, timeService spi.TimeService) *CommsRetrier {
+	return &CommsRetrier{
+		maxAttempts: maxAttempts,
+		retryBackoffSeconds: retryBackoffSeconds,
+		timeService: timeService,
+	}
+}
+
+// ExecuteCommandWithRateLimitRetries keeps trying until we've tried enough, it worked, 
+// or it's failed too many times with rate limit issues.
+func (retrier *CommsRetrier) ExecuteCommandWithRateLimitRetries(
+    commandExecutionFunc func() error,
+) error {
+    var err error
+    isDone := false
+	attempt := 0
+	maxAttempts := retrier.maxAttempts
+	retryBackoffSeconds := retrier.retryBackoffSeconds
+	timeService := retrier.timeService
+
+    for !isDone {
+
+        err = commandExecutionFunc()
+
+        isDone = true
+        if err != nil {
+
+            // Try to convert the error received from the command into an API error
+            galasaError, isGalasaError := err.(*galasaErrors.GalasaError)
+            if isGalasaError && galasaError.IsRetryRequired() {
+				log.Printf("Rate limit exceeded on attempt %v/%v", attempt, maxAttempts)
+				
+				if (attempt + 1) < maxAttempts {
+					log.Printf("Retrying in %v seconds", retryBackoffSeconds)
+					timeService.Sleep(time.Duration(retryBackoffSeconds) * time.Second)
+					isDone = false
+					attempt++
+				}
+            }
+        }
+    }
+    return err
+}

--- a/pkg/api/commsRetrier.go
+++ b/pkg/api/commsRetrier.go
@@ -55,7 +55,7 @@ func (retrier *CommsRetrier) ExecuteCommandWithRateLimitRetries(
         if err != nil {
 
             // Try to convert the error received from the command into an API error
-            galasaError, isGalasaError := err.(*galasaErrors.GalasaError)
+            galasaError, isGalasaError := err.(galasaErrors.GalasaCommsError)
             if isGalasaError && galasaError.IsRetryRequired() {
 				log.Printf("Rate limit exceeded on attempt %v/%v", attempt, maxAttempts)
 				

--- a/pkg/api/commsRetrier_test.go
+++ b/pkg/api/commsRetrier_test.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func createMockErrorMessageType() *galasaErrors.MessageType {
+	return galasaErrors.NewMessageType("TEST123: simulating a failure on attempt %v", 123, false)
+}
+
+func TestExecuteCommandWithRateLimitRetriesOnlyRunsOnceOnSuccess(t *testing.T) {
+    // Given...
+    maxAttempts := 3
+    retryBackoffSeconds := 1
+	
+	now := time.Now()
+    timeService := utils.NewOverridableMockTimeService(now)
+	commsRetrier := NewCommsRetrier(maxAttempts, float64(retryBackoffSeconds), timeService)
+    runCounter := 0
+    executionFunc := func() error {
+        runCounter++
+        return nil
+    }
+
+    // When...
+    err := commsRetrier.ExecuteCommandWithRateLimitRetries(executionFunc)
+
+    // Then...
+    assert.Nil(t, err)
+    assert.Equal(t, 1, runCounter, "The execution function should only have been run once")
+	assert.Equal(t, now, timeService.Now(), "Time should not have advanced")
+}
+
+func TestExecuteCommandWithRateLimitRetriesTriesAgainOnRateLimitFailure(t *testing.T) {
+    // Given...
+    maxAttempts := 3
+    retryBackoffSeconds := 10
+
+	now := time.Now()
+    timeService := utils.NewOverridableMockTimeService(now)
+	commsRetrier := NewCommsRetrier(maxAttempts, float64(retryBackoffSeconds), timeService)
+    attemptCounter := 0
+    executionFunc := func() error {
+        var err error
+        attemptCounter++
+        if attemptCounter != 2 {
+            err = galasaErrors.NewGalasaErrorWithHttpStatusCode(http.StatusTooManyRequests, createMockErrorMessageType(), attemptCounter)
+        }
+        return err
+    }
+
+    // When...
+    err := commsRetrier.ExecuteCommandWithRateLimitRetries(executionFunc)
+
+    // Then...
+    assert.Nil(t, err)
+    assert.Equal(t, 2, attemptCounter, "The execution function should have been run twice")
+	assert.Equal(t, now.Add(10 * time.Second), timeService.Now(), "Time should have advanced after each attempt")
+}
+
+func TestExecuteCommandWithRateLimitRetriesGivesUpAfterMaxAttempts(t *testing.T) {
+    // Given...
+    maxAttempts := 4
+    retryBackoffSeconds := 10
+
+	now := time.Now()
+    timeService := utils.NewOverridableMockTimeService(now)
+	commsRetrier := NewCommsRetrier(maxAttempts, float64(retryBackoffSeconds), timeService)
+    attemptCounter := 0
+    executionFunc := func() error {
+        attemptCounter++
+        return galasaErrors.NewGalasaErrorWithHttpStatusCode(http.StatusTooManyRequests, createMockErrorMessageType(), attemptCounter)
+    }
+
+    // When...
+    err := commsRetrier.ExecuteCommandWithRateLimitRetries(executionFunc)
+
+    // Then...
+    assert.NotNil(t, err)
+    assert.ErrorContains(t, err, strconv.Itoa(maxAttempts), "The last error should have been returned")
+    assert.Equal(t, maxAttempts, attemptCounter, "The execution function should have been run the maximum number of times")
+	assert.Equal(t, now.Add(30 * time.Second), timeService.Now(), "Time should have advanced after each attempt")
+}
+
+func TestExecuteCommandWithRateLimitRetriesRunsOnceOnNonRateLimitedFailure(t *testing.T) {
+    // Given...
+    maxAttempts := 3
+    retryBackoffSeconds := 1
+
+	now := time.Now()
+    timeService := utils.NewOverridableMockTimeService(now)
+	commsRetrier := NewCommsRetrier(maxAttempts, float64(retryBackoffSeconds), timeService)
+    attemptCounter := 0
+    errorMsg := "simulating an error that is not related to the API server response"
+    executionFunc := func() error {
+        attemptCounter++
+        return errors.New(errorMsg)
+    }
+
+    // When...
+    err := commsRetrier.ExecuteCommandWithRateLimitRetries(executionFunc)
+
+    // Then...
+    assert.NotNil(t, err)
+    assert.ErrorContains(t, err, errorMsg)
+    assert.Equal(t, 1, attemptCounter, "The execution function should only have been run once")
+	assert.Equal(t, now, timeService.Now(), "Time should not have advanced")
+}

--- a/pkg/cmd/auth.go
+++ b/pkg/cmd/auth.go
@@ -60,8 +60,8 @@ func (cmd *AuthCommand) createCobraCommand(rootCmd spi.GalasaCommand, commsCmd s
 			"enabling secure interactions with the ecosystem.",
 	}
 
+	authCmd.PersistentFlags().AddFlagSet(commsCmd.CobraCommand().PersistentFlags())
 	rootCmd.CobraCommand().AddCommand(authCmd)
-	commsCmd.CobraCommand().AddCommand(authCmd)
 
 	return authCmd, err
 }

--- a/pkg/cmd/auth.go
+++ b/pkg/cmd/auth.go
@@ -17,10 +17,10 @@ type AuthCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors
 // ------------------------------------------------------------------------------------------------
-func NewAuthCommand(rootCmd spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewAuthCommand(rootCmd spi.GalasaCommand, commsCmd spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(AuthCommand)
 
-	cmd.init(rootCmd)
+	cmd.init(rootCmd, commsCmd)
 	return cmd, nil
 }
 
@@ -43,13 +43,13 @@ func (cmd *AuthCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *AuthCommand) init(rootCmd spi.GalasaCommand) error {
+func (cmd *AuthCommand) init(rootCmd spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
 	var err error
-	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd)
+	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd, commsCmd)
 	return err
 }
 
-func (cmd *AuthCommand) createCobraCommand(rootCmd spi.GalasaCommand) (*cobra.Command, error) {
+func (cmd *AuthCommand) createCobraCommand(rootCmd spi.GalasaCommand, commsCmd spi.GalasaCommand) (*cobra.Command, error) {
 
 	var err error
 
@@ -61,6 +61,7 @@ func (cmd *AuthCommand) createCobraCommand(rootCmd spi.GalasaCommand) (*cobra.Co
 	}
 
 	rootCmd.CobraCommand().AddCommand(authCmd)
+	commsCmd.CobraCommand().AddCommand(authCmd)
 
 	return authCmd, err
 }

--- a/pkg/cmd/auth.go
+++ b/pkg/cmd/auth.go
@@ -17,10 +17,10 @@ type AuthCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors
 // ------------------------------------------------------------------------------------------------
-func NewAuthCommand(rootCmd spi.GalasaCommand, commsCmd spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewAuthCommand(rootCmd spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(AuthCommand)
 
-	cmd.init(rootCmd, commsCmd)
+	cmd.init(rootCmd, commsFlagSet)
 	return cmd, nil
 }
 
@@ -43,13 +43,13 @@ func (cmd *AuthCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *AuthCommand) init(rootCmd spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *AuthCommand) init(rootCmd spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
-	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd, commsCmd)
+	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd, commsFlagSet)
 	return err
 }
 
-func (cmd *AuthCommand) createCobraCommand(rootCmd spi.GalasaCommand, commsCmd spi.GalasaCommand) (*cobra.Command, error) {
+func (cmd *AuthCommand) createCobraCommand(rootCmd spi.GalasaCommand, commsFlagSet GalasaFlagSet) (*cobra.Command, error) {
 
 	var err error
 
@@ -60,7 +60,7 @@ func (cmd *AuthCommand) createCobraCommand(rootCmd spi.GalasaCommand, commsCmd s
 			"enabling secure interactions with the ecosystem.",
 	}
 
-	authCmd.PersistentFlags().AddFlagSet(commsCmd.CobraCommand().PersistentFlags())
+	authCmd.PersistentFlags().AddFlagSet(commsFlagSet.Flags())
 	rootCmd.CobraCommand().AddCommand(authCmd)
 
 	return authCmd, err

--- a/pkg/cmd/authLogin.go
+++ b/pkg/cmd/authLogin.go
@@ -71,6 +71,9 @@ func (cmd *AuthLoginComamnd) createCobraCommand(
 ) (*cobra.Command, error) {
 
 	var err error
+
+	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
+
 	authLoginCobraCmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to a Galasa ecosystem using an existing access token",
@@ -80,7 +83,10 @@ func (cmd *AuthLoginComamnd) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"auth login"},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
-			return cmd.executeAuthLogin(factory, commsCmd.Values().(*CommsCmdValues))
+			executionFunc := func() error {
+				return cmd.executeAuthLogin(factory, commsCmdValues)
+			}
+			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
 		},
 	}
 
@@ -99,35 +105,32 @@ func (cmd *AuthLoginComamnd) executeAuthLogin(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	commsCmdValues.isCapturingLogs = true
+
+	log.Println("Galasa CLI - Log in to an ecosystem")
+
+	// Get the ability to query environment variables.
+	env := factory.GetEnvironment()
+
+	var galasaHome spi.GalasaHome
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	if err != nil {
+		panic(err)
+	}
+
+	// Read the bootstrap properties.
+	var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
+	var bootstrapData *api.BootstrapData
+	bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 	if err == nil {
-		commsCmdValues.isCapturingLogs = true
+		apiServerUrl := bootstrapData.ApiServerURL
+		log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-		log.Println("Galasa CLI - Log in to an ecosystem")
-
-		// Get the ability to query environment variables.
-		env := factory.GetEnvironment()
-
-		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
-		if err != nil {
-			panic(err)
-		}
-
-		// Read the bootstrap properties.
-		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
-		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
-		if err == nil {
-			apiServerUrl := bootstrapData.ApiServerURL
-			log.Printf("The API server is at '%s'\n", apiServerUrl)
-
-			authenticator := factory.GetAuthenticator(
-				apiServerUrl,
-				galasaHome,
-			)
-			err = authenticator.Login()
-		}
+		authenticator := factory.GetAuthenticator(
+			apiServerUrl,
+			galasaHome,
+		)
+		err = authenticator.Login()
 	}
 	return err
 }

--- a/pkg/cmd/authLogin.go
+++ b/pkg/cmd/authLogin.go
@@ -72,7 +72,7 @@ func (cmd *AuthLoginComamnd) createCobraCommand(
 
 	var err error
 
-	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
+	commsFlagSetValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	authLoginCobraCmd := &cobra.Command{
 		Use:   "login",
@@ -84,9 +84,9 @@ func (cmd *AuthLoginComamnd) createCobraCommand(
 		Aliases: []string{"auth login"},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeAuthLogin(factory, commsCmdValues)
+				return cmd.executeAuthLogin(factory, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -97,7 +97,7 @@ func (cmd *AuthLoginComamnd) createCobraCommand(
 
 func (cmd *AuthLoginComamnd) executeAuthLogin(
 	factory spi.Factory,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
@@ -105,7 +105,7 @@ func (cmd *AuthLoginComamnd) executeAuthLogin(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Log in to an ecosystem")
 
@@ -113,7 +113,7 @@ func (cmd *AuthLoginComamnd) executeAuthLogin(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err != nil {
 		panic(err)
 	}
@@ -121,7 +121,7 @@ func (cmd *AuthLoginComamnd) executeAuthLogin(
 	// Read the bootstrap properties.
 	var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 	var bootstrapData *api.BootstrapData
-	bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+	bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 	if err == nil {
 		apiServerUrl := bootstrapData.ApiServerURL
 		log.Printf("The API server is at '%s'\n", apiServerUrl)

--- a/pkg/cmd/authLogin.go
+++ b/pkg/cmd/authLogin.go
@@ -29,10 +29,10 @@ func NewAuthLoginCommand(
 	factory spi.Factory,
 	authCommand spi.GalasaCommand,
 	rootCommand spi.GalasaCommand,
-	commsCommand spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (spi.GalasaCommand, error) {
 	cmd := new(AuthLoginComamnd)
-	err := cmd.init(factory, authCommand, commsCommand)
+	err := cmd.init(factory, authCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -54,12 +54,12 @@ func (cmd *AuthLoginComamnd) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *AuthLoginComamnd) init(factory spi.Factory, authCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *AuthLoginComamnd) init(factory spi.Factory, authCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 
 	cmd.values = &AuthLoginCmdValues{}
 
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, authCommand, commsCmd)
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, authCommand, commsFlagSet)
 
 	return err
 }
@@ -67,12 +67,12 @@ func (cmd *AuthLoginComamnd) init(factory spi.Factory, authCommand spi.GalasaCom
 func (cmd *AuthLoginComamnd) createCobraCommand(
 	factory spi.Factory,
 	authCommand spi.GalasaCommand,
-	commsCmd spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (*cobra.Command, error) {
 
 	var err error
 
-	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
+	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	authLoginCobraCmd := &cobra.Command{
 		Use:   "login",
@@ -97,7 +97,7 @@ func (cmd *AuthLoginComamnd) createCobraCommand(
 
 func (cmd *AuthLoginComamnd) executeAuthLogin(
 	factory spi.Factory,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/authTokens.go
+++ b/pkg/cmd/authTokens.go
@@ -15,7 +15,6 @@ import (
 //	auth tokens ...
 
 type AuthTokensCmdValues struct {
-	bootstrap string
 	loginId   string
 }
 
@@ -27,7 +26,7 @@ type AuthTokensCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewAuthTokensCommand(authCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewAuthTokensCommand(authCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(AuthTokensCommand)
 
 	err := cmd.init(authCommand)
@@ -72,7 +71,6 @@ func (cmd *AuthTokensCommand) createAuthTokensCobraCmd(
 		Args:    cobra.NoArgs,
 	}
 
-	addBootstrapFlag(authTokensCmd, &cmd.values.bootstrap)
 	authCommand.CobraCommand().AddCommand(authTokensCmd)
 
 	return authTokensCmd, err

--- a/pkg/cmd/authTokensDelete.go
+++ b/pkg/cmd/authTokensDelete.go
@@ -80,7 +80,7 @@ func (cmd *AuthTokensDeleteCommand) createCobraCmd(
 
 	var err error
 
-	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
+	commsFlagSetValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	authDeleteTokensCobraCmd := &cobra.Command{
 		Use:     "delete",
@@ -89,9 +89,9 @@ func (cmd *AuthTokensDeleteCommand) createCobraCmd(
 		Aliases: []string{COMMAND_NAME_AUTH_TOKENS_DELETE},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeAuthTokensDelete(factory, commsCmdValues)
+				return cmd.executeAuthTokensDelete(factory, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -105,14 +105,14 @@ func (cmd *AuthTokensDeleteCommand) createCobraCmd(
 
 func (cmd *AuthTokensDeleteCommand) executeAuthTokensDelete(
 	factory spi.Factory,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Revoke a token from the ecosystem")
 
@@ -120,13 +120,13 @@ func (cmd *AuthTokensDeleteCommand) executeAuthTokensDelete(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			apiServerUrl := bootstrapData.ApiServerURL

--- a/pkg/cmd/authTokensDelete.go
+++ b/pkg/cmd/authTokensDelete.go
@@ -33,11 +33,11 @@ type AuthTokensDeleteCommand struct {
 func NewAuthTokensDeleteCommand(
 	factory spi.Factory,
 	authTokensCommand spi.GalasaCommand,
-	commsCmd spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (spi.GalasaCommand, error) {
 
 	cmd := new(AuthTokensDeleteCommand)
-	err := cmd.init(factory, authTokensCommand, commsCmd)
+	err := cmd.init(factory, authTokensCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -62,12 +62,12 @@ func (cmd *AuthTokensDeleteCommand) Values() interface{} {
 func (cmd *AuthTokensDeleteCommand) init(
 	factory spi.Factory,
 	authTokensCommand spi.GalasaCommand,
-	commsCmd spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) error {
 	var err error
 
 	cmd.values = &AuthTokensDeleteCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCmd(factory, authTokensCommand, commsCmd)
+	cmd.cobraCommand, err = cmd.createCobraCmd(factory, authTokensCommand, commsFlagSet)
 
 	return err
 }
@@ -75,12 +75,12 @@ func (cmd *AuthTokensDeleteCommand) init(
 func (cmd *AuthTokensDeleteCommand) createCobraCmd(
 	factory spi.Factory,
 	authTokensCommand spi.GalasaCommand,
-	commsCmd spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (*cobra.Command, error) {
 
 	var err error
 
-	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
+	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	authDeleteTokensCobraCmd := &cobra.Command{
 		Use:     "delete",
@@ -105,7 +105,7 @@ func (cmd *AuthTokensDeleteCommand) createCobraCmd(
 
 func (cmd *AuthTokensDeleteCommand) executeAuthTokensDelete(
 	factory spi.Factory,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/authTokensDelete.go
+++ b/pkg/cmd/authTokensDelete.go
@@ -80,13 +80,18 @@ func (cmd *AuthTokensDeleteCommand) createCobraCmd(
 
 	var err error
 
+	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
+
 	authDeleteTokensCobraCmd := &cobra.Command{
 		Use:     "delete",
 		Short:   "Revokes a personal access token",
 		Long:    "Revokes a token used for authentication with the Galasa API server through the provided token id",
 		Aliases: []string{COMMAND_NAME_AUTH_TOKENS_DELETE},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
-			return cmd.executeAuthTokensDelete(factory, commsCmd.Values().(*CommsCmdValues))
+			executionFunc := func() error {
+				return cmd.executeAuthTokensDelete(factory, commsCmdValues)
+			}
+			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
 		},
 	}
 
@@ -107,40 +112,36 @@ func (cmd *AuthTokensDeleteCommand) executeAuthTokensDelete(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	commsCmdValues.isCapturingLogs = true
 
+	log.Println("Galasa CLI - Revoke a token from the ecosystem")
+
+	// Get the ability to query environment variables.
+	env := factory.GetEnvironment()
+
+	var galasaHome spi.GalasaHome
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 	if err == nil {
-		commsCmdValues.isCapturingLogs = true
 
-		log.Println("Galasa CLI - Revoke a token from the ecosystem")
-
-		// Get the ability to query environment variables.
-		env := factory.GetEnvironment()
-
-		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+		// Read the bootstrap properties.
+		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
+		var bootstrapData *api.BootstrapData
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 		if err == nil {
 
-			// Read the bootstrap properties.
-			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
-			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+			apiServerUrl := bootstrapData.ApiServerURL
+			log.Printf("The API server is at '%s'\n", apiServerUrl)
+
+			authenticator := factory.GetAuthenticator(
+				apiServerUrl,
+				galasaHome,
+			)
+
+			var apiClient *galasaapi.APIClient
+			apiClient, err = authenticator.GetAuthenticatedAPIClient()
+
 			if err == nil {
-
-				apiServerUrl := bootstrapData.ApiServerURL
-				log.Printf("The API server is at '%s'\n", apiServerUrl)
-
-				authenticator := factory.GetAuthenticator(
-					apiServerUrl,
-					galasaHome,
-				)
-
-				var apiClient *galasaapi.APIClient
-				apiClient, err = authenticator.GetAuthenticatedAPIClient()
-
-				if err == nil {
-					err = auth.DeleteToken(cmd.values.tokenId, apiClient)
-				}
+				err = auth.DeleteToken(cmd.values.tokenId, apiClient)
 			}
 		}
 	}

--- a/pkg/cmd/authTokensGet.go
+++ b/pkg/cmd/authTokensGet.go
@@ -30,12 +30,12 @@ type AuthTokensGetCommand struct {
 func NewAuthTokensGetCommand(
 	factory spi.Factory,
 	authTokensCommand spi.GalasaCommand,
-	rootCmd spi.GalasaCommand,
+	commsCmd spi.GalasaCommand,
 ) (spi.GalasaCommand, error) {
 
 	cmd := new(AuthTokensGetCommand)
 
-	err := cmd.init(factory, authTokensCommand, rootCmd)
+	err := cmd.init(factory, authTokensCommand, commsCmd)
 	return cmd, err
 }
 
@@ -58,10 +58,14 @@ func (cmd *AuthTokensGetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *AuthTokensGetCommand) init(factory spi.Factory, authTokensCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) error {
+func (cmd *AuthTokensGetCommand) init(
+	factory spi.Factory,
+	authTokensCommand spi.GalasaCommand,
+	commsCmd spi.GalasaCommand,
+) error {
 	var err error
 
-	cmd.cobraCommand, err = cmd.createCobraCmd(factory, authTokensCommand, rootCmd)
+	cmd.cobraCommand, err = cmd.createCobraCmd(factory, authTokensCommand, commsCmd)
 
 	return err
 }
@@ -69,7 +73,7 @@ func (cmd *AuthTokensGetCommand) init(factory spi.Factory, authTokensCommand spi
 func (cmd *AuthTokensGetCommand) createCobraCmd(
 	factory spi.Factory,
 	authTokensCommand,
-	rootCmd spi.GalasaCommand,
+	commsCmd spi.GalasaCommand,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -81,7 +85,7 @@ func (cmd *AuthTokensGetCommand) createCobraCmd(
 		Long:    "Get a list of tokens used for authentication with the Galasa API server",
 		Aliases: []string{COMMAND_NAME_AUTH_TOKENS_GET},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
-			return cmd.executeAuthTokensGet(factory, authTokensCommand.Values().(*AuthTokensCmdValues), rootCmd.Values().(*RootCmdValues))
+			return cmd.executeAuthTokensGet(factory, authTokensCommand.Values().(*AuthTokensCmdValues), commsCmd.Values().(*CommsCmdValues))
 		},
 	}
 
@@ -94,17 +98,17 @@ func (cmd *AuthTokensGetCommand) createCobraCmd(
 func (cmd *AuthTokensGetCommand) executeAuthTokensGet(
 	factory spi.Factory,
 	authTokenCmdValues *AuthTokensCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 
 	var err error
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 
 	if err == nil {
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Get tokens from the ecosystem")
 
@@ -112,13 +116,13 @@ func (cmd *AuthTokensGetCommand) executeAuthTokensGet(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, authTokenCmdValues.bootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				var console = factory.GetStdOutConsole()

--- a/pkg/cmd/authTokensGet.go
+++ b/pkg/cmd/authTokensGet.go
@@ -30,12 +30,12 @@ type AuthTokensGetCommand struct {
 func NewAuthTokensGetCommand(
 	factory spi.Factory,
 	authTokensCommand spi.GalasaCommand,
-	commsCmd spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (spi.GalasaCommand, error) {
 
 	cmd := new(AuthTokensGetCommand)
 
-	err := cmd.init(factory, authTokensCommand, commsCmd)
+	err := cmd.init(factory, authTokensCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -61,24 +61,24 @@ func (cmd *AuthTokensGetCommand) Values() interface{} {
 func (cmd *AuthTokensGetCommand) init(
 	factory spi.Factory,
 	authTokensCommand spi.GalasaCommand,
-	commsCmd spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) error {
 	var err error
 
-	cmd.cobraCommand, err = cmd.createCobraCmd(factory, authTokensCommand, commsCmd)
+	cmd.cobraCommand, err = cmd.createCobraCmd(factory, authTokensCommand, commsFlagSet)
 
 	return err
 }
 
 func (cmd *AuthTokensGetCommand) createCobraCmd(
 	factory spi.Factory,
-	authTokensCommand,
-	commsCmd spi.GalasaCommand,
+	authTokensCommand spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (*cobra.Command, error) {
 
 	var err error
 
-	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
+	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	authTokensGetCommandValues := authTokensCommand.Values().(*AuthTokensCmdValues)
 	authGetTokensCobraCmd := &cobra.Command{
@@ -103,7 +103,7 @@ func (cmd *AuthTokensGetCommand) createCobraCmd(
 func (cmd *AuthTokensGetCommand) executeAuthTokensGet(
 	factory spi.Factory,
 	authTokenCmdValues *AuthTokensCmdValues,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/authTokensGet.go
+++ b/pkg/cmd/authTokensGet.go
@@ -78,7 +78,7 @@ func (cmd *AuthTokensGetCommand) createCobraCmd(
 
 	var err error
 
-	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
+	commsFlagSetValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	authTokensGetCommandValues := authTokensCommand.Values().(*AuthTokensCmdValues)
 	authGetTokensCobraCmd := &cobra.Command{
@@ -88,9 +88,9 @@ func (cmd *AuthTokensGetCommand) createCobraCmd(
 		Aliases: []string{COMMAND_NAME_AUTH_TOKENS_GET},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeAuthTokensGet(factory, authTokensCommand.Values().(*AuthTokensCmdValues), commsCmdValues)
+				return cmd.executeAuthTokensGet(factory, authTokensCommand.Values().(*AuthTokensCmdValues), commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -103,14 +103,14 @@ func (cmd *AuthTokensGetCommand) createCobraCmd(
 func (cmd *AuthTokensGetCommand) executeAuthTokensGet(
 	factory spi.Factory,
 	authTokenCmdValues *AuthTokensCmdValues,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Get tokens from the ecosystem")
 
@@ -118,13 +118,13 @@ func (cmd *AuthTokensGetCommand) executeAuthTokensGet(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/commandCollection.go
+++ b/pkg/cmd/commandCollection.go
@@ -264,13 +264,13 @@ func (commands *commandCollectionImpl) addPropertiesCommands(factory spi.Factory
 
 	propertiesCommand, err = NewPropertiesCommand(rootCommand, commsCommand)
 	if err == nil {
-		propertiesGetCommand, err = NewPropertiesGetCommand(factory, propertiesCommand, rootCommand)
+		propertiesGetCommand, err = NewPropertiesGetCommand(factory, propertiesCommand, commsCommand)
 		if err == nil {
-			propertiesSetCommand, err = NewPropertiesSetCommand(factory, propertiesCommand, rootCommand)
+			propertiesSetCommand, err = NewPropertiesSetCommand(factory, propertiesCommand, commsCommand)
 			if err == nil {
-				propertiesDeleteCommand, err = NewPropertiesDeleteCommand(factory, propertiesCommand, rootCommand)
+				propertiesDeleteCommand, err = NewPropertiesDeleteCommand(factory, propertiesCommand, commsCommand)
 				if err == nil {
-					err = commands.addPropertiesNamespaceCommands(factory, rootCommand, propertiesCommand)
+					err = commands.addPropertiesNamespaceCommands(factory, commsCommand, propertiesCommand)
 				}
 			}
 		}
@@ -286,14 +286,14 @@ func (commands *commandCollectionImpl) addPropertiesCommands(factory spi.Factory
 	return err
 }
 
-func (commands *commandCollectionImpl) addPropertiesNamespaceCommands(factory spi.Factory, rootCommand spi.GalasaCommand, propertiesCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addPropertiesNamespaceCommands(factory spi.Factory, commsCommand spi.GalasaCommand, propertiesCommand spi.GalasaCommand) error {
 	var err error
 	var propertiesNamespaceCommand spi.GalasaCommand
 	var propertiesNamespaceGetCommand spi.GalasaCommand
 
-	propertiesNamespaceCommand, err = NewPropertiesNamespaceCommand(propertiesCommand, rootCommand)
+	propertiesNamespaceCommand, err = NewPropertiesNamespaceCommand(propertiesCommand)
 	if err == nil {
-		propertiesNamespaceGetCommand, err = NewPropertiesNamespaceGetCommand(factory, propertiesNamespaceCommand, propertiesCommand, rootCommand)
+		propertiesNamespaceGetCommand, err = NewPropertiesNamespaceGetCommand(factory, propertiesNamespaceCommand, propertiesCommand, commsCommand)
 	}
 
 	if err == nil {

--- a/pkg/cmd/commandCollection.go
+++ b/pkg/cmd/commandCollection.go
@@ -433,9 +433,9 @@ func (commands *commandCollectionImpl) addUsersCommands(factory spi.Factory, roo
 	usersCommand, err = NewUsersCommand(rootCommand, commsCommand)
 
 	if err == nil {
-		usersGetCommand, err = NewUsersGetCommand(factory, usersCommand, rootCommand)
+		usersGetCommand, err = NewUsersGetCommand(factory, usersCommand, commsCommand)
 		if err == nil {
-			usersDeleteCommand, err = NewUsersDeleteCommand(factory, usersCommand, rootCommand)
+			usersDeleteCommand, err = NewUsersDeleteCommand(factory, usersCommand, commsCommand)
 			if err == nil {
 				commands.commandMap[usersCommand.Name()] = usersCommand
 				commands.commandMap[usersGetCommand.Name()] = usersGetCommand

--- a/pkg/cmd/commandCollection.go
+++ b/pkg/cmd/commandCollection.go
@@ -114,7 +114,7 @@ func (commands *commandCollectionImpl) Execute(args []string) error {
 // Private functions.
 // -----------------------------------------------------------------
 func (commands *commandCollectionImpl) init(factory spi.Factory) error {
-	var commsCommand spi.GalasaCommand
+	var commsFlagSet GalasaFlagSet
 
 	commands.commandMap = make(map[string]spi.GalasaCommand)
 
@@ -123,11 +123,11 @@ func (commands *commandCollectionImpl) init(factory spi.Factory) error {
 		commands.rootCommand = rootCommand
 		commands.commandMap[rootCommand.Name()] = rootCommand
 
-		commsCommand, err = NewCommsCommand(rootCommand)
+		commsFlagSet, err = NewCommsFlagSet(rootCommand)
 	}
 
 	if err == nil {
-		err = commands.addAuthCommands(factory, rootCommand, commsCommand)
+		err = commands.addAuthCommands(factory, rootCommand, commsFlagSet)
 	}
 
 	if err == nil {
@@ -139,23 +139,23 @@ func (commands *commandCollectionImpl) init(factory spi.Factory) error {
 	}
 
 	if err == nil {
-		err = commands.addPropertiesCommands(factory, rootCommand, commsCommand)
+		err = commands.addPropertiesCommands(factory, rootCommand, commsFlagSet)
 	}
 
 	if err == nil {
-		err = commands.addRunsCommands(factory, rootCommand, commsCommand)
+		err = commands.addRunsCommands(factory, rootCommand, commsFlagSet)
 	}
 
 	if err == nil {
-		err = commands.addResourcesCommands(factory, rootCommand, commsCommand)
+		err = commands.addResourcesCommands(factory, rootCommand, commsFlagSet)
 	}
 
 	if err == nil {
-		err = commands.addSecretsCommands(factory, rootCommand, commsCommand)
+		err = commands.addSecretsCommands(factory, rootCommand, commsFlagSet)
 	}
 
 	if err == nil {
-		err = commands.addUsersCommands(factory, rootCommand, commsCommand)
+		err = commands.addUsersCommands(factory, rootCommand, commsFlagSet)
 	}
 
 	if err == nil {
@@ -165,19 +165,19 @@ func (commands *commandCollectionImpl) init(factory spi.Factory) error {
 	return err
 }
 
-func (commands *commandCollectionImpl) addAuthCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addAuthCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 	var authCommand spi.GalasaCommand
 	var authLoginCommand spi.GalasaCommand
 	var authLogoutCommand spi.GalasaCommand
 
-	authCommand, err = NewAuthCommand(rootCommand, commsCommand)
+	authCommand, err = NewAuthCommand(rootCommand, commsFlagSet)
 	if err == nil {
-		authLoginCommand, err = NewAuthLoginCommand(factory, authCommand, rootCommand, commsCommand)
+		authLoginCommand, err = NewAuthLoginCommand(factory, authCommand, rootCommand, commsFlagSet)
 		if err == nil {
 			authLogoutCommand, err = NewAuthLogoutCommand(factory, authCommand, rootCommand)
 			if err == nil {
-				err = commands.addAuthTokensCommands(factory, authCommand, commsCommand)
+				err = commands.addAuthTokensCommands(factory, authCommand, commsFlagSet)
 			}
 		}
 	}
@@ -194,7 +194,7 @@ func (commands *commandCollectionImpl) addAuthCommands(factory spi.Factory, root
 func (commands *commandCollectionImpl) addAuthTokensCommands(
 	factory spi.Factory,
 	authCommand spi.GalasaCommand,
-	commsCommand spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) error {
 	var err error
 	var authTokensCommand spi.GalasaCommand
@@ -203,9 +203,9 @@ func (commands *commandCollectionImpl) addAuthTokensCommands(
 
 	authTokensCommand, err = NewAuthTokensCommand(authCommand)
 	if err == nil {
-		authTokensGetCommand, err = NewAuthTokensGetCommand(factory, authTokensCommand, commsCommand)
+		authTokensGetCommand, err = NewAuthTokensGetCommand(factory, authTokensCommand, commsFlagSet)
 		if err == nil {
-			authTokensDeleteCommand, err = NewAuthTokensDeleteCommand(factory, authTokensCommand, commsCommand)
+			authTokensDeleteCommand, err = NewAuthTokensDeleteCommand(factory, authTokensCommand, commsFlagSet)
 		}
 	}
 
@@ -255,22 +255,22 @@ func (commands *commandCollectionImpl) addProjectCommands(factory spi.Factory, r
 	return err
 }
 
-func (commands *commandCollectionImpl) addPropertiesCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addPropertiesCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 	var propertiesCommand spi.GalasaCommand
 	var propertiesGetCommand spi.GalasaCommand
 	var propertiesDeleteCommand spi.GalasaCommand
 	var propertiesSetCommand spi.GalasaCommand
 
-	propertiesCommand, err = NewPropertiesCommand(rootCommand, commsCommand)
+	propertiesCommand, err = NewPropertiesCommand(rootCommand, commsFlagSet)
 	if err == nil {
-		propertiesGetCommand, err = NewPropertiesGetCommand(factory, propertiesCommand, commsCommand)
+		propertiesGetCommand, err = NewPropertiesGetCommand(factory, propertiesCommand, commsFlagSet)
 		if err == nil {
-			propertiesSetCommand, err = NewPropertiesSetCommand(factory, propertiesCommand, commsCommand)
+			propertiesSetCommand, err = NewPropertiesSetCommand(factory, propertiesCommand, commsFlagSet)
 			if err == nil {
-				propertiesDeleteCommand, err = NewPropertiesDeleteCommand(factory, propertiesCommand, commsCommand)
+				propertiesDeleteCommand, err = NewPropertiesDeleteCommand(factory, propertiesCommand, commsFlagSet)
 				if err == nil {
-					err = commands.addPropertiesNamespaceCommands(factory, commsCommand, propertiesCommand)
+					err = commands.addPropertiesNamespaceCommands(factory, commsFlagSet, propertiesCommand)
 				}
 			}
 		}
@@ -286,14 +286,14 @@ func (commands *commandCollectionImpl) addPropertiesCommands(factory spi.Factory
 	return err
 }
 
-func (commands *commandCollectionImpl) addPropertiesNamespaceCommands(factory spi.Factory, commsCommand spi.GalasaCommand, propertiesCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addPropertiesNamespaceCommands(factory spi.Factory, commsFlagSet GalasaFlagSet, propertiesCommand spi.GalasaCommand) error {
 	var err error
 	var propertiesNamespaceCommand spi.GalasaCommand
 	var propertiesNamespaceGetCommand spi.GalasaCommand
 
 	propertiesNamespaceCommand, err = NewPropertiesNamespaceCommand(propertiesCommand)
 	if err == nil {
-		propertiesNamespaceGetCommand, err = NewPropertiesNamespaceGetCommand(factory, propertiesNamespaceCommand, propertiesCommand, commsCommand)
+		propertiesNamespaceGetCommand, err = NewPropertiesNamespaceGetCommand(factory, propertiesNamespaceCommand, propertiesCommand, commsFlagSet)
 	}
 
 	if err == nil {
@@ -303,7 +303,7 @@ func (commands *commandCollectionImpl) addPropertiesNamespaceCommands(factory sp
 	return err
 }
 
-func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 	var runsCommand spi.GalasaCommand
@@ -316,23 +316,23 @@ func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, root
 	var runsCancelCommand spi.GalasaCommand
 	var runsDeleteCommand spi.GalasaCommand
 
-	runsCommand, err = NewRunsCmd(rootCommand, commsCommand)
+	runsCommand, err = NewRunsCmd(rootCommand, commsFlagSet)
 	if err == nil {
-		runsDownloadCommand, err = NewRunsDownloadCommand(factory, runsCommand, commsCommand)
+		runsDownloadCommand, err = NewRunsDownloadCommand(factory, runsCommand, commsFlagSet)
 		if err == nil {
-			runsGetCommand, err = NewRunsGetCommand(factory, runsCommand, commsCommand)
+			runsGetCommand, err = NewRunsGetCommand(factory, runsCommand, commsFlagSet)
 			if err == nil {
-				runsPrepareCommand, err = NewRunsPrepareCommand(factory, runsCommand, commsCommand)
+				runsPrepareCommand, err = NewRunsPrepareCommand(factory, runsCommand, commsFlagSet)
 				if err == nil {
-					runsSubmitCommand, err = NewRunsSubmitCommand(factory, runsCommand, commsCommand)
+					runsSubmitCommand, err = NewRunsSubmitCommand(factory, runsCommand, commsFlagSet)
 					if err == nil {
-						runsSubmitLocalCommand, err = NewRunsSubmitLocalCommand(factory, runsSubmitCommand, runsCommand, commsCommand)
+						runsSubmitLocalCommand, err = NewRunsSubmitLocalCommand(factory, runsSubmitCommand, runsCommand, commsFlagSet)
 						if err == nil {
-							runsResetCommand, err = NewRunsResetCommand(factory, runsCommand, commsCommand)
+							runsResetCommand, err = NewRunsResetCommand(factory, runsCommand, commsFlagSet)
 							if err == nil {
-								runsCancelCommand, err = NewRunsCancelCommand(factory, runsCommand, commsCommand)
+								runsCancelCommand, err = NewRunsCancelCommand(factory, runsCommand, commsFlagSet)
 								if err == nil {
-									runsDeleteCommand, err = NewRunsDeleteCommand(factory, runsCommand, commsCommand)
+									runsDeleteCommand, err = NewRunsDeleteCommand(factory, runsCommand, commsFlagSet)
 								}
 							}
 						}
@@ -357,7 +357,7 @@ func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, root
 	return err
 }
 
-func (commands *commandCollectionImpl) addResourcesCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addResourcesCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 	var resourcesCommand spi.GalasaCommand
@@ -366,15 +366,15 @@ func (commands *commandCollectionImpl) addResourcesCommands(factory spi.Factory,
 	var resourcesUpdateCommand spi.GalasaCommand
 	var resourcesDeleteCommand spi.GalasaCommand
 
-	resourcesCommand, err = NewResourcesCmd(rootCommand, commsCommand)
+	resourcesCommand, err = NewResourcesCmd(rootCommand, commsFlagSet)
 	if err == nil {
-		resourcesApplyCommand, err = NewResourcesApplyCommand(factory, resourcesCommand, commsCommand)
+		resourcesApplyCommand, err = NewResourcesApplyCommand(factory, resourcesCommand, commsFlagSet)
 		if err == nil {
-			resourcesCreateCommand, err = NewResourcesCreateCommand(factory, resourcesCommand, commsCommand)
+			resourcesCreateCommand, err = NewResourcesCreateCommand(factory, resourcesCommand, commsFlagSet)
 			if err == nil {
-				resourcesUpdateCommand, err = NewResourcesUpdateCommand(factory, resourcesCommand, commsCommand)
+				resourcesUpdateCommand, err = NewResourcesUpdateCommand(factory, resourcesCommand, commsFlagSet)
 				if err == nil {
-					resourcesDeleteCommand, err = NewResourcesDeleteCommand(factory, resourcesCommand, commsCommand)
+					resourcesDeleteCommand, err = NewResourcesDeleteCommand(factory, resourcesCommand, commsFlagSet)
 				}
 			}
 		}
@@ -391,7 +391,7 @@ func (commands *commandCollectionImpl) addResourcesCommands(factory spi.Factory,
 	return err
 }
 
-func (commands *commandCollectionImpl) addSecretsCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addSecretsCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 	var secretsCommand spi.GalasaCommand
@@ -399,18 +399,18 @@ func (commands *commandCollectionImpl) addSecretsCommands(factory spi.Factory, r
 	var secretsSetCommand spi.GalasaCommand
 	var secretsDeleteCommand spi.GalasaCommand
 
-	secretsCommand, err = NewSecretsCmd(rootCommand, commsCommand)
+	secretsCommand, err = NewSecretsCmd(rootCommand, commsFlagSet)
 
 	if err == nil {
-		secretsGetCommand, err = NewSecretsGetCommand(factory, secretsCommand, commsCommand)
+		secretsGetCommand, err = NewSecretsGetCommand(factory, secretsCommand, commsFlagSet)
 	}
 
 	if err == nil {
-		secretsSetCommand, err = NewSecretsSetCommand(factory, secretsCommand, commsCommand)
+		secretsSetCommand, err = NewSecretsSetCommand(factory, secretsCommand, commsFlagSet)
 	}
 
 	if err == nil {
-		secretsDeleteCommand, err = NewSecretsDeleteCommand(factory, secretsCommand, commsCommand)
+		secretsDeleteCommand, err = NewSecretsDeleteCommand(factory, secretsCommand, commsFlagSet)
 	}
 
 	if err == nil {
@@ -423,19 +423,19 @@ func (commands *commandCollectionImpl) addSecretsCommands(factory spi.Factory, r
 	return err
 }
 
-func (commands *commandCollectionImpl) addUsersCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addUsersCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 	var usersCommand spi.GalasaCommand
 	var usersGetCommand spi.GalasaCommand
 	var usersDeleteCommand spi.GalasaCommand
 
-	usersCommand, err = NewUsersCommand(rootCommand, commsCommand)
+	usersCommand, err = NewUsersCommand(rootCommand, commsFlagSet)
 
 	if err == nil {
-		usersGetCommand, err = NewUsersGetCommand(factory, usersCommand, commsCommand)
+		usersGetCommand, err = NewUsersGetCommand(factory, usersCommand, commsFlagSet)
 		if err == nil {
-			usersDeleteCommand, err = NewUsersDeleteCommand(factory, usersCommand, commsCommand)
+			usersDeleteCommand, err = NewUsersDeleteCommand(factory, usersCommand, commsFlagSet)
 			if err == nil {
 				commands.commandMap[usersCommand.Name()] = usersCommand
 				commands.commandMap[usersGetCommand.Name()] = usersGetCommand

--- a/pkg/cmd/commandCollection.go
+++ b/pkg/cmd/commandCollection.go
@@ -173,7 +173,7 @@ func (commands *commandCollectionImpl) addAuthCommands(factory spi.Factory, root
 
 	authCommand, err = NewAuthCommand(rootCommand, commsCommand)
 	if err == nil {
-		authLoginCommand, err = NewAuthLoginCommand(factory, authCommand, rootCommand)
+		authLoginCommand, err = NewAuthLoginCommand(factory, authCommand, rootCommand, commsCommand)
 		if err == nil {
 			authLogoutCommand, err = NewAuthLogoutCommand(factory, authCommand, rootCommand)
 			if err == nil {
@@ -191,17 +191,21 @@ func (commands *commandCollectionImpl) addAuthCommands(factory spi.Factory, root
 	return err
 }
 
-func (commands *commandCollectionImpl) addAuthTokensCommands(factory spi.Factory, authCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addAuthTokensCommands(
+	factory spi.Factory,
+	authCommand spi.GalasaCommand,
+	commsCommand spi.GalasaCommand,
+) error {
 	var err error
 	var authTokensCommand spi.GalasaCommand
 	var authTokensGetCommand spi.GalasaCommand
 	var authTokensDeleteCommand spi.GalasaCommand
 
-	authTokensCommand, err = NewAuthTokensCommand(authCommand, rootCommand)
+	authTokensCommand, err = NewAuthTokensCommand(authCommand)
 	if err == nil {
-		authTokensGetCommand, err = NewAuthTokensGetCommand(factory, authTokensCommand, rootCommand)
+		authTokensGetCommand, err = NewAuthTokensGetCommand(factory, authTokensCommand, commsCommand)
 		if err == nil {
-			authTokensDeleteCommand, err = NewAuthTokensDeleteCommand(factory, authTokensCommand, rootCommand)
+			authTokensDeleteCommand, err = NewAuthTokensDeleteCommand(factory, authTokensCommand, commsCommand)
 		}
 	}
 

--- a/pkg/cmd/commandCollection.go
+++ b/pkg/cmd/commandCollection.go
@@ -318,21 +318,21 @@ func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, root
 
 	runsCommand, err = NewRunsCmd(rootCommand, commsCommand)
 	if err == nil {
-		runsDownloadCommand, err = NewRunsDownloadCommand(factory, runsCommand, rootCommand)
+		runsDownloadCommand, err = NewRunsDownloadCommand(factory, runsCommand, commsCommand)
 		if err == nil {
-			runsGetCommand, err = NewRunsGetCommand(factory, runsCommand, rootCommand)
+			runsGetCommand, err = NewRunsGetCommand(factory, runsCommand, commsCommand)
 			if err == nil {
-				runsPrepareCommand, err = NewRunsPrepareCommand(factory, runsCommand, rootCommand)
+				runsPrepareCommand, err = NewRunsPrepareCommand(factory, runsCommand, commsCommand)
 				if err == nil {
-					runsSubmitCommand, err = NewRunsSubmitCommand(factory, runsCommand, rootCommand)
+					runsSubmitCommand, err = NewRunsSubmitCommand(factory, runsCommand, commsCommand)
 					if err == nil {
-						runsSubmitLocalCommand, err = NewRunsSubmitLocalCommand(factory, runsSubmitCommand, runsCommand, rootCommand)
+						runsSubmitLocalCommand, err = NewRunsSubmitLocalCommand(factory, runsSubmitCommand, runsCommand, commsCommand)
 						if err == nil {
-							runsResetCommand, err = NewRunsResetCommand(factory, runsCommand, rootCommand)
+							runsResetCommand, err = NewRunsResetCommand(factory, runsCommand, commsCommand)
 							if err == nil {
-								runsCancelCommand, err = NewRunsCancelCommand(factory, runsCommand, rootCommand)
+								runsCancelCommand, err = NewRunsCancelCommand(factory, runsCommand, commsCommand)
 								if err == nil {
-									runsDeleteCommand, err = NewRunsDeleteCommand(factory, runsCommand, rootCommand)
+									runsDeleteCommand, err = NewRunsDeleteCommand(factory, runsCommand, commsCommand)
 								}
 							}
 						}

--- a/pkg/cmd/commandCollection.go
+++ b/pkg/cmd/commandCollection.go
@@ -402,15 +402,15 @@ func (commands *commandCollectionImpl) addSecretsCommands(factory spi.Factory, r
 	secretsCommand, err = NewSecretsCmd(rootCommand, commsCommand)
 
 	if err == nil {
-		secretsGetCommand, err = NewSecretsGetCommand(factory, secretsCommand, rootCommand)
+		secretsGetCommand, err = NewSecretsGetCommand(factory, secretsCommand, commsCommand)
 	}
 
 	if err == nil {
-		secretsSetCommand, err = NewSecretsSetCommand(factory, secretsCommand, rootCommand)
+		secretsSetCommand, err = NewSecretsSetCommand(factory, secretsCommand, commsCommand)
 	}
 
 	if err == nil {
-		secretsDeleteCommand, err = NewSecretsDeleteCommand(factory, secretsCommand, rootCommand)
+		secretsDeleteCommand, err = NewSecretsDeleteCommand(factory, secretsCommand, commsCommand)
 	}
 
 	if err == nil {

--- a/pkg/cmd/commandCollection.go
+++ b/pkg/cmd/commandCollection.go
@@ -368,13 +368,13 @@ func (commands *commandCollectionImpl) addResourcesCommands(factory spi.Factory,
 
 	resourcesCommand, err = NewResourcesCmd(rootCommand, commsCommand)
 	if err == nil {
-		resourcesApplyCommand, err = NewResourcesApplyCommand(factory, resourcesCommand, rootCommand)
+		resourcesApplyCommand, err = NewResourcesApplyCommand(factory, resourcesCommand, commsCommand)
 		if err == nil {
-			resourcesCreateCommand, err = NewResourcesCreateCommand(factory, resourcesCommand, rootCommand)
+			resourcesCreateCommand, err = NewResourcesCreateCommand(factory, resourcesCommand, commsCommand)
 			if err == nil {
-				resourcesUpdateCommand, err = NewResourcesUpdateCommand(factory, resourcesCommand, rootCommand)
+				resourcesUpdateCommand, err = NewResourcesUpdateCommand(factory, resourcesCommand, commsCommand)
 				if err == nil {
-					resourcesDeleteCommand, err = NewResourcesDeleteCommand(factory, resourcesCommand, rootCommand)
+					resourcesDeleteCommand, err = NewResourcesDeleteCommand(factory, resourcesCommand, commsCommand)
 				}
 			}
 		}

--- a/pkg/cmd/commandCollection.go
+++ b/pkg/cmd/commandCollection.go
@@ -114,6 +114,7 @@ func (commands *commandCollectionImpl) Execute(args []string) error {
 // Private functions.
 // -----------------------------------------------------------------
 func (commands *commandCollectionImpl) init(factory spi.Factory) error {
+	var commsCommand spi.GalasaCommand
 
 	commands.commandMap = make(map[string]spi.GalasaCommand)
 
@@ -121,10 +122,12 @@ func (commands *commandCollectionImpl) init(factory spi.Factory) error {
 	if err == nil {
 		commands.rootCommand = rootCommand
 		commands.commandMap[rootCommand.Name()] = rootCommand
+
+		commsCommand, err = NewCommsCommand(rootCommand)
 	}
 
 	if err == nil {
-		err = commands.addAuthCommands(factory, rootCommand)
+		err = commands.addAuthCommands(factory, rootCommand, commsCommand)
 	}
 
 	if err == nil {
@@ -136,23 +139,23 @@ func (commands *commandCollectionImpl) init(factory spi.Factory) error {
 	}
 
 	if err == nil {
-		err = commands.addPropertiesCommands(factory, rootCommand)
+		err = commands.addPropertiesCommands(factory, rootCommand, commsCommand)
 	}
 
 	if err == nil {
-		err = commands.addRunsCommands(factory, rootCommand)
+		err = commands.addRunsCommands(factory, rootCommand, commsCommand)
 	}
 
 	if err == nil {
-		err = commands.addResourcesCommands(factory, rootCommand)
+		err = commands.addResourcesCommands(factory, rootCommand, commsCommand)
 	}
 
 	if err == nil {
-		err = commands.addSecretsCommands(factory, rootCommand)
+		err = commands.addSecretsCommands(factory, rootCommand, commsCommand)
 	}
 
 	if err == nil {
-		err = commands.addUsersCommands(factory, rootCommand)
+		err = commands.addUsersCommands(factory, rootCommand, commsCommand)
 	}
 
 	if err == nil {
@@ -162,19 +165,19 @@ func (commands *commandCollectionImpl) init(factory spi.Factory) error {
 	return err
 }
 
-func (commands *commandCollectionImpl) addAuthCommands(factory spi.Factory, rootCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addAuthCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 	var err error
 	var authCommand spi.GalasaCommand
 	var authLoginCommand spi.GalasaCommand
 	var authLogoutCommand spi.GalasaCommand
 
-	authCommand, err = NewAuthCommand(rootCommand)
+	authCommand, err = NewAuthCommand(rootCommand, commsCommand)
 	if err == nil {
 		authLoginCommand, err = NewAuthLoginCommand(factory, authCommand, rootCommand)
 		if err == nil {
 			authLogoutCommand, err = NewAuthLogoutCommand(factory, authCommand, rootCommand)
 			if err == nil {
-				err = commands.addAuthTokensCommands(factory, authCommand, rootCommand)
+				err = commands.addAuthTokensCommands(factory, authCommand, commsCommand)
 			}
 		}
 	}
@@ -248,14 +251,14 @@ func (commands *commandCollectionImpl) addProjectCommands(factory spi.Factory, r
 	return err
 }
 
-func (commands *commandCollectionImpl) addPropertiesCommands(factory spi.Factory, rootCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addPropertiesCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 	var err error
 	var propertiesCommand spi.GalasaCommand
 	var propertiesGetCommand spi.GalasaCommand
 	var propertiesDeleteCommand spi.GalasaCommand
 	var propertiesSetCommand spi.GalasaCommand
 
-	propertiesCommand, err = NewPropertiesCommand(rootCommand)
+	propertiesCommand, err = NewPropertiesCommand(rootCommand, commsCommand)
 	if err == nil {
 		propertiesGetCommand, err = NewPropertiesGetCommand(factory, propertiesCommand, rootCommand)
 		if err == nil {
@@ -296,7 +299,7 @@ func (commands *commandCollectionImpl) addPropertiesNamespaceCommands(factory sp
 	return err
 }
 
-func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, rootCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 	var runsCommand spi.GalasaCommand
@@ -309,7 +312,7 @@ func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, root
 	var runsCancelCommand spi.GalasaCommand
 	var runsDeleteCommand spi.GalasaCommand
 
-	runsCommand, err = NewRunsCmd(rootCommand)
+	runsCommand, err = NewRunsCmd(rootCommand, commsCommand)
 	if err == nil {
 		runsDownloadCommand, err = NewRunsDownloadCommand(factory, runsCommand, rootCommand)
 		if err == nil {
@@ -350,7 +353,7 @@ func (commands *commandCollectionImpl) addRunsCommands(factory spi.Factory, root
 	return err
 }
 
-func (commands *commandCollectionImpl) addResourcesCommands(factory spi.Factory, rootCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addResourcesCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 	var resourcesCommand spi.GalasaCommand
@@ -359,7 +362,7 @@ func (commands *commandCollectionImpl) addResourcesCommands(factory spi.Factory,
 	var resourcesUpdateCommand spi.GalasaCommand
 	var resourcesDeleteCommand spi.GalasaCommand
 
-	resourcesCommand, err = NewResourcesCmd(rootCommand)
+	resourcesCommand, err = NewResourcesCmd(rootCommand, commsCommand)
 	if err == nil {
 		resourcesApplyCommand, err = NewResourcesApplyCommand(factory, resourcesCommand, rootCommand)
 		if err == nil {
@@ -384,7 +387,7 @@ func (commands *commandCollectionImpl) addResourcesCommands(factory spi.Factory,
 	return err
 }
 
-func (commands *commandCollectionImpl) addSecretsCommands(factory spi.Factory, rootCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addSecretsCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 	var secretsCommand spi.GalasaCommand
@@ -392,7 +395,7 @@ func (commands *commandCollectionImpl) addSecretsCommands(factory spi.Factory, r
 	var secretsSetCommand spi.GalasaCommand
 	var secretsDeleteCommand spi.GalasaCommand
 
-	secretsCommand, err = NewSecretsCmd(rootCommand)
+	secretsCommand, err = NewSecretsCmd(rootCommand, commsCommand)
 
 	if err == nil {
 		secretsGetCommand, err = NewSecretsGetCommand(factory, secretsCommand, rootCommand)
@@ -416,14 +419,14 @@ func (commands *commandCollectionImpl) addSecretsCommands(factory spi.Factory, r
 	return err
 }
 
-func (commands *commandCollectionImpl) addUsersCommands(factory spi.Factory, rootCommand spi.GalasaCommand) error {
+func (commands *commandCollectionImpl) addUsersCommands(factory spi.Factory, rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 	var usersCommand spi.GalasaCommand
 	var usersGetCommand spi.GalasaCommand
 	var usersDeleteCommand spi.GalasaCommand
 
-	usersCommand, err = NewUsersCommand(rootCommand)
+	usersCommand, err = NewUsersCommand(rootCommand, commsCommand)
 
 	if err == nil {
 		usersGetCommand, err = NewUsersGetCommand(factory, usersCommand, rootCommand)

--- a/pkg/cmd/commonFlags.go
+++ b/pkg/cmd/commonFlags.go
@@ -6,7 +6,7 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // ------------------------------------------------------------------------------------------------
@@ -15,19 +15,19 @@ import (
 //   depending on the command it is being added to.
 // ------------------------------------------------------------------------------------------------
 
-func addBootstrapFlag(cobraCommand *cobra.Command, parsedValueLocation *string) {
-	cobraCommand.PersistentFlags().StringVarP(parsedValueLocation, "bootstrap", "b", "",
+func addBootstrapFlag(flagSet *pflag.FlagSet, parsedValueLocation *string) {
+	flagSet.StringVarP(parsedValueLocation, "bootstrap", "b", "",
 		"Bootstrap URL. Should start with 'http://' or 'file://'. "+
 			"If it starts with neither, it is assumed to be a fully-qualified path. "+
 			"If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. "+
 			"Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties")
 }
 
-func addRateLimitRetryFlags(cobraCommand *cobra.Command, maxRetries *int, retryBackoffSeconds *float64) {
-	cobraCommand.PersistentFlags().IntVar(maxRetries, "rate-limit-retries", 3,
+func addRateLimitRetryFlags(flagSet *pflag.FlagSet, maxRetries *int, retryBackoffSeconds *float64) {
+	flagSet.IntVar(maxRetries, "rate-limit-retries", 3,
 		"The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. "+
 			"Defaults to 3 retries")
 
-	cobraCommand.PersistentFlags().Float64Var(retryBackoffSeconds, "rate-limit-retry-backoff", float64(1),
+	flagSet.Float64Var(retryBackoffSeconds, "rate-limit-retry-backoff-secs", float64(1),
 	"The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second.")
 }

--- a/pkg/cmd/commonFlags.go
+++ b/pkg/cmd/commonFlags.go
@@ -22,3 +22,12 @@ func addBootstrapFlag(cobraCommand *cobra.Command, parsedValueLocation *string) 
 			"If missing, it defaults to use the 'bootstrap.properties' file in your GALASA_HOME. "+
 			"Example: http://example.com/bootstrap, file:///user/myuserid/.galasa/bootstrap.properties , file://C:/Users/myuserid/.galasa/bootstrap.properties")
 }
+
+func addRateLimitRetryFlags(cobraCommand *cobra.Command, maxRetries *int, retryBackoffSeconds *float64) {
+	cobraCommand.PersistentFlags().IntVar(maxRetries, "rate-limit-retries", 3,
+		"The maximum number of retries that should be made when requests to the Galasa Service fail due to rate limits being exceeded. Must be a whole number. "+
+			"Defaults to 3 retries")
+
+	cobraCommand.PersistentFlags().Float64Var(retryBackoffSeconds, "rate-limit-retry-backoff", float64(1),
+	"The amount of time in seconds to wait before retrying a command if it failed due to rate limits being exceeded. Defaults to 1 second.")
+}

--- a/pkg/cmd/commsCommand.go
+++ b/pkg/cmd/commsCommand.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package cmd
+
+import (
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/spf13/cobra"
+)
+
+type CommsCmdValues struct {
+	bootstrap string
+    maxRetries int
+    retryBackoffSeconds float64
+}
+
+type CommsCommand struct {
+	cobraCommand *cobra.Command
+	values       *CommsCmdValues
+}
+
+// ------------------------------------------------------------------------------------------------
+// Constructors
+// ------------------------------------------------------------------------------------------------
+
+func NewCommsCommand(rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+	cmd := new(CommsCommand)
+	err := cmd.init(rootCommand)
+	return cmd, err
+}
+
+// ------------------------------------------------------------------------------------------------
+// Public functions
+// ------------------------------------------------------------------------------------------------
+
+func (cmd *CommsCommand) Name() string {
+    // This is a hidden command, so no assume no name
+	return ""
+}
+
+func (cmd *CommsCommand) CobraCommand() *cobra.Command {
+	return cmd.cobraCommand
+}
+
+func (cmd *CommsCommand) Values() interface{} {
+	return cmd.values
+}
+
+// ------------------------------------------------------------------------------------------------
+// Private functions
+// ------------------------------------------------------------------------------------------------
+
+func (cmd *CommsCommand) init(rootCmd spi.GalasaCommand) error {
+
+	var err error
+
+	cmd.values = &CommsCmdValues{}
+	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd)
+
+	return err
+}
+
+func (cmd *CommsCommand) createCobraCommand(rootCommand spi.GalasaCommand) (*cobra.Command, error) {
+
+	var err error
+
+	commsCobraCmd := &cobra.Command{
+		Hidden: true,
+		SilenceUsage: true,
+	}
+
+	addBootstrapFlag(commsCobraCmd, &cmd.values.bootstrap)
+    addRateLimitRetryFlags(commsCobraCmd, &cmd.values.maxRetries, &cmd.values.retryBackoffSeconds)
+
+	rootCommand.CobraCommand().AddCommand(commsCobraCmd)
+
+	return commsCobraCmd, err
+}

--- a/pkg/cmd/commsCommand.go
+++ b/pkg/cmd/commsCommand.go
@@ -14,6 +14,7 @@ type CommsCmdValues struct {
 	bootstrap string
     maxRetries int
     retryBackoffSeconds float64
+	*RootCmdValues
 }
 
 type CommsCommand struct {
@@ -56,7 +57,9 @@ func (cmd *CommsCommand) init(rootCmd spi.GalasaCommand) error {
 
 	var err error
 
-	cmd.values = &CommsCmdValues{}
+	cmd.values = &CommsCmdValues{
+		RootCmdValues: rootCmd.Values().(*RootCmdValues),
+	}
 	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd)
 
 	return err

--- a/pkg/cmd/commsCommand.go
+++ b/pkg/cmd/commsCommand.go
@@ -62,25 +62,22 @@ func (cmd *CommsCommand) init(rootCmd spi.GalasaCommand) error {
 	cmd.values = &CommsCmdValues{
 		RootCmdValues: rootCmd.Values().(*RootCmdValues),
 	}
-	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd)
+	cmd.cobraCommand, err = cmd.createCobraCommand()
 
 	return err
 }
 
-func (cmd *CommsCommand) createCobraCommand(rootCommand spi.GalasaCommand) (*cobra.Command, error) {
+func (cmd *CommsCommand) createCobraCommand() (*cobra.Command, error) {
 
 	var err error
 
 	commsCobraCmd := &cobra.Command{
-		Use: "",
 		Hidden: true,
 		SilenceUsage: true,
 	}
 
 	addBootstrapFlag(commsCobraCmd, &cmd.values.bootstrap)
     addRateLimitRetryFlags(commsCobraCmd, &cmd.values.maxRetries, &cmd.values.retryBackoffSeconds)
-
-	rootCommand.CobraCommand().AddCommand(commsCobraCmd)
 
 	return commsCobraCmd, err
 }

--- a/pkg/cmd/commsFlagSet.go
+++ b/pkg/cmd/commsFlagSet.go
@@ -79,10 +79,10 @@ func (commsFlagSet *CommsFlagSet) createFlagSet() (*pflag.FlagSet, error) {
 	return flagSet, err
 }
 
-func executeCommandWithRetries(factory spi.Factory, commsCmdValues *CommsFlagSetValues, executionFunc func() error) error {
+func executeCommandWithRetries(factory spi.Factory, commsFlagSetValues *CommsFlagSetValues, executionFunc func() error) error {
 	retryFunc := func() error {
-		commsRetrier := api.NewCommsRetrier(commsCmdValues.maxRetries, commsCmdValues.retryBackoffSeconds, factory.GetTimeService())
+		commsRetrier := api.NewCommsRetrier(commsFlagSetValues.maxRetries, commsFlagSetValues.retryBackoffSeconds, factory.GetTimeService())
 		return commsRetrier.ExecuteCommandWithRateLimitRetries(executionFunc)
 	}
-	return utils.CaptureExecutionLogs(factory, commsCmdValues.logFileName, retryFunc)
+	return utils.CaptureExecutionLogs(factory, commsFlagSetValues.logFileName, retryFunc)
 }

--- a/pkg/cmd/properties.go
+++ b/pkg/cmd/properties.go
@@ -12,7 +12,6 @@ import (
 )
 
 type PropertiesCmdValues struct {
-	ecosystemBootstrap string
 	namespace          string
 	propertyName       string
 }
@@ -70,8 +69,6 @@ func (cmd *PropertiesCommand) createCobraCommand(
 		Short: "Manages properties in an ecosystem",
 		Long:  "Allows interaction with the CPS to create, query and maintain properties in Galasa Ecosystem",
 	}
-
-	addBootstrapFlag(propertiesCobraCmd, &cmd.values.ecosystemBootstrap)
 
 	rootCommand.CobraCommand().AddCommand(propertiesCobraCmd)
 	commsCommand.CobraCommand().AddCommand(propertiesCobraCmd)

--- a/pkg/cmd/properties.go
+++ b/pkg/cmd/properties.go
@@ -70,8 +70,8 @@ func (cmd *PropertiesCommand) createCobraCommand(
 		Long:  "Allows interaction with the CPS to create, query and maintain properties in Galasa Ecosystem",
 	}
 
+	propertiesCobraCmd.PersistentFlags().AddFlagSet(commsCommand.CobraCommand().PersistentFlags())
 	rootCommand.CobraCommand().AddCommand(propertiesCobraCmd)
-	commsCommand.CobraCommand().AddCommand(propertiesCobraCmd)
 
 	return propertiesCobraCmd
 }

--- a/pkg/cmd/properties.go
+++ b/pkg/cmd/properties.go
@@ -25,10 +25,10 @@ type PropertiesCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewPropertiesCommand(rootCmd spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewPropertiesCommand(rootCmd spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 
 	cmd := new(PropertiesCommand)
-	err := cmd.init(rootCmd)
+	err := cmd.init(rootCmd, commsCommand)
 	return cmd, err
 }
 
@@ -51,18 +51,19 @@ func (cmd *PropertiesCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *PropertiesCommand) init(rootCmd spi.GalasaCommand) error {
+func (cmd *PropertiesCommand) init(rootCmd spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 
 	cmd.values = &PropertiesCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(rootCmd)
+	cmd.cobraCommand = cmd.createCobraCommand(rootCmd, commsCommand)
 
 	return err
 }
 
 func (cmd *PropertiesCommand) createCobraCommand(
 	rootCommand spi.GalasaCommand,
+	commsCommand spi.GalasaCommand,
 ) *cobra.Command {
 	propertiesCobraCmd := &cobra.Command{
 		Use:   "properties",
@@ -73,6 +74,7 @@ func (cmd *PropertiesCommand) createCobraCommand(
 	addBootstrapFlag(propertiesCobraCmd, &cmd.values.ecosystemBootstrap)
 
 	rootCommand.CobraCommand().AddCommand(propertiesCobraCmd)
+	commsCommand.CobraCommand().AddCommand(propertiesCobraCmd)
 
 	return propertiesCobraCmd
 }

--- a/pkg/cmd/properties.go
+++ b/pkg/cmd/properties.go
@@ -24,10 +24,10 @@ type PropertiesCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewPropertiesCommand(rootCmd spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewPropertiesCommand(rootCmd spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 
 	cmd := new(PropertiesCommand)
-	err := cmd.init(rootCmd, commsCommand)
+	err := cmd.init(rootCmd, commsFlagSet)
 	return cmd, err
 }
 
@@ -50,19 +50,19 @@ func (cmd *PropertiesCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *PropertiesCommand) init(rootCmd spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *PropertiesCommand) init(rootCmd spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 
 	cmd.values = &PropertiesCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(rootCmd, commsCommand)
+	cmd.cobraCommand = cmd.createCobraCommand(rootCmd, commsFlagSet)
 
 	return err
 }
 
 func (cmd *PropertiesCommand) createCobraCommand(
 	rootCommand spi.GalasaCommand,
-	commsCommand spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) *cobra.Command {
 	propertiesCobraCmd := &cobra.Command{
 		Use:   "properties",
@@ -70,7 +70,7 @@ func (cmd *PropertiesCommand) createCobraCommand(
 		Long:  "Allows interaction with the CPS to create, query and maintain properties in Galasa Ecosystem",
 	}
 
-	propertiesCobraCmd.PersistentFlags().AddFlagSet(commsCommand.CobraCommand().PersistentFlags())
+	propertiesCobraCmd.PersistentFlags().AddFlagSet(commsFlagSet.Flags())
 	rootCommand.CobraCommand().AddCommand(propertiesCobraCmd)
 
 	return propertiesCobraCmd

--- a/pkg/cmd/propertiesDelete.go
+++ b/pkg/cmd/propertiesDelete.go
@@ -67,7 +67,7 @@ func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
 
 	var err error
 	propertiesCmdValues := propertiesCommand.Values().(*PropertiesCmdValues)
-	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
+	commsFlagSetValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	propertiesDeleteCmd := &cobra.Command{
 		Use:   "delete",
@@ -76,9 +76,9 @@ func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executePropertiesDelete(factory, propertiesCmdValues, commsCmdValues)
+				return cmd.executePropertiesDelete(factory, propertiesCmdValues, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 		Aliases: []string{"properties delete"},
 	}
@@ -93,13 +93,13 @@ func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
 	return propertiesDeleteCmd, err
 }
 
-func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory spi.Factory, propertiesCmdValues *PropertiesCmdValues, commsCmdValues *CommsFlagSetValues) error {
+func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory spi.Factory, propertiesCmdValues *PropertiesCmdValues, commsFlagSetValues *CommsFlagSetValues) error {
 	var err error
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Delete ecosystem properties")
 
@@ -107,13 +107,13 @@ func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory spi.Factory,
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			apiServerUrl := bootstrapData.ApiServerURL

--- a/pkg/cmd/propertiesDelete.go
+++ b/pkg/cmd/propertiesDelete.go
@@ -24,10 +24,10 @@ type PropertiesDeleteCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewPropertiesDeleteCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewPropertiesDeleteCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(PropertiesDeleteCommand)
 
-	err := cmd.init(factory, propertiesCommand, rootCommand)
+	err := cmd.init(factory, propertiesCommand, commsCommand)
 	return cmd, err
 }
 
@@ -50,9 +50,9 @@ func (cmd *PropertiesDeleteCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *PropertiesDeleteCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) error {
+func (cmd *PropertiesDeleteCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
 	var err error
-	cmd.cobraCommand, err = cmd.createPropertiesDeleteCobraCmd(factory, propertiesCommand, rootCmd)
+	cmd.cobraCommand, err = cmd.createPropertiesDeleteCobraCmd(factory, propertiesCommand, commsCmd)
 	return err
 }
 
@@ -63,7 +63,7 @@ func (cmd *PropertiesDeleteCommand) init(factory spi.Factory, propertiesCommand 
 func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
 	factory spi.Factory,
 	propertiesCommand spi.GalasaCommand,
-	rootCmd spi.GalasaCommand) (*cobra.Command, error) {
+	commsCmd spi.GalasaCommand) (*cobra.Command, error) {
 
 	var err error
 	propertiesCmdValues := propertiesCommand.Values().(*PropertiesCmdValues)
@@ -74,7 +74,7 @@ func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
 		Long:  "Delete a property and its value in a namespace",
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executePropertiesDelete(factory, propertiesCmdValues, rootCmd.Values().(*RootCmdValues))
+			return cmd.executePropertiesDelete(factory, propertiesCmdValues, commsCmd.Values().(*CommsCmdValues))
 		},
 		Aliases: []string{"properties delete"},
 	}
@@ -89,16 +89,16 @@ func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
 	return propertiesDeleteCmd, err
 }
 
-func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory spi.Factory, propertiesCmdValues *PropertiesCmdValues, rootCmdValues *RootCmdValues) error {
+func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory spi.Factory, propertiesCmdValues *PropertiesCmdValues, commsCmdValues *CommsCmdValues) error {
 	var err error
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
 
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Delete ecosystem properties")
 
@@ -106,13 +106,13 @@ func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory spi.Factory,
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, propertiesCmdValues.ecosystemBootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				apiServerUrl := bootstrapData.ApiServerURL

--- a/pkg/cmd/propertiesDelete.go
+++ b/pkg/cmd/propertiesDelete.go
@@ -67,6 +67,7 @@ func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
 
 	var err error
 	propertiesCmdValues := propertiesCommand.Values().(*PropertiesCmdValues)
+	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
 
 	propertiesDeleteCmd := &cobra.Command{
 		Use:   "delete",
@@ -74,7 +75,10 @@ func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
 		Long:  "Delete a property and its value in a namespace",
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executePropertiesDelete(factory, propertiesCmdValues, commsCmd.Values().(*CommsCmdValues))
+			executionFunc := func() error {
+				return cmd.executePropertiesDelete(factory, propertiesCmdValues, commsCmdValues)
+			}
+			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
 		},
 		Aliases: []string{"properties delete"},
 	}
@@ -95,39 +99,35 @@ func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory spi.Factory,
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	commsCmdValues.isCapturingLogs = true
+
+	log.Println("Galasa CLI - Delete ecosystem properties")
+
+	// Get the ability to query environment variables.
+	env := factory.GetEnvironment()
+
+	var galasaHome spi.GalasaHome
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 	if err == nil {
 
-		commsCmdValues.isCapturingLogs = true
-
-		log.Println("Galasa CLI - Delete ecosystem properties")
-
-		// Get the ability to query environment variables.
-		env := factory.GetEnvironment()
-
-		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+		// Read the bootstrap properties.
+		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
+		var bootstrapData *api.BootstrapData
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 		if err == nil {
 
-			// Read the bootstrap properties.
-			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
-			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+			apiServerUrl := bootstrapData.ApiServerURL
+			log.Printf("The API server is at '%s'\n", apiServerUrl)
+
+			var apiClient *galasaapi.APIClient
+			authenticator := factory.GetAuthenticator(
+				apiServerUrl,
+				galasaHome,
+			)
+			apiClient, err = authenticator.GetAuthenticatedAPIClient()
 			if err == nil {
-
-				apiServerUrl := bootstrapData.ApiServerURL
-				log.Printf("The API server is at '%s'\n", apiServerUrl)
-
-				var apiClient *galasaapi.APIClient
-				authenticator := factory.GetAuthenticator(
-					apiServerUrl,
-					galasaHome,
-				)
-				apiClient, err = authenticator.GetAuthenticatedAPIClient()
-				if err == nil {
-					// Call to process the command in a unit-testable way.
-					err = properties.DeleteProperty(propertiesCmdValues.namespace, propertiesCmdValues.propertyName, apiClient)
-				}
+				// Call to process the command in a unit-testable way.
+				err = properties.DeleteProperty(propertiesCmdValues.namespace, propertiesCmdValues.propertyName, apiClient)
 			}
 		}
 	}

--- a/pkg/cmd/propertiesDelete.go
+++ b/pkg/cmd/propertiesDelete.go
@@ -24,10 +24,10 @@ type PropertiesDeleteCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewPropertiesDeleteCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewPropertiesDeleteCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(PropertiesDeleteCommand)
 
-	err := cmd.init(factory, propertiesCommand, commsCommand)
+	err := cmd.init(factory, propertiesCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -50,9 +50,9 @@ func (cmd *PropertiesDeleteCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *PropertiesDeleteCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *PropertiesDeleteCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
-	cmd.cobraCommand, err = cmd.createPropertiesDeleteCobraCmd(factory, propertiesCommand, commsCmd)
+	cmd.cobraCommand, err = cmd.createPropertiesDeleteCobraCmd(factory, propertiesCommand, commsFlagSet)
 	return err
 }
 
@@ -63,11 +63,11 @@ func (cmd *PropertiesDeleteCommand) init(factory spi.Factory, propertiesCommand 
 func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
 	factory spi.Factory,
 	propertiesCommand spi.GalasaCommand,
-	commsCmd spi.GalasaCommand) (*cobra.Command, error) {
+	commsFlagSet GalasaFlagSet) (*cobra.Command, error) {
 
 	var err error
 	propertiesCmdValues := propertiesCommand.Values().(*PropertiesCmdValues)
-	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
+	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	propertiesDeleteCmd := &cobra.Command{
 		Use:   "delete",
@@ -93,7 +93,7 @@ func (cmd *PropertiesDeleteCommand) createPropertiesDeleteCobraCmd(
 	return propertiesDeleteCmd, err
 }
 
-func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory spi.Factory, propertiesCmdValues *PropertiesCmdValues, commsCmdValues *CommsCmdValues) error {
+func (cmd *PropertiesDeleteCommand) executePropertiesDelete(factory spi.Factory, propertiesCmdValues *PropertiesCmdValues, commsCmdValues *CommsFlagSetValues) error {
 	var err error
 
 	// Operations on the file system will all be relative to the current folder.

--- a/pkg/cmd/propertiesGet.go
+++ b/pkg/cmd/propertiesGet.go
@@ -40,10 +40,10 @@ type PropertiesGetCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewPropertiesGetCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewPropertiesGetCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 
 	cmd := new(PropertiesGetCommand)
-	err := cmd.init(factory, propertiesCommand, rootCommand)
+	err := cmd.init(factory, propertiesCommand, commsCommand)
 	return cmd, err
 }
 
@@ -66,12 +66,12 @@ func (cmd *PropertiesGetCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *PropertiesGetCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (cmd *PropertiesGetCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 
 	cmd.values = &PropertiesGetCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(factory, propertiesCommand, rootCommand.Values().(*RootCmdValues))
+	cmd.cobraCommand = cmd.createCobraCommand(factory, propertiesCommand, commsCommand.Values().(*CommsCmdValues))
 
 	return err
 }
@@ -79,7 +79,7 @@ func (cmd *PropertiesGetCommand) init(factory spi.Factory, propertiesCommand spi
 func (cmd *PropertiesGetCommand) createCobraCommand(
 	factory spi.Factory,
 	propertiesCommand spi.GalasaCommand,
-	rootCommandValues *RootCmdValues,
+	commsCommandValues *CommsCmdValues,
 ) *cobra.Command {
 
 	propertiesCommandValues := propertiesCommand.Values().(*PropertiesCmdValues)
@@ -91,7 +91,7 @@ func (cmd *PropertiesGetCommand) createCobraCommand(
 		Aliases: []string{"properties get"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.executePropertiesGet(factory,
-				propertiesCommandValues, rootCommandValues)
+				propertiesCommandValues, commsCommandValues)
 		},
 	}
 
@@ -133,17 +133,17 @@ func (cmd *PropertiesGetCommand) createCobraCommand(
 func (cmd *PropertiesGetCommand) executePropertiesGet(
 	factory spi.Factory,
 	propertiesCmdValues *PropertiesCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 	var err error
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
 
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Get ecosystem properties")
 
@@ -151,13 +151,13 @@ func (cmd *PropertiesGetCommand) executePropertiesGet(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, propertiesCmdValues.ecosystemBootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				var console = factory.GetStdOutConsole()

--- a/pkg/cmd/propertiesGet.go
+++ b/pkg/cmd/propertiesGet.go
@@ -79,7 +79,7 @@ func (cmd *PropertiesGetCommand) init(factory spi.Factory, propertiesCommand spi
 func (cmd *PropertiesGetCommand) createCobraCommand(
 	factory spi.Factory,
 	propertiesCommand spi.GalasaCommand,
-	commsCommandValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) *cobra.Command {
 
 	propertiesCommandValues := propertiesCommand.Values().(*PropertiesCmdValues)
@@ -92,9 +92,9 @@ func (cmd *PropertiesGetCommand) createCobraCommand(
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
 				return cmd.executePropertiesGet(factory,
-					propertiesCommandValues, commsCommandValues)
+					propertiesCommandValues, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -136,14 +136,14 @@ func (cmd *PropertiesGetCommand) createCobraCommand(
 func (cmd *PropertiesGetCommand) executePropertiesGet(
 	factory spi.Factory,
 	propertiesCmdValues *PropertiesCmdValues,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 	var err error
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Get ecosystem properties")
 
@@ -151,13 +151,13 @@ func (cmd *PropertiesGetCommand) executePropertiesGet(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/propertiesGet.go
+++ b/pkg/cmd/propertiesGet.go
@@ -40,10 +40,10 @@ type PropertiesGetCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewPropertiesGetCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewPropertiesGetCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 
 	cmd := new(PropertiesGetCommand)
-	err := cmd.init(factory, propertiesCommand, commsCommand)
+	err := cmd.init(factory, propertiesCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -66,12 +66,12 @@ func (cmd *PropertiesGetCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *PropertiesGetCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *PropertiesGetCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 
 	cmd.values = &PropertiesGetCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(factory, propertiesCommand, commsCommand.Values().(*CommsCmdValues))
+	cmd.cobraCommand = cmd.createCobraCommand(factory, propertiesCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 
 	return err
 }
@@ -79,7 +79,7 @@ func (cmd *PropertiesGetCommand) init(factory spi.Factory, propertiesCommand spi
 func (cmd *PropertiesGetCommand) createCobraCommand(
 	factory spi.Factory,
 	propertiesCommand spi.GalasaCommand,
-	commsCommandValues *CommsCmdValues,
+	commsCommandValues *CommsFlagSetValues,
 ) *cobra.Command {
 
 	propertiesCommandValues := propertiesCommand.Values().(*PropertiesCmdValues)
@@ -136,7 +136,7 @@ func (cmd *PropertiesGetCommand) createCobraCommand(
 func (cmd *PropertiesGetCommand) executePropertiesGet(
 	factory spi.Factory,
 	propertiesCmdValues *PropertiesCmdValues,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 	var err error
 

--- a/pkg/cmd/propertiesGet.go
+++ b/pkg/cmd/propertiesGet.go
@@ -90,8 +90,11 @@ func (cmd *PropertiesGetCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"properties get"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executePropertiesGet(factory,
-				propertiesCommandValues, commsCommandValues)
+			executionFunc := func() error {
+				return cmd.executePropertiesGet(factory,
+					propertiesCommandValues, commsCommandValues)
+			}
+			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
 		},
 	}
 
@@ -140,51 +143,47 @@ func (cmd *PropertiesGetCommand) executePropertiesGet(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	commsCmdValues.isCapturingLogs = true
+
+	log.Println("Galasa CLI - Get ecosystem properties")
+
+	// Get the ability to query environment variables.
+	env := factory.GetEnvironment()
+
+	var galasaHome spi.GalasaHome
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 	if err == nil {
 
-		commsCmdValues.isCapturingLogs = true
-
-		log.Println("Galasa CLI - Get ecosystem properties")
-
-		// Get the ability to query environment variables.
-		env := factory.GetEnvironment()
-
-		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+		// Read the bootstrap properties.
+		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
+		var bootstrapData *api.BootstrapData
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 		if err == nil {
 
-			// Read the bootstrap properties.
-			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
-			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+			var console = factory.GetStdOutConsole()
+
+			apiServerUrl := bootstrapData.ApiServerURL
+			log.Printf("The API server is at '%s'\n", apiServerUrl)
+
+			var apiClient *galasaapi.APIClient
+			authenticator := factory.GetAuthenticator(
+				apiServerUrl,
+				galasaHome,
+			)
+			apiClient, err = authenticator.GetAuthenticatedAPIClient()
+
 			if err == nil {
-
-				var console = factory.GetStdOutConsole()
-
-				apiServerUrl := bootstrapData.ApiServerURL
-				log.Printf("The API server is at '%s'\n", apiServerUrl)
-
-				var apiClient *galasaapi.APIClient
-				authenticator := factory.GetAuthenticator(
-					apiServerUrl,
-					galasaHome,
+				// Call to process the command in a unit-testable way.
+				err = properties.GetProperties(
+					propertiesCmdValues.namespace,
+					propertiesCmdValues.propertyName,
+					cmd.values.propertiesPrefix,
+					cmd.values.propertiesSuffix,
+					cmd.values.propertiesInfix,
+					apiClient,
+					cmd.values.propertiesOutputFormat,
+					console,
 				)
-				apiClient, err = authenticator.GetAuthenticatedAPIClient()
-
-				if err == nil {
-					// Call to process the command in a unit-testable way.
-					err = properties.GetProperties(
-						propertiesCmdValues.namespace,
-						propertiesCmdValues.propertyName,
-						cmd.values.propertiesPrefix,
-						cmd.values.propertiesSuffix,
-						cmd.values.propertiesInfix,
-						apiClient,
-						cmd.values.propertiesOutputFormat,
-						console,
-					)
-				}
 			}
 		}
 	}

--- a/pkg/cmd/propertiesNamespace.go
+++ b/pkg/cmd/propertiesNamespace.go
@@ -22,7 +22,7 @@ type PropertiesNamespaceCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewPropertiesNamespaceCommand(propertiesCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewPropertiesNamespaceCommand(propertiesCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(PropertiesNamespaceCommand)
 
 	err := cmd.init(propertiesCommand)

--- a/pkg/cmd/propertiesNamespaceGet.go
+++ b/pkg/cmd/propertiesNamespaceGet.go
@@ -37,12 +37,12 @@ func NewPropertiesNamespaceGetCommand(
 	factory spi.Factory,
 	propertiesNamespaceCommand spi.GalasaCommand,
 	propertiesCommand spi.GalasaCommand,
-	commsCommand spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (spi.GalasaCommand, error) {
 
 	cmd := new(PropertiesNamespaceGetCommand)
 
-	err := cmd.init(factory, propertiesNamespaceCommand, commsCommand)
+	err := cmd.init(factory, propertiesNamespaceCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -64,21 +64,21 @@ func (cmd *PropertiesNamespaceGetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *PropertiesNamespaceGetCommand) init(factory spi.Factory, propertiesNamespaceCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *PropertiesNamespaceGetCommand) init(factory spi.Factory, propertiesNamespaceCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 	cmd.values = &PropertiesNamespaceGetCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, propertiesNamespaceCommand, commsCmd)
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, propertiesNamespaceCommand, commsFlagSet)
 	return err
 }
 
 func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 	factory spi.Factory,
 	propertiesNamespaceCommand spi.GalasaCommand,
-	commsCmd spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (*cobra.Command, error) {
 
 	var err error
-	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
+	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	propertieNamespaceGetCobraCommand := &cobra.Command{
 		Use:   "get",
@@ -105,7 +105,7 @@ func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 
 func (cmd *PropertiesNamespaceGetCommand) executePropertiesNamespaceGet(
 	factory spi.Factory,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 	var err error
 

--- a/pkg/cmd/propertiesNamespaceGet.go
+++ b/pkg/cmd/propertiesNamespaceGet.go
@@ -37,12 +37,12 @@ func NewPropertiesNamespaceGetCommand(
 	factory spi.Factory,
 	propertiesNamespaceCommand spi.GalasaCommand,
 	propertiesCommand spi.GalasaCommand,
-	rootCommand spi.GalasaCommand,
+	commsCommand spi.GalasaCommand,
 ) (spi.GalasaCommand, error) {
 
 	cmd := new(PropertiesNamespaceGetCommand)
 
-	err := cmd.init(factory, propertiesNamespaceCommand, propertiesCommand, rootCommand)
+	err := cmd.init(factory, propertiesNamespaceCommand, propertiesCommand, commsCommand)
 	return cmd, err
 }
 
@@ -64,10 +64,10 @@ func (cmd *PropertiesNamespaceGetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *PropertiesNamespaceGetCommand) init(factory spi.Factory, propertiesNamespaceCommand spi.GalasaCommand, propertiesCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) error {
+func (cmd *PropertiesNamespaceGetCommand) init(factory spi.Factory, propertiesNamespaceCommand spi.GalasaCommand, propertiesCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
 	var err error
 	cmd.values = &PropertiesNamespaceGetCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, propertiesNamespaceCommand, propertiesCommand, rootCmd)
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, propertiesNamespaceCommand, propertiesCommand, commsCmd)
 	return err
 }
 
@@ -75,7 +75,7 @@ func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 	factory spi.Factory,
 	propertiesNamespaceCommand spi.GalasaCommand,
 	propertiesCommand spi.GalasaCommand,
-	rootCmd spi.GalasaCommand,
+	commsCmd spi.GalasaCommand,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -87,7 +87,7 @@ func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 		Long:  "Get a list of namespaces within the CPS",
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executePropertiesNamespaceGet(factory, propertiesCmdValues, rootCmd.Values().(*RootCmdValues))
+			return cmd.executePropertiesNamespaceGet(factory, propertiesCmdValues, commsCmd.Values().(*CommsCmdValues))
 		},
 		Aliases: []string{"namespaces get"},
 	}
@@ -104,17 +104,17 @@ func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 func (cmd *PropertiesNamespaceGetCommand) executePropertiesNamespaceGet(
 	factory spi.Factory,
 	propertiesCmdValues *PropertiesCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 	var err error
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
 
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Get ecosystem namespaces")
 
@@ -122,13 +122,13 @@ func (cmd *PropertiesNamespaceGetCommand) executePropertiesNamespaceGet(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, propertiesCmdValues.ecosystemBootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				var console = factory.GetStdOutConsole()

--- a/pkg/cmd/propertiesNamespaceGet.go
+++ b/pkg/cmd/propertiesNamespaceGet.go
@@ -78,7 +78,7 @@ func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 ) (*cobra.Command, error) {
 
 	var err error
-	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
+	commsFlagSetValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	propertieNamespaceGetCobraCommand := &cobra.Command{
 		Use:   "get",
@@ -87,9 +87,9 @@ func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executePropertiesNamespaceGet(factory, commsCmdValues)
+				return cmd.executePropertiesNamespaceGet(factory, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 		Aliases: []string{"namespaces get"},
 	}
@@ -105,14 +105,14 @@ func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 
 func (cmd *PropertiesNamespaceGetCommand) executePropertiesNamespaceGet(
 	factory spi.Factory,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 	var err error
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Get ecosystem namespaces")
 
@@ -120,13 +120,13 @@ func (cmd *PropertiesNamespaceGetCommand) executePropertiesNamespaceGet(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/propertiesNamespaceGet.go
+++ b/pkg/cmd/propertiesNamespaceGet.go
@@ -42,7 +42,7 @@ func NewPropertiesNamespaceGetCommand(
 
 	cmd := new(PropertiesNamespaceGetCommand)
 
-	err := cmd.init(factory, propertiesNamespaceCommand, propertiesCommand, commsCommand)
+	err := cmd.init(factory, propertiesNamespaceCommand, commsCommand)
 	return cmd, err
 }
 
@@ -64,22 +64,20 @@ func (cmd *PropertiesNamespaceGetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *PropertiesNamespaceGetCommand) init(factory spi.Factory, propertiesNamespaceCommand spi.GalasaCommand, propertiesCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *PropertiesNamespaceGetCommand) init(factory spi.Factory, propertiesNamespaceCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
 	var err error
 	cmd.values = &PropertiesNamespaceGetCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, propertiesNamespaceCommand, propertiesCommand, commsCmd)
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, propertiesNamespaceCommand, commsCmd)
 	return err
 }
 
 func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 	factory spi.Factory,
 	propertiesNamespaceCommand spi.GalasaCommand,
-	propertiesCommand spi.GalasaCommand,
 	commsCmd spi.GalasaCommand,
 ) (*cobra.Command, error) {
 
 	var err error
-	propertiesCmdValues := propertiesCommand.Values().(*PropertiesCmdValues)
 
 	propertieNamespaceGetCobraCommand := &cobra.Command{
 		Use:   "get",
@@ -87,7 +85,7 @@ func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 		Long:  "Get a list of namespaces within the CPS",
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executePropertiesNamespaceGet(factory, propertiesCmdValues, commsCmd.Values().(*CommsCmdValues))
+			return cmd.executePropertiesNamespaceGet(factory, commsCmd.Values().(*CommsCmdValues))
 		},
 		Aliases: []string{"namespaces get"},
 	}
@@ -103,7 +101,6 @@ func (cmd *PropertiesNamespaceGetCommand) createCobraCommand(
 
 func (cmd *PropertiesNamespaceGetCommand) executePropertiesNamespaceGet(
 	factory spi.Factory,
-	propertiesCmdValues *PropertiesCmdValues,
 	commsCmdValues *CommsCmdValues,
 ) error {
 	var err error

--- a/pkg/cmd/propertiesSet.go
+++ b/pkg/cmd/propertiesSet.go
@@ -34,10 +34,10 @@ type PropertiesSetCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewPropertiesSetCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewPropertiesSetCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 
 	cmd := new(PropertiesSetCommand)
-	err := cmd.init(factory, propertiesCommand, commsCommand)
+	err := cmd.init(factory, propertiesCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -60,12 +60,12 @@ func (cmd *PropertiesSetCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *PropertiesSetCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *PropertiesSetCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 	cmd.values = &PropertiesSetCmdValues{}
 
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, propertiesCommand, commsCmd.Values().(*CommsCmdValues))
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, propertiesCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 
 	return err
 }
@@ -73,7 +73,7 @@ func (cmd *PropertiesSetCommand) init(factory spi.Factory, propertiesCommand spi
 func (cmd *PropertiesSetCommand) createCobraCommand(
 	factory spi.Factory,
 	propertiesCommand spi.GalasaCommand,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -110,7 +110,7 @@ func (cmd *PropertiesSetCommand) createCobraCommand(
 func (cmd *PropertiesSetCommand) executePropertiesSet(
 	factory spi.Factory,
 	propertiesCmdValues *PropertiesCmdValues,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 	var err error
 

--- a/pkg/cmd/propertiesSet.go
+++ b/pkg/cmd/propertiesSet.go
@@ -87,7 +87,10 @@ func (cmd *PropertiesSetCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"properties set"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executePropertiesSet(factory, propertiesCmdValues, commsCmdValues)
+			executionFunc := func() error {
+				return cmd.executePropertiesSet(factory, propertiesCmdValues, commsCmdValues)
+			}
+			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
 		},
 	}
 
@@ -114,44 +117,40 @@ func (cmd *PropertiesSetCommand) executePropertiesSet(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	commsCmdValues.isCapturingLogs = true
+
+	log.Println("Galasa CLI - Set ecosystem properties")
+
+	// Get the ability to query environment variables.
+	env := factory.GetEnvironment()
+
+	var galasaHome spi.GalasaHome
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 	if err == nil {
 
-		commsCmdValues.isCapturingLogs = true
-
-		log.Println("Galasa CLI - Set ecosystem properties")
-
-		// Get the ability to query environment variables.
-		env := factory.GetEnvironment()
-
-		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+		// Read the bootstrap properties.
+		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
+		var bootstrapData *api.BootstrapData
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 		if err == nil {
 
-			// Read the bootstrap properties.
-			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
-			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+			apiServerUrl := bootstrapData.ApiServerURL
+			log.Printf("The API server is at '%s'\n", apiServerUrl)
+
+			var apiClient *galasaapi.APIClient
+			authenticator := factory.GetAuthenticator(
+				apiServerUrl,
+				galasaHome,
+			)
+			apiClient, err = authenticator.GetAuthenticatedAPIClient()
+
 			if err == nil {
-
-				apiServerUrl := bootstrapData.ApiServerURL
-				log.Printf("The API server is at '%s'\n", apiServerUrl)
-
-				var apiClient *galasaapi.APIClient
-				authenticator := factory.GetAuthenticator(
-					apiServerUrl,
-					galasaHome,
-				)
-				apiClient, err = authenticator.GetAuthenticatedAPIClient()
-
-				if err == nil {
-					// Call to process the command in a unit-testable way.
-					err = properties.SetProperty(
-						propertiesCmdValues.namespace,
-						propertiesCmdValues.propertyName,
-						cmd.values.propertyValue,
-						apiClient)
-				}
+				// Call to process the command in a unit-testable way.
+				err = properties.SetProperty(
+					propertiesCmdValues.namespace,
+					propertiesCmdValues.propertyName,
+					cmd.values.propertyValue,
+					apiClient)
 			}
 		}
 	}

--- a/pkg/cmd/propertiesSet.go
+++ b/pkg/cmd/propertiesSet.go
@@ -73,7 +73,7 @@ func (cmd *PropertiesSetCommand) init(factory spi.Factory, propertiesCommand spi
 func (cmd *PropertiesSetCommand) createCobraCommand(
 	factory spi.Factory,
 	propertiesCommand spi.GalasaCommand,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -88,9 +88,9 @@ func (cmd *PropertiesSetCommand) createCobraCommand(
 		Aliases: []string{"properties set"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executePropertiesSet(factory, propertiesCmdValues, commsCmdValues)
+				return cmd.executePropertiesSet(factory, propertiesCmdValues, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -110,14 +110,14 @@ func (cmd *PropertiesSetCommand) createCobraCommand(
 func (cmd *PropertiesSetCommand) executePropertiesSet(
 	factory spi.Factory,
 	propertiesCmdValues *PropertiesCmdValues,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 	var err error
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Set ecosystem properties")
 
@@ -125,13 +125,13 @@ func (cmd *PropertiesSetCommand) executePropertiesSet(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			apiServerUrl := bootstrapData.ApiServerURL

--- a/pkg/cmd/propertiesSet.go
+++ b/pkg/cmd/propertiesSet.go
@@ -34,10 +34,10 @@ type PropertiesSetCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewPropertiesSetCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewPropertiesSetCommand(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 
 	cmd := new(PropertiesSetCommand)
-	err := cmd.init(factory, propertiesCommand, rootCommand)
+	err := cmd.init(factory, propertiesCommand, commsCommand)
 	return cmd, err
 }
 
@@ -60,12 +60,12 @@ func (cmd *PropertiesSetCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *PropertiesSetCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) error {
+func (cmd *PropertiesSetCommand) init(factory spi.Factory, propertiesCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
 
 	var err error
 	cmd.values = &PropertiesSetCmdValues{}
 
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, propertiesCommand, rootCmd.Values().(*RootCmdValues))
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, propertiesCommand, commsCmd.Values().(*CommsCmdValues))
 
 	return err
 }
@@ -73,7 +73,7 @@ func (cmd *PropertiesSetCommand) init(factory spi.Factory, propertiesCommand spi
 func (cmd *PropertiesSetCommand) createCobraCommand(
 	factory spi.Factory,
 	propertiesCommand spi.GalasaCommand,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -87,7 +87,7 @@ func (cmd *PropertiesSetCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"properties set"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executePropertiesSet(factory, propertiesCmdValues, rootCmdValues)
+			return cmd.executePropertiesSet(factory, propertiesCmdValues, commsCmdValues)
 		},
 	}
 
@@ -107,17 +107,17 @@ func (cmd *PropertiesSetCommand) createCobraCommand(
 func (cmd *PropertiesSetCommand) executePropertiesSet(
 	factory spi.Factory,
 	propertiesCmdValues *PropertiesCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 	var err error
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
 
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Set ecosystem properties")
 
@@ -125,13 +125,13 @@ func (cmd *PropertiesSetCommand) executePropertiesSet(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, propertiesCmdValues.ecosystemBootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				apiServerUrl := bootstrapData.ApiServerURL

--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -76,8 +76,8 @@ func (cmd *ResourcesCommand) createCobraCommand(rootCommand spi.GalasaCommand, c
 			"Example: my_resources.yaml")
 	resourcesCobraCmd.MarkPersistentFlagRequired("file")
 
+	resourcesCobraCmd.PersistentFlags().AddFlagSet(commsCommand.CobraCommand().PersistentFlags())
 	rootCommand.CobraCommand().AddCommand(resourcesCobraCmd)
-	commsCommand.CobraCommand().AddCommand(resourcesCobraCmd)
 
 	return resourcesCobraCmd, err
 }

--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -24,9 +24,9 @@ type ResourcesCommand struct {
 // Constructors
 // ------------------------------------------------------------------------------------------------
 
-func NewResourcesCmd(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewResourcesCmd(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(ResourcesCommand)
-	err := cmd.init(rootCommand, commsCommand)
+	err := cmd.init(rootCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -50,17 +50,17 @@ func (cmd *ResourcesCommand) Values() interface{} {
 // Private functions
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *ResourcesCommand) init(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *ResourcesCommand) init(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 
 	cmd.values = &ResourcesCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(rootCommand, commsCommand)
+	cmd.cobraCommand, err = cmd.createCobraCommand(rootCommand, commsFlagSet)
 
 	return err
 }
 
-func (cmd *ResourcesCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (*cobra.Command, error) {
+func (cmd *ResourcesCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (*cobra.Command, error) {
 
 	var err error
 
@@ -76,7 +76,7 @@ func (cmd *ResourcesCommand) createCobraCommand(rootCommand spi.GalasaCommand, c
 			"Example: my_resources.yaml")
 	resourcesCobraCmd.MarkPersistentFlagRequired("file")
 
-	resourcesCobraCmd.PersistentFlags().AddFlagSet(commsCommand.CobraCommand().PersistentFlags())
+	resourcesCobraCmd.PersistentFlags().AddFlagSet(commsFlagSet.Flags())
 	rootCommand.CobraCommand().AddCommand(resourcesCobraCmd)
 
 	return resourcesCobraCmd, err

--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -25,9 +25,9 @@ type ResourcesCommand struct {
 // Constructors
 // ------------------------------------------------------------------------------------------------
 
-func NewResourcesCmd(rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewResourcesCmd(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(ResourcesCommand)
-	err := cmd.init(rootCommand)
+	err := cmd.init(rootCommand, commsCommand)
 	return cmd, err
 }
 
@@ -51,17 +51,17 @@ func (cmd *ResourcesCommand) Values() interface{} {
 // Private functions
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *ResourcesCommand) init(rootCmd spi.GalasaCommand) error {
+func (cmd *ResourcesCommand) init(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 
 	cmd.values = &ResourcesCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd)
+	cmd.cobraCommand, err = cmd.createCobraCommand(rootCommand, commsCommand)
 
 	return err
 }
 
-func (cmd *ResourcesCommand) createCobraCommand(rootCommand spi.GalasaCommand) (*cobra.Command, error) {
+func (cmd *ResourcesCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (*cobra.Command, error) {
 
 	var err error
 
@@ -79,6 +79,7 @@ func (cmd *ResourcesCommand) createCobraCommand(rootCommand spi.GalasaCommand) (
 	resourcesCobraCmd.MarkPersistentFlagRequired("file")
 
 	rootCommand.CobraCommand().AddCommand(resourcesCobraCmd)
+	commsCommand.CobraCommand().AddCommand(resourcesCobraCmd)
 
 	return resourcesCobraCmd, err
 }

--- a/pkg/cmd/resources.go
+++ b/pkg/cmd/resources.go
@@ -12,7 +12,6 @@ import (
 )
 
 type ResourcesCmdValues struct {
-	bootstrap string
 	filePath  string
 }
 
@@ -71,7 +70,6 @@ func (cmd *ResourcesCommand) createCobraCommand(rootCommand spi.GalasaCommand, c
 		Long:  "Allows interaction with the Resources endpoint to create and maintain resources in the Galasa Ecosystem",
 	}
 
-	addBootstrapFlag(resourcesCobraCmd, &cmd.values.bootstrap)
 	resourcesCobraCmd.PersistentFlags().StringVarP(&cmd.values.filePath, "file", "f", "",
 		"The file containing yaml definitions of resources to be applied manipulated by this command. "+
 			"This can be a fully-qualified path or path relative to the current directory."+

--- a/pkg/cmd/resourcesApply.go
+++ b/pkg/cmd/resourcesApply.go
@@ -67,7 +67,7 @@ func (cmd *ResourcesApplyCommand) init(factory spi.Factory, resourcesApplyComman
 func (cmd *ResourcesApplyCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	commsCommandValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) *cobra.Command {
 
 	resourcesApplyCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -80,9 +80,9 @@ func (cmd *ResourcesApplyCommand) createCobraCommand(
 		RunE: func(cmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
 				return executeResourcesApply(factory,
-					resourcesApplyCommandValues, commsCommandValues)
+					resourcesApplyCommandValues, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -93,21 +93,21 @@ func (cmd *ResourcesApplyCommand) createCobraCommand(
 
 func executeResourcesApply(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 	action := "apply"
 
-	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsCmdValues)
+	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsFlagSetValues)
 
 	return err
 }
 
-func loadAndPassDataIntoResourcesApi(action string, factory spi.Factory, resourcesCmdValues *ResourcesCmdValues, commsCmdValues *CommsFlagSetValues) error {
+func loadAndPassDataIntoResourcesApi(action string, factory spi.Factory, resourcesCmdValues *ResourcesCmdValues, commsFlagSetValues *CommsFlagSetValues) error {
 	var err error
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI -", action, "Resources Command")
 
@@ -115,13 +115,13 @@ func loadAndPassDataIntoResourcesApi(action string, factory spi.Factory, resourc
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 
 	if err == nil {
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			apiServerUrl := bootstrapData.ApiServerURL

--- a/pkg/cmd/resourcesApply.go
+++ b/pkg/cmd/resourcesApply.go
@@ -28,10 +28,10 @@ type ResourcesApplyCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewResourcesApplyCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewResourcesApplyCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 
 	cmd := new(ResourcesApplyCommand)
-	err := cmd.init(factory, resourcesCommand, commsCommand)
+	err := cmd.init(factory, resourcesCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -54,12 +54,12 @@ func (cmd *ResourcesApplyCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *ResourcesApplyCommand) init(factory spi.Factory, resourcesApplyCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *ResourcesApplyCommand) init(factory spi.Factory, resourcesApplyCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 
 	cmd.values = &ResourcesApplyCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesApplyCommand, commsCommand.Values().(*CommsCmdValues))
+	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesApplyCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 
 	return err
 }
@@ -67,7 +67,7 @@ func (cmd *ResourcesApplyCommand) init(factory spi.Factory, resourcesApplyComman
 func (cmd *ResourcesApplyCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	commsCommandValues *CommsCmdValues,
+	commsCommandValues *CommsFlagSetValues,
 ) *cobra.Command {
 
 	resourcesApplyCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -93,7 +93,7 @@ func (cmd *ResourcesApplyCommand) createCobraCommand(
 
 func executeResourcesApply(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 	action := "apply"
 
@@ -102,7 +102,7 @@ func executeResourcesApply(factory spi.Factory,
 	return err
 }
 
-func loadAndPassDataIntoResourcesApi(action string, factory spi.Factory, resourcesCmdValues *ResourcesCmdValues, commsCmdValues *CommsCmdValues) error {
+func loadAndPassDataIntoResourcesApi(action string, factory spi.Factory, resourcesCmdValues *ResourcesCmdValues, commsCmdValues *CommsFlagSetValues) error {
 	var err error
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()

--- a/pkg/cmd/resourcesCreate.go
+++ b/pkg/cmd/resourcesCreate.go
@@ -73,8 +73,11 @@ func (cmd *ResourcesCreateCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"resources create"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return executeResourcesCreate(factory,
-				resourcesCreateCommandValues, commsCommandValues)
+			executionFunc := func() error {
+				return executeResourcesCreate(factory,
+					resourcesCreateCommandValues, commsCommandValues)
+			}
+			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
 		},
 	}
 

--- a/pkg/cmd/resourcesCreate.go
+++ b/pkg/cmd/resourcesCreate.go
@@ -23,10 +23,10 @@ type ResourcesCreateCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewResourcesCreateCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewResourcesCreateCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 
 	cmd := new(ResourcesCreateCommand)
-	err := cmd.init(factory, resourcesCommand, commsCommand)
+	err := cmd.init(factory, resourcesCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -49,12 +49,12 @@ func (cmd *ResourcesCreateCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *ResourcesCreateCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *ResourcesCreateCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 
 	cmd.values = &ResourcesCreateCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, commsCommand.Values().(*CommsCmdValues))
+	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 
 	return err
 }
@@ -62,7 +62,7 @@ func (cmd *ResourcesCreateCommand) init(factory spi.Factory, resourcesCommand sp
 func (cmd *ResourcesCreateCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	commsCommandValues *CommsCmdValues,
+	commsCommandValues *CommsFlagSetValues,
 ) *cobra.Command {
 
 	resourcesCreateCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -88,7 +88,7 @@ func (cmd *ResourcesCreateCommand) createCobraCommand(
 
 func executeResourcesCreate(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 	action := "create"
 

--- a/pkg/cmd/resourcesCreate.go
+++ b/pkg/cmd/resourcesCreate.go
@@ -23,10 +23,10 @@ type ResourcesCreateCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewResourcesCreateCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewResourcesCreateCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 
 	cmd := new(ResourcesCreateCommand)
-	err := cmd.init(factory, resourcesCommand, rootCommand)
+	err := cmd.init(factory, resourcesCommand, commsCommand)
 	return cmd, err
 }
 
@@ -49,12 +49,12 @@ func (cmd *ResourcesCreateCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *ResourcesCreateCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (cmd *ResourcesCreateCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 
 	cmd.values = &ResourcesCreateCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, rootCommand.Values().(*RootCmdValues))
+	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, commsCommand.Values().(*CommsCmdValues))
 
 	return err
 }
@@ -62,7 +62,7 @@ func (cmd *ResourcesCreateCommand) init(factory spi.Factory, resourcesCommand sp
 func (cmd *ResourcesCreateCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	rootCommandValues *RootCmdValues,
+	commsCommandValues *CommsCmdValues,
 ) *cobra.Command {
 
 	resourcesCreateCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -74,7 +74,7 @@ func (cmd *ResourcesCreateCommand) createCobraCommand(
 		Aliases: []string{"resources create"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return executeResourcesCreate(factory,
-				resourcesCreateCommandValues, rootCommandValues)
+				resourcesCreateCommandValues, commsCommandValues)
 		},
 	}
 
@@ -85,11 +85,11 @@ func (cmd *ResourcesCreateCommand) createCobraCommand(
 
 func executeResourcesCreate(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 	action := "create"
 
-	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, rootCmdValues)
+	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsCmdValues)
 
 	return err
 }

--- a/pkg/cmd/resourcesCreate.go
+++ b/pkg/cmd/resourcesCreate.go
@@ -62,7 +62,7 @@ func (cmd *ResourcesCreateCommand) init(factory spi.Factory, resourcesCommand sp
 func (cmd *ResourcesCreateCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	commsCommandValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) *cobra.Command {
 
 	resourcesCreateCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -75,9 +75,9 @@ func (cmd *ResourcesCreateCommand) createCobraCommand(
 		RunE: func(cmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
 				return executeResourcesCreate(factory,
-					resourcesCreateCommandValues, commsCommandValues)
+					resourcesCreateCommandValues, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -88,11 +88,11 @@ func (cmd *ResourcesCreateCommand) createCobraCommand(
 
 func executeResourcesCreate(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 	action := "create"
 
-	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsCmdValues)
+	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsFlagSetValues)
 
 	return err
 }

--- a/pkg/cmd/resourcesDelete.go
+++ b/pkg/cmd/resourcesDelete.go
@@ -23,10 +23,10 @@ type ResourcesDeleteCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewResourcesDeleteCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewResourcesDeleteCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 
 	cmd := new(ResourcesDeleteCommand)
-	err := cmd.init(factory, resourcesCommand, commsCommand)
+	err := cmd.init(factory, resourcesCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -49,12 +49,12 @@ func (cmd *ResourcesDeleteCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *ResourcesDeleteCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *ResourcesDeleteCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 
 	cmd.values = &ResourcesDeleteCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, commsCommand.Values().(*CommsCmdValues))
+	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 
 	return err
 }
@@ -62,7 +62,7 @@ func (cmd *ResourcesDeleteCommand) init(factory spi.Factory, resourcesCommand sp
 func (cmd *ResourcesDeleteCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	commsCommandValues *CommsCmdValues,
+	commsCommandValues *CommsFlagSetValues,
 ) *cobra.Command {
 
 	resourcesDeleteCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -88,7 +88,7 @@ func (cmd *ResourcesDeleteCommand) createCobraCommand(
 
 func executeResourcesDelete(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 	action := "delete"
 

--- a/pkg/cmd/resourcesDelete.go
+++ b/pkg/cmd/resourcesDelete.go
@@ -73,8 +73,11 @@ func (cmd *ResourcesDeleteCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"resources delete"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return executeResourcesDelete(factory,
-				resourcesDeleteCommandValues, commsCommandValues)
+			executionFunc := func() error {
+				return executeResourcesDelete(factory,
+					resourcesDeleteCommandValues, commsCommandValues)
+			}
+			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
 		},
 	}
 

--- a/pkg/cmd/resourcesDelete.go
+++ b/pkg/cmd/resourcesDelete.go
@@ -23,10 +23,10 @@ type ResourcesDeleteCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewResourcesDeleteCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewResourcesDeleteCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 
 	cmd := new(ResourcesDeleteCommand)
-	err := cmd.init(factory, resourcesCommand, rootCommand)
+	err := cmd.init(factory, resourcesCommand, commsCommand)
 	return cmd, err
 }
 
@@ -49,12 +49,12 @@ func (cmd *ResourcesDeleteCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *ResourcesDeleteCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (cmd *ResourcesDeleteCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 
 	cmd.values = &ResourcesDeleteCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, rootCommand.Values().(*RootCmdValues))
+	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, commsCommand.Values().(*CommsCmdValues))
 
 	return err
 }
@@ -62,7 +62,7 @@ func (cmd *ResourcesDeleteCommand) init(factory spi.Factory, resourcesCommand sp
 func (cmd *ResourcesDeleteCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	rootCommandValues *RootCmdValues,
+	commsCommandValues *CommsCmdValues,
 ) *cobra.Command {
 
 	resourcesDeleteCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -74,7 +74,7 @@ func (cmd *ResourcesDeleteCommand) createCobraCommand(
 		Aliases: []string{"resources delete"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return executeResourcesDelete(factory,
-				resourcesDeleteCommandValues, rootCommandValues)
+				resourcesDeleteCommandValues, commsCommandValues)
 		},
 	}
 
@@ -85,11 +85,11 @@ func (cmd *ResourcesDeleteCommand) createCobraCommand(
 
 func executeResourcesDelete(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 	action := "delete"
 
-	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, rootCmdValues)
+	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsCmdValues)
 
 	return err
 }

--- a/pkg/cmd/resourcesDelete.go
+++ b/pkg/cmd/resourcesDelete.go
@@ -62,7 +62,7 @@ func (cmd *ResourcesDeleteCommand) init(factory spi.Factory, resourcesCommand sp
 func (cmd *ResourcesDeleteCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	commsCommandValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) *cobra.Command {
 
 	resourcesDeleteCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -75,9 +75,9 @@ func (cmd *ResourcesDeleteCommand) createCobraCommand(
 		RunE: func(cmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
 				return executeResourcesDelete(factory,
-					resourcesDeleteCommandValues, commsCommandValues)
+					resourcesDeleteCommandValues, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -88,11 +88,11 @@ func (cmd *ResourcesDeleteCommand) createCobraCommand(
 
 func executeResourcesDelete(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 	action := "delete"
 
-	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsCmdValues)
+	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsFlagSetValues)
 
 	return err
 }

--- a/pkg/cmd/resourcesUpdate.go
+++ b/pkg/cmd/resourcesUpdate.go
@@ -73,8 +73,11 @@ func (cmd *ResourcesUpdateCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"resources update"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return executeResourcesUpdate(factory,
-				resourcesUpdateCommandValues, commsCommandValues)
+			executionFunc := func() error {
+				return executeResourcesUpdate(factory,
+					resourcesUpdateCommandValues, commsCommandValues)
+			}
+			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
 		},
 	}
 

--- a/pkg/cmd/resourcesUpdate.go
+++ b/pkg/cmd/resourcesUpdate.go
@@ -62,7 +62,7 @@ func (cmd *ResourcesUpdateCommand) init(factory spi.Factory, resourcesCommand sp
 func (cmd *ResourcesUpdateCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	commsCommandValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) *cobra.Command {
 
 	resourcesUpdateCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -75,9 +75,9 @@ func (cmd *ResourcesUpdateCommand) createCobraCommand(
 		RunE: func(cmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
 				return executeResourcesUpdate(factory,
-					resourcesUpdateCommandValues, commsCommandValues)
+					resourcesUpdateCommandValues, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -88,11 +88,11 @@ func (cmd *ResourcesUpdateCommand) createCobraCommand(
 
 func executeResourcesUpdate(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 	action := "update"
 
-	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsCmdValues)
+	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsFlagSetValues)
 
 	return err
 }

--- a/pkg/cmd/resourcesUpdate.go
+++ b/pkg/cmd/resourcesUpdate.go
@@ -23,10 +23,10 @@ type ResourcesUpdateCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewResourcesUpdateCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewResourcesUpdateCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 
 	cmd := new(ResourcesUpdateCommand)
-	err := cmd.init(factory, resourcesCommand, rootCommand)
+	err := cmd.init(factory, resourcesCommand, commsCommand)
 	return cmd, err
 }
 
@@ -49,12 +49,12 @@ func (cmd *ResourcesUpdateCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *ResourcesUpdateCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (cmd *ResourcesUpdateCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 
 	cmd.values = &ResourcesUpdateCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, rootCommand.Values().(*RootCmdValues))
+	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, commsCommand.Values().(*CommsCmdValues))
 
 	return err
 }
@@ -62,7 +62,7 @@ func (cmd *ResourcesUpdateCommand) init(factory spi.Factory, resourcesCommand sp
 func (cmd *ResourcesUpdateCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	rootCommandValues *RootCmdValues,
+	commsCommandValues *CommsCmdValues,
 ) *cobra.Command {
 
 	resourcesUpdateCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -74,7 +74,7 @@ func (cmd *ResourcesUpdateCommand) createCobraCommand(
 		Aliases: []string{"resources update"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return executeResourcesUpdate(factory,
-				resourcesUpdateCommandValues, rootCommandValues)
+				resourcesUpdateCommandValues, commsCommandValues)
 		},
 	}
 
@@ -85,11 +85,11 @@ func (cmd *ResourcesUpdateCommand) createCobraCommand(
 
 func executeResourcesUpdate(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 	action := "update"
 
-	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, rootCmdValues)
+	err := loadAndPassDataIntoResourcesApi(action, factory, resourcesCmdValues, commsCmdValues)
 
 	return err
 }

--- a/pkg/cmd/resourcesUpdate.go
+++ b/pkg/cmd/resourcesUpdate.go
@@ -23,10 +23,10 @@ type ResourcesUpdateCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewResourcesUpdateCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewResourcesUpdateCommand(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 
 	cmd := new(ResourcesUpdateCommand)
-	err := cmd.init(factory, resourcesCommand, commsCommand)
+	err := cmd.init(factory, resourcesCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -49,12 +49,12 @@ func (cmd *ResourcesUpdateCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *ResourcesUpdateCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *ResourcesUpdateCommand) init(factory spi.Factory, resourcesCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 
 	cmd.values = &ResourcesUpdateCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, commsCommand.Values().(*CommsCmdValues))
+	cmd.cobraCommand = cmd.createCobraCommand(factory, resourcesCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 
 	return err
 }
@@ -62,7 +62,7 @@ func (cmd *ResourcesUpdateCommand) init(factory spi.Factory, resourcesCommand sp
 func (cmd *ResourcesUpdateCommand) createCobraCommand(
 	factory spi.Factory,
 	resourcesCommand spi.GalasaCommand,
-	commsCommandValues *CommsCmdValues,
+	commsCommandValues *CommsFlagSetValues,
 ) *cobra.Command {
 
 	resourcesUpdateCommandValues := resourcesCommand.Values().(*ResourcesCmdValues)
@@ -88,7 +88,7 @@ func (cmd *ResourcesUpdateCommand) createCobraCommand(
 
 func executeResourcesUpdate(factory spi.Factory,
 	resourcesCmdValues *ResourcesCmdValues,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 	action := "update"
 

--- a/pkg/cmd/runs.go
+++ b/pkg/cmd/runs.go
@@ -68,8 +68,8 @@ func (cmd *RunsCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsC
 		Long:  "Assembles, submits and monitors test runs in Galasa Ecosystem",
 	}
 
+	runsCobraCmd.PersistentFlags().AddFlagSet(commsCommand.CobraCommand().PersistentFlags())
 	rootCommand.CobraCommand().AddCommand(runsCobraCmd)
-	commsCommand.CobraCommand().AddCommand(runsCobraCmd)
 
 	return runsCobraCmd, err
 }

--- a/pkg/cmd/runs.go
+++ b/pkg/cmd/runs.go
@@ -22,9 +22,9 @@ type RunsCommand struct {
 // Constructors
 // ------------------------------------------------------------------------------------------------
 
-func NewRunsCmd(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsCmd(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(RunsCommand)
-	err := cmd.init(rootCommand, commsCommand)
+	err := cmd.init(rootCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -48,17 +48,17 @@ func (cmd *RunsCommand) Values() interface{} {
 // Private functions
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsCommand) init(rootCmd spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *RunsCommand) init(rootCmd spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 
 	cmd.values = &RunsCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd, commsCommand)
+	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd, commsFlagSet)
 
 	return err
 }
 
-func (cmd *RunsCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (*cobra.Command, error) {
+func (cmd *RunsCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (*cobra.Command, error) {
 
 	var err error
 
@@ -68,7 +68,7 @@ func (cmd *RunsCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsC
 		Long:  "Assembles, submits and monitors test runs in Galasa Ecosystem",
 	}
 
-	runsCobraCmd.PersistentFlags().AddFlagSet(commsCommand.CobraCommand().PersistentFlags())
+	runsCobraCmd.PersistentFlags().AddFlagSet(commsFlagSet.Flags())
 	rootCommand.CobraCommand().AddCommand(runsCobraCmd)
 
 	return runsCobraCmd, err

--- a/pkg/cmd/runs.go
+++ b/pkg/cmd/runs.go
@@ -11,7 +11,6 @@ import (
 )
 
 type RunsCmdValues struct {
-	bootstrap string
 }
 
 type RunsCommand struct {
@@ -68,8 +67,6 @@ func (cmd *RunsCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsC
 		Short: "Manage test runs in the ecosystem",
 		Long:  "Assembles, submits and monitors test runs in Galasa Ecosystem",
 	}
-
-	addBootstrapFlag(runsCobraCmd, &cmd.values.bootstrap)
 
 	rootCommand.CobraCommand().AddCommand(runsCobraCmd)
 	commsCommand.CobraCommand().AddCommand(runsCobraCmd)

--- a/pkg/cmd/runs.go
+++ b/pkg/cmd/runs.go
@@ -23,9 +23,9 @@ type RunsCommand struct {
 // Constructors
 // ------------------------------------------------------------------------------------------------
 
-func NewRunsCmd(rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsCmd(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(RunsCommand)
-	err := cmd.init(rootCommand)
+	err := cmd.init(rootCommand, commsCommand)
 	return cmd, err
 }
 
@@ -49,17 +49,17 @@ func (cmd *RunsCommand) Values() interface{} {
 // Private functions
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsCommand) init(rootCmd spi.GalasaCommand) error {
+func (cmd *RunsCommand) init(rootCmd spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
 	var err error
 
 	cmd.values = &RunsCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd)
+	cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd, commsCommand)
 
 	return err
 }
 
-func (cmd *RunsCommand) createCobraCommand(rootCommand spi.GalasaCommand) (*cobra.Command, error) {
+func (cmd *RunsCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (*cobra.Command, error) {
 
 	var err error
 
@@ -72,6 +72,7 @@ func (cmd *RunsCommand) createCobraCommand(rootCommand spi.GalasaCommand) (*cobr
 	addBootstrapFlag(runsCobraCmd, &cmd.values.bootstrap)
 
 	rootCommand.CobraCommand().AddCommand(runsCobraCmd)
+	commsCommand.CobraCommand().AddCommand(runsCobraCmd)
 
 	return runsCobraCmd, err
 }

--- a/pkg/cmd/runsCancel.go
+++ b/pkg/cmd/runsCancel.go
@@ -69,7 +69,7 @@ func (cmd *RunsCancelCommand) init(factory spi.Factory, runsCommand spi.GalasaCo
 
 func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -82,9 +82,9 @@ func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 		Aliases: []string{"runs cancel"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeCancel(factory, commsCmdValues)
+				return cmd.executeCancel(factory, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -99,7 +99,7 @@ func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 
 func (cmd *RunsCancelCommand) executeCancel(
 	factory spi.Factory,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
@@ -107,7 +107,7 @@ func (cmd *RunsCancelCommand) executeCancel(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Cancel an active run by abandoning it.")
 
@@ -115,13 +115,13 @@ func (cmd *RunsCancelCommand) executeCancel(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/runsCancel.go
+++ b/pkg/cmd/runsCancel.go
@@ -73,7 +73,6 @@ func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 ) (*cobra.Command, error) {
 
 	var err error
-	runsCmdValues := runsCommand.Values().(*RunsCmdValues)
 
 	runsCancelCmd := &cobra.Command{
 		Use:     "cancel",
@@ -82,7 +81,7 @@ func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs cancel"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeCancel(factory, runsCmdValues, commsCmdValues)
+			return cmd.executeCancel(factory, commsCmdValues)
 		},
 	}
 
@@ -97,7 +96,6 @@ func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 
 func (cmd *RunsCancelCommand) executeCancel(
 	factory spi.Factory,
-	runsCmdValues *RunsCmdValues,
 	commsCmdValues *CommsCmdValues,
 ) error {
 

--- a/pkg/cmd/runsCancel.go
+++ b/pkg/cmd/runsCancel.go
@@ -32,9 +32,9 @@ type RunsCancelCmdValues struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewRunsCancelCommand(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsCancelCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(RunsCancelCommand)
-	err := cmd.init(factory, runsCommand, rootCommand)
+	err := cmd.init(factory, runsCommand, commsCommand)
 	return cmd, err
 }
 
@@ -56,20 +56,20 @@ func (cmd *RunsCancelCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *RunsCancelCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (cmd *RunsCancelCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 	var err error
 	cmd.values = &RunsCancelCmdValues{}
 	cmd.cobraCommand, err = cmd.createRunsCancelCobraCmd(
 		factory,
 		runsCommand,
-		rootCommand.Values().(*RootCmdValues),
+		commsCommand.Values().(*CommsCmdValues),
 	)
 	return err
 }
 
 func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -82,7 +82,7 @@ func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs cancel"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeCancel(factory, runsCmdValues, rootCmdValues)
+			return cmd.executeCancel(factory, runsCmdValues, commsCmdValues)
 		},
 	}
 
@@ -98,7 +98,7 @@ func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 func (cmd *RunsCancelCommand) executeCancel(
 	factory spi.Factory,
 	runsCmdValues *RunsCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 
 	var err error
@@ -106,9 +106,9 @@ func (cmd *RunsCancelCommand) executeCancel(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Cancel an active run by abandoning it.")
 
@@ -116,13 +116,13 @@ func (cmd *RunsCancelCommand) executeCancel(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, runsCmdValues.bootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				var console = factory.GetStdOutConsole()

--- a/pkg/cmd/runsCancel.go
+++ b/pkg/cmd/runsCancel.go
@@ -32,9 +32,9 @@ type RunsCancelCmdValues struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewRunsCancelCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsCancelCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(RunsCancelCommand)
-	err := cmd.init(factory, runsCommand, commsCommand)
+	err := cmd.init(factory, runsCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -56,20 +56,20 @@ func (cmd *RunsCancelCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *RunsCancelCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *RunsCancelCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 	cmd.values = &RunsCancelCmdValues{}
 	cmd.cobraCommand, err = cmd.createRunsCancelCobraCmd(
 		factory,
 		runsCommand,
-		commsCommand.Values().(*CommsCmdValues),
+		commsFlagSet.Values().(*CommsFlagSetValues),
 	)
 	return err
 }
 
 func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -99,7 +99,7 @@ func (cmd *RunsCancelCommand) createRunsCancelCobraCmd(factory spi.Factory,
 
 func (cmd *RunsCancelCommand) executeCancel(
 	factory spi.Factory,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/runsDelete.go
+++ b/pkg/cmd/runsDelete.go
@@ -69,7 +69,6 @@ func (cmd *RunsDeleteCommand) createCobraCommand(
 ) (*cobra.Command, error) {
 
 	var err error
-	runsCmdValues := runsCommand.Values().(*RunsCmdValues)
 
 	runsDeleteCobraCmd := &cobra.Command{
 		Use:     "delete",
@@ -78,7 +77,7 @@ func (cmd *RunsDeleteCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs delete"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeRunsDelete(factory, runsCmdValues, commsCmdValues)
+			return cmd.executeRunsDelete(factory, commsCmdValues)
 		},
 	}
 
@@ -93,7 +92,6 @@ func (cmd *RunsDeleteCommand) createCobraCommand(
 
 func (cmd *RunsDeleteCommand) executeRunsDelete(
 	factory spi.Factory,
-	runsCmdValues *RunsCmdValues,
 	commsCmdValues *CommsCmdValues,
 ) error {
 

--- a/pkg/cmd/runsDelete.go
+++ b/pkg/cmd/runsDelete.go
@@ -30,9 +30,9 @@ type RunsDeleteCommand struct {
 	cobraCommand *cobra.Command
 }
 
-func NewRunsDeleteCommand(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsDeleteCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(RunsDeleteCommand)
-	err := cmd.init(factory, runsCommand, rootCommand)
+	err := cmd.init(factory, runsCommand, commsCommand)
 	return cmd, err
 }
 
@@ -55,17 +55,17 @@ func (cmd *RunsDeleteCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsDeleteCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (cmd *RunsDeleteCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 	var err error
 	cmd.values = &RunsDeleteCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, runsCommand, rootCommand.Values().(*RootCmdValues))
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, runsCommand, commsCommand.Values().(*CommsCmdValues))
 	return err
 }
 
 func (cmd *RunsDeleteCommand) createCobraCommand(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -78,7 +78,7 @@ func (cmd *RunsDeleteCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs delete"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeRunsDelete(factory, runsCmdValues, rootCmdValues)
+			return cmd.executeRunsDelete(factory, runsCmdValues, commsCmdValues)
 		},
 	}
 
@@ -94,7 +94,7 @@ func (cmd *RunsDeleteCommand) createCobraCommand(
 func (cmd *RunsDeleteCommand) executeRunsDelete(
 	factory spi.Factory,
 	runsCmdValues *RunsCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 
 	var err error
@@ -102,9 +102,9 @@ func (cmd *RunsDeleteCommand) executeRunsDelete(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Delete runs about to execute")
 
@@ -112,13 +112,13 @@ func (cmd *RunsDeleteCommand) executeRunsDelete(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, runsCmdValues.bootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				var console = factory.GetStdOutConsole()

--- a/pkg/cmd/runsDelete.go
+++ b/pkg/cmd/runsDelete.go
@@ -65,7 +65,7 @@ func (cmd *RunsDeleteCommand) init(factory spi.Factory, runsCommand spi.GalasaCo
 func (cmd *RunsDeleteCommand) createCobraCommand(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -78,9 +78,9 @@ func (cmd *RunsDeleteCommand) createCobraCommand(
 		Aliases: []string{"runs delete"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeRunsDelete(factory, commsCmdValues)
+				return cmd.executeRunsDelete(factory, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -95,7 +95,7 @@ func (cmd *RunsDeleteCommand) createCobraCommand(
 
 func (cmd *RunsDeleteCommand) executeRunsDelete(
 	factory spi.Factory,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
@@ -103,7 +103,7 @@ func (cmd *RunsDeleteCommand) executeRunsDelete(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Delete runs about to execute")
 
@@ -111,13 +111,13 @@ func (cmd *RunsDeleteCommand) executeRunsDelete(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/runsDelete.go
+++ b/pkg/cmd/runsDelete.go
@@ -30,9 +30,9 @@ type RunsDeleteCommand struct {
 	cobraCommand *cobra.Command
 }
 
-func NewRunsDeleteCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsDeleteCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(RunsDeleteCommand)
-	err := cmd.init(factory, runsCommand, commsCommand)
+	err := cmd.init(factory, runsCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -55,17 +55,17 @@ func (cmd *RunsDeleteCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsDeleteCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *RunsDeleteCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 	cmd.values = &RunsDeleteCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, runsCommand, commsCommand.Values().(*CommsCmdValues))
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, runsCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 	return err
 }
 
 func (cmd *RunsDeleteCommand) createCobraCommand(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -95,7 +95,7 @@ func (cmd *RunsDeleteCommand) createCobraCommand(
 
 func (cmd *RunsDeleteCommand) executeRunsDelete(
 	factory spi.Factory,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/runsDownload.go
+++ b/pkg/cmd/runsDownload.go
@@ -77,7 +77,6 @@ func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 ) (*cobra.Command, error) {
 
 	var err error
-	runsCmdValues := runsCommand.Values().(*RunsCmdValues)
 
 	runsDownloadCobraCmd := &cobra.Command{
 		Use:     "download",
@@ -86,7 +85,7 @@ func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs download"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeRunsDownload(factory, runsCmdValues, commsCmdValues)
+			return cmd.executeRunsDownload(factory, commsCmdValues)
 		},
 	}
 
@@ -104,7 +103,6 @@ func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 
 func (cmd *RunsDownloadCommand) executeRunsDownload(
 	factory spi.Factory,
-	runsCmdValues *RunsCmdValues,
 	commsCmdValues *CommsCmdValues,
 ) error {
 

--- a/pkg/cmd/runsDownload.go
+++ b/pkg/cmd/runsDownload.go
@@ -73,7 +73,7 @@ func (cmd *RunsDownloadCommand) init(factory spi.Factory, runsCommand spi.Galasa
 func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -86,9 +86,9 @@ func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 		Aliases: []string{"runs download"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeRunsDownload(factory, commsCmdValues)
+				return cmd.executeRunsDownload(factory, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -106,7 +106,7 @@ func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 
 func (cmd *RunsDownloadCommand) executeRunsDownload(
 	factory spi.Factory,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
@@ -114,7 +114,7 @@ func (cmd *RunsDownloadCommand) executeRunsDownload(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Download artifacts for a run")
 
@@ -122,13 +122,13 @@ func (cmd *RunsDownloadCommand) executeRunsDownload(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/runsDownload.go
+++ b/pkg/cmd/runsDownload.go
@@ -35,9 +35,9 @@ type RunsDownloadCmdValues struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewRunsDownloadCommand(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsDownloadCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(RunsDownloadCommand)
-	err := cmd.init(factory, runsCommand, rootCommand)
+	err := cmd.init(factory, runsCommand, commsCommand)
 	return cmd, err
 }
 
@@ -60,12 +60,12 @@ func (cmd *RunsDownloadCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsDownloadCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (cmd *RunsDownloadCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 	var err error
 	cmd.values = &RunsDownloadCmdValues{}
 	cmd.cobraCommand, err = cmd.createRunsDownloadCobraCmd(factory,
 		runsCommand,
-		rootCommand.Values().(*RootCmdValues),
+		commsCommand.Values().(*CommsCmdValues),
 	)
 	return err
 }
@@ -73,7 +73,7 @@ func (cmd *RunsDownloadCommand) init(factory spi.Factory, runsCommand spi.Galasa
 func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -86,7 +86,7 @@ func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs download"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeRunsDownload(factory, runsCmdValues, rootCmdValues)
+			return cmd.executeRunsDownload(factory, runsCmdValues, commsCmdValues)
 		},
 	}
 
@@ -105,7 +105,7 @@ func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 func (cmd *RunsDownloadCommand) executeRunsDownload(
 	factory spi.Factory,
 	runsCmdValues *RunsCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 
 	var err error
@@ -113,10 +113,10 @@ func (cmd *RunsDownloadCommand) executeRunsDownload(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
 
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Download artifacts for a run")
 
@@ -124,13 +124,13 @@ func (cmd *RunsDownloadCommand) executeRunsDownload(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, runsCmdValues.bootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				var console = factory.GetStdOutConsole()

--- a/pkg/cmd/runsDownload.go
+++ b/pkg/cmd/runsDownload.go
@@ -35,9 +35,9 @@ type RunsDownloadCmdValues struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewRunsDownloadCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsDownloadCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(RunsDownloadCommand)
-	err := cmd.init(factory, runsCommand, commsCommand)
+	err := cmd.init(factory, runsCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -60,12 +60,12 @@ func (cmd *RunsDownloadCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsDownloadCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *RunsDownloadCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 	cmd.values = &RunsDownloadCmdValues{}
 	cmd.cobraCommand, err = cmd.createRunsDownloadCobraCmd(factory,
 		runsCommand,
-		commsCommand.Values().(*CommsCmdValues),
+		commsFlagSet.Values().(*CommsFlagSetValues),
 	)
 	return err
 }
@@ -73,7 +73,7 @@ func (cmd *RunsDownloadCommand) init(factory spi.Factory, runsCommand spi.Galasa
 func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -106,7 +106,7 @@ func (cmd *RunsDownloadCommand) createRunsDownloadCobraCmd(
 
 func (cmd *RunsDownloadCommand) executeRunsDownload(
 	factory spi.Factory,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/runsGet.go
+++ b/pkg/cmd/runsGet.go
@@ -74,7 +74,6 @@ func (cmd *RunsGetCommand) createCobraCommand(
 ) (*cobra.Command, error) {
 
 	var err error
-	runsCmdValues := runsCommand.Values().(*RunsCmdValues)
 
 	runsGetCobraCmd := &cobra.Command{
 		Use:     "get",
@@ -83,7 +82,7 @@ func (cmd *RunsGetCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs get"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeRunsGet(factory, runsCmdValues, commsCmdValues)
+			return cmd.executeRunsGet(factory, commsCmdValues)
 		},
 	}
 
@@ -115,7 +114,6 @@ func (cmd *RunsGetCommand) createCobraCommand(
 
 func (cmd *RunsGetCommand) executeRunsGet(
 	factory spi.Factory,
-	runsCmdValues *RunsCmdValues,
 	commsCmdValues *CommsCmdValues,
 ) error {
 

--- a/pkg/cmd/runsGet.go
+++ b/pkg/cmd/runsGet.go
@@ -70,7 +70,7 @@ func (cmd *RunsGetCommand) init(factory spi.Factory, runsCommand spi.GalasaComma
 func (cmd *RunsGetCommand) createCobraCommand(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -83,9 +83,9 @@ func (cmd *RunsGetCommand) createCobraCommand(
 		Aliases: []string{"runs get"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeRunsGet(factory, commsCmdValues)
+				return cmd.executeRunsGet(factory, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -117,7 +117,7 @@ func (cmd *RunsGetCommand) createCobraCommand(
 
 func (cmd *RunsGetCommand) executeRunsGet(
 	factory spi.Factory,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
@@ -125,7 +125,7 @@ func (cmd *RunsGetCommand) executeRunsGet(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Get info about a run")
 
@@ -133,13 +133,13 @@ func (cmd *RunsGetCommand) executeRunsGet(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/runsGet.go
+++ b/pkg/cmd/runsGet.go
@@ -35,9 +35,9 @@ type RunsGetCommand struct {
 	cobraCommand *cobra.Command
 }
 
-func NewRunsGetCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsGetCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(RunsGetCommand)
-	err := cmd.init(factory, runsCommand, commsCommand)
+	err := cmd.init(factory, runsCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -60,17 +60,17 @@ func (cmd *RunsGetCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsGetCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *RunsGetCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 	cmd.values = &RunsGetCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, runsCommand, commsCommand.Values().(*CommsCmdValues))
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, runsCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 	return err
 }
 
 func (cmd *RunsGetCommand) createCobraCommand(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -117,7 +117,7 @@ func (cmd *RunsGetCommand) createCobraCommand(
 
 func (cmd *RunsGetCommand) executeRunsGet(
 	factory spi.Factory,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/runsGet.go
+++ b/pkg/cmd/runsGet.go
@@ -82,7 +82,10 @@ func (cmd *RunsGetCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs get"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeRunsGet(factory, commsCmdValues)
+			executionFunc := func() error {
+				return cmd.executeRunsGet(factory, commsCmdValues)
+			}
+			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
 		},
 	}
 
@@ -122,54 +125,51 @@ func (cmd *RunsGetCommand) executeRunsGet(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	commsCmdValues.isCapturingLogs = true
+
+	log.Println("Galasa CLI - Get info about a run")
+
+	// Get the ability to query environment variables.
+	env := factory.GetEnvironment()
+
+	var galasaHome spi.GalasaHome
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 	if err == nil {
-		commsCmdValues.isCapturingLogs = true
 
-		log.Println("Galasa CLI - Get info about a run")
-
-		// Get the ability to query environment variables.
-		env := factory.GetEnvironment()
-
-		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+		// Read the bootstrap properties.
+		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
+		var bootstrapData *api.BootstrapData
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 		if err == nil {
 
-			// Read the bootstrap properties.
-			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
-			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+			var console = factory.GetStdOutConsole()
+			timeService := factory.GetTimeService()
+
+			apiServerUrl := bootstrapData.ApiServerURL
+			log.Printf("The API server is at '%s'\n", apiServerUrl)
+
+			authenticator := factory.GetAuthenticator(
+				apiServerUrl,
+				galasaHome,
+			)
+
+			var apiClient *galasaapi.APIClient
+			apiClient, err = authenticator.GetAuthenticatedAPIClient()
+
 			if err == nil {
-
-				var console = factory.GetStdOutConsole()
-				timeService := factory.GetTimeService()
-
-				apiServerUrl := bootstrapData.ApiServerURL
-				log.Printf("The API server is at '%s'\n", apiServerUrl)
-
-				authenticator := factory.GetAuthenticator(
+				// Call to process the command in a unit-testable way.
+				err = runs.GetRuns(
+					cmd.values.runName,
+					cmd.values.age,
+					cmd.values.requestor,
+					cmd.values.result,
+					cmd.values.isActiveRuns,
+					cmd.values.outputFormatString,
+					timeService,
+					console,
 					apiServerUrl,
-					galasaHome,
+					apiClient,
 				)
-
-				var apiClient *galasaapi.APIClient
-				apiClient, err = authenticator.GetAuthenticatedAPIClient()
-
-				if err == nil {
-					// Call to process the command in a unit-testable way.
-					err = runs.GetRuns(
-						cmd.values.runName,
-						cmd.values.age,
-						cmd.values.requestor,
-						cmd.values.result,
-						cmd.values.isActiveRuns,
-						cmd.values.outputFormatString,
-						timeService,
-						console,
-						apiServerUrl,
-						apiClient,
-					)
-				}
 			}
 		}
 	}

--- a/pkg/cmd/runsGet.go
+++ b/pkg/cmd/runsGet.go
@@ -35,9 +35,9 @@ type RunsGetCommand struct {
 	cobraCommand *cobra.Command
 }
 
-func NewRunsGetCommand(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsGetCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(RunsGetCommand)
-	err := cmd.init(factory, runsCommand, rootCommand)
+	err := cmd.init(factory, runsCommand, commsCommand)
 	return cmd, err
 }
 
@@ -60,17 +60,17 @@ func (cmd *RunsGetCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsGetCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (cmd *RunsGetCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 	var err error
 	cmd.values = &RunsGetCmdValues{}
-	cmd.cobraCommand, err = cmd.createCobraCommand(factory, runsCommand, rootCommand.Values().(*RootCmdValues))
+	cmd.cobraCommand, err = cmd.createCobraCommand(factory, runsCommand, commsCommand.Values().(*CommsCmdValues))
 	return err
 }
 
 func (cmd *RunsGetCommand) createCobraCommand(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -83,7 +83,7 @@ func (cmd *RunsGetCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs get"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeRunsGet(factory, runsCmdValues, rootCmdValues)
+			return cmd.executeRunsGet(factory, runsCmdValues, commsCmdValues)
 		},
 	}
 
@@ -116,7 +116,7 @@ func (cmd *RunsGetCommand) createCobraCommand(
 func (cmd *RunsGetCommand) executeRunsGet(
 	factory spi.Factory,
 	runsCmdValues *RunsCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 
 	var err error
@@ -124,9 +124,9 @@ func (cmd *RunsGetCommand) executeRunsGet(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Get info about a run")
 
@@ -134,13 +134,13 @@ func (cmd *RunsGetCommand) executeRunsGet(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, runsCmdValues.bootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				var console = factory.GetStdOutConsole()

--- a/pkg/cmd/runsPrepare.go
+++ b/pkg/cmd/runsPrepare.go
@@ -70,7 +70,7 @@ func (cmd *RunsPrepareCommand) init(factory spi.Factory, runsCommand spi.GalasaC
 func (cmd *RunsPrepareCommand) createCobraCommand(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 	var err error
 
@@ -83,7 +83,7 @@ func (cmd *RunsPrepareCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs prepare"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeAssemble(factory, commsCmdValues)
+			return cmd.executeAssemble(factory, commsFlagSetValues)
 		},
 	}
 
@@ -101,16 +101,16 @@ func (cmd *RunsPrepareCommand) createCobraCommand(
 
 func (cmd *RunsPrepareCommand) executeAssemble(
 	factory spi.Factory,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 	var err error
 
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsFlagSetValues.logFileName)
 	if err == nil {
-		commsCmdValues.isCapturingLogs = true
+		commsFlagSetValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Assemble tests")
 
@@ -118,7 +118,7 @@ func (cmd *RunsPrepareCommand) executeAssemble(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Convert overrides to a map
@@ -141,13 +141,13 @@ func (cmd *RunsPrepareCommand) executeAssemble(
 
 			if err == nil {
 
-				commsRetrier := api.NewCommsRetrier(commsCmdValues.maxRetries, commsCmdValues.retryBackoffSeconds, factory.GetTimeService())
+				commsRetrier := api.NewCommsRetrier(commsFlagSetValues.maxRetries, commsFlagSetValues.retryBackoffSeconds, factory.GetTimeService())
 
 				// Load the bootstrap properties.
 				var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 				var bootstrapData *api.BootstrapData
 				loadBootstrapWithRetriesFunc := func() error {
-					bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+					bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 					return err
 				}
 	

--- a/pkg/cmd/runsPrepare.go
+++ b/pkg/cmd/runsPrepare.go
@@ -83,10 +83,7 @@ func (cmd *RunsPrepareCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs prepare"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			executionFunc := func() error {
-				return cmd.executeAssemble(factory, commsCmdValues)
-			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return cmd.executeAssemble(factory, commsCmdValues)
 		},
 	}
 
@@ -111,91 +108,101 @@ func (cmd *RunsPrepareCommand) executeAssemble(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
-
-	log.Println("Galasa CLI - Assemble tests")
-
-	// Get the ability to query environment variables.
-	env := factory.GetEnvironment()
-
-	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
+		commsCmdValues.isCapturingLogs = true
 
-		// Convert overrides to a map
-		testOverrides := make(map[string]string)
-		for _, override := range *cmd.values.prepareFlagOverrides {
-			pos := strings.Index(override, "=")
-			if pos < 1 {
-				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_PREPARE_INVALID_OVERRIDE, override)
-				break
-			}
-			key := override[:pos]
-			value := override[pos+1:]
-			if value == "" {
-				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_PREPARE_INVALID_OVERRIDE, override)
-				break
-			}
+		log.Println("Galasa CLI - Assemble tests")
 
-			testOverrides[key] = value
-		}
+		// Get the ability to query environment variables.
+		env := factory.GetEnvironment()
 
+		var galasaHome spi.GalasaHome
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
-			// Load the bootstrap properties.
-			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
-			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+			// Convert overrides to a map
+			testOverrides := make(map[string]string)
+			for _, override := range *cmd.values.prepareFlagOverrides {
+				pos := strings.Index(override, "=")
+				if pos < 1 {
+					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_PREPARE_INVALID_OVERRIDE, override)
+					break
+				}
+				key := override[:pos]
+				value := override[pos+1:]
+				if value == "" {
+					err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_PREPARE_INVALID_OVERRIDE, override)
+					break
+				}
+
+				testOverrides[key] = value
+			}
+
 			if err == nil {
 
-				// Create an API client
-				var apiClient *galasaapi.APIClient
-				apiServerUrl := bootstrapData.ApiServerURL
-				authenticator := factory.GetAuthenticator(
-					apiServerUrl,
-					galasaHome,
-				)
-				apiClient, err = authenticator.GetAuthenticatedAPIClient()
+				commsRetrier := api.NewCommsRetrier(commsCmdValues.maxRetries, commsCmdValues.retryBackoffSeconds, factory.GetTimeService())
+
+				// Load the bootstrap properties.
+				var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
+				var bootstrapData *api.BootstrapData
+				loadBootstrapWithRetriesFunc := func() error {
+					bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+					return err
+				}
+	
+				err = commsRetrier.ExecuteCommandWithRateLimitRetries(loadBootstrapWithRetriesFunc)
 				if err == nil {
-					launcher := launcher.NewRemoteLauncher(apiServerUrl, apiClient)
 
-					validator := runs.NewStreamBasedValidator()
-					err = validator.Validate(cmd.values.prepareSelectionFlags)
+					// Create an API client
+					var apiClient *galasaapi.APIClient
+					apiServerUrl := bootstrapData.ApiServerURL
+					authenticator := factory.GetAuthenticator(
+						apiServerUrl,
+						galasaHome,
+					)
+					apiClient, err = authenticator.GetAuthenticatedAPIClient()
 					if err == nil {
+						launcher := launcher.NewRemoteLauncher(apiServerUrl, apiClient, commsRetrier)
 
-						var testSelection runs.TestSelection
-						testSelection, err = runs.SelectTests(launcher, cmd.values.prepareSelectionFlags)
+						validator := runs.NewStreamBasedValidator()
+						err = validator.Validate(cmd.values.prepareSelectionFlags)
 						if err == nil {
 
-							count := len(testSelection.Classes)
-							if count < 1 {
-								err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_NO_TESTS_SELECTED)
-							} else {
-								if count == 1 {
-									log.Println("1 test was selected")
-								} else {
-									log.Printf("%v tests were selected", count)
-								}
-							}
-
+							var testSelection runs.TestSelection
+							testSelection, err = runs.SelectTests(launcher, cmd.values.prepareSelectionFlags)
 							if err == nil {
 
-								var portfolio *runs.Portfolio
-								if *cmd.values.prepareAppend {
-									portfolio, err = runs.ReadPortfolio(fileSystem, cmd.values.portfolioFilename)
+								count := len(testSelection.Classes)
+								if count < 1 {
+									err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_NO_TESTS_SELECTED)
 								} else {
-									portfolio = runs.NewPortfolio()
+									if count == 1 {
+										log.Println("1 test was selected")
+									} else {
+										log.Printf("%v tests were selected", count)
+									}
 								}
 
 								if err == nil {
-									runs.AddClassesToPortfolio(&testSelection, &testOverrides, portfolio)
 
-									err = runs.WritePortfolio(fileSystem, cmd.values.portfolioFilename, portfolio)
+									var portfolio *runs.Portfolio
+									if *cmd.values.prepareAppend {
+										portfolio, err = runs.ReadPortfolio(fileSystem, cmd.values.portfolioFilename)
+									} else {
+										portfolio = runs.NewPortfolio()
+									}
+
 									if err == nil {
-										if *cmd.values.prepareAppend {
-											log.Println("Portfolio appended")
-										} else {
-											log.Println("Portfolio created")
+										runs.AddClassesToPortfolio(&testSelection, &testOverrides, portfolio)
+
+										err = runs.WritePortfolio(fileSystem, cmd.values.portfolioFilename, portfolio)
+										if err == nil {
+											if *cmd.values.prepareAppend {
+												log.Println("Portfolio appended")
+											} else {
+												log.Println("Portfolio created")
+											}
 										}
 									}
 								}

--- a/pkg/cmd/runsPrepare.go
+++ b/pkg/cmd/runsPrepare.go
@@ -32,9 +32,9 @@ type RunsPrepareCommand struct {
 	cobraCommand *cobra.Command
 }
 
-func NewRunsPrepareCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsPrepareCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(RunsPrepareCommand)
-	err := cmd.init(factory, runsCommand, commsCommand)
+	err := cmd.init(factory, runsCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -57,20 +57,20 @@ func (cmd *RunsPrepareCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsPrepareCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *RunsPrepareCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 	cmd.values = &RunsPrepareCmdValues{}
 	cmd.cobraCommand, err = cmd.createCobraCommand(
 		factory,
 		runsCommand,
-		commsCommand.Values().(*CommsCmdValues),
+		commsFlagSet.Values().(*CommsFlagSetValues),
 	)
 	return err
 }
 func (cmd *RunsPrepareCommand) createCobraCommand(
 	factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 	var err error
 
@@ -101,7 +101,7 @@ func (cmd *RunsPrepareCommand) createCobraCommand(
 
 func (cmd *RunsPrepareCommand) executeAssemble(
 	factory spi.Factory,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 	var err error
 

--- a/pkg/cmd/runsPrepare.go
+++ b/pkg/cmd/runsPrepare.go
@@ -83,7 +83,7 @@ func (cmd *RunsPrepareCommand) createCobraCommand(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs prepare"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeAssemble(factory, runsCommand.Values().(*RunsCmdValues), commsCmdValues)
+			return cmd.executeAssemble(factory, commsCmdValues)
 		},
 	}
 
@@ -101,7 +101,6 @@ func (cmd *RunsPrepareCommand) createCobraCommand(
 
 func (cmd *RunsPrepareCommand) executeAssemble(
 	factory spi.Factory,
-	runsCmdValues *RunsCmdValues,
 	commsCmdValues *CommsCmdValues,
 ) error {
 	var err error

--- a/pkg/cmd/runsReset.go
+++ b/pkg/cmd/runsReset.go
@@ -32,9 +32,9 @@ type RunsResetCmdValues struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewRunsResetCommand(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsResetCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(RunsResetCommand)
-	err := cmd.init(factory, runsCommand, rootCommand)
+	err := cmd.init(factory, runsCommand, commsCommand)
 	return cmd, err
 }
 
@@ -56,20 +56,20 @@ func (cmd *RunsResetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *RunsResetCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (cmd *RunsResetCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 	var err error
 	cmd.values = &RunsResetCmdValues{}
 	cmd.cobraCommand, err = cmd.createRunsResetCobraCmd(
 		factory,
 		runsCommand,
-		rootCommand.Values().(*RootCmdValues),
+		commsCommand.Values().(*CommsCmdValues),
 	)
 	return err
 }
 
 func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -82,7 +82,7 @@ func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs reset"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeReset(factory, runsCmdValues, rootCmdValues)
+			return cmd.executeReset(factory, runsCmdValues, commsCmdValues)
 		},
 	}
 
@@ -98,7 +98,7 @@ func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 func (cmd *RunsResetCommand) executeReset(
 	factory spi.Factory,
 	runsCmdValues *RunsCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 
 	var err error
@@ -106,9 +106,9 @@ func (cmd *RunsResetCommand) executeReset(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Reset an active run by requeuing it.")
 
@@ -116,13 +116,13 @@ func (cmd *RunsResetCommand) executeReset(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, runsCmdValues.bootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				var console = factory.GetStdOutConsole()

--- a/pkg/cmd/runsReset.go
+++ b/pkg/cmd/runsReset.go
@@ -69,7 +69,7 @@ func (cmd *RunsResetCommand) init(factory spi.Factory, runsCommand spi.GalasaCom
 
 func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -82,9 +82,9 @@ func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 		Aliases: []string{"runs reset"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeReset(factory, commsCmdValues)
+				return cmd.executeReset(factory, commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -99,7 +99,7 @@ func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 
 func (cmd *RunsResetCommand) executeReset(
 	factory spi.Factory,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
@@ -107,7 +107,7 @@ func (cmd *RunsResetCommand) executeReset(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Reset an active run by requeuing it.")
 
@@ -115,13 +115,13 @@ func (cmd *RunsResetCommand) executeReset(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/runsReset.go
+++ b/pkg/cmd/runsReset.go
@@ -73,7 +73,6 @@ func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 ) (*cobra.Command, error) {
 
 	var err error
-	runsCmdValues := runsCommand.Values().(*RunsCmdValues)
 
 	runsResetCmd := &cobra.Command{
 		Use:     "reset",
@@ -82,7 +81,7 @@ func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs reset"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeReset(factory, runsCmdValues, commsCmdValues)
+			return cmd.executeReset(factory, commsCmdValues)
 		},
 	}
 
@@ -97,7 +96,6 @@ func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 
 func (cmd *RunsResetCommand) executeReset(
 	factory spi.Factory,
-	runsCmdValues *RunsCmdValues,
 	commsCmdValues *CommsCmdValues,
 ) error {
 

--- a/pkg/cmd/runsReset.go
+++ b/pkg/cmd/runsReset.go
@@ -32,9 +32,9 @@ type RunsResetCmdValues struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewRunsResetCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsResetCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(RunsResetCommand)
-	err := cmd.init(factory, runsCommand, commsCommand)
+	err := cmd.init(factory, runsCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -56,20 +56,20 @@ func (cmd *RunsResetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *RunsResetCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *RunsResetCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 	cmd.values = &RunsResetCmdValues{}
 	cmd.cobraCommand, err = cmd.createRunsResetCobraCmd(
 		factory,
 		runsCommand,
-		commsCommand.Values().(*CommsCmdValues),
+		commsFlagSet.Values().(*CommsFlagSetValues),
 	)
 	return err
 }
 
 func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -99,7 +99,7 @@ func (cmd *RunsResetCommand) createRunsResetCobraCmd(factory spi.Factory,
 
 func (cmd *RunsResetCommand) executeReset(
 	factory spi.Factory,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -66,7 +66,7 @@ func (cmd *RunsSubmitCommand) init(factory spi.Factory, runsCommand spi.GalasaCo
 
 func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -81,7 +81,7 @@ func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs submit"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeSubmit(factory, commsCmdValues)
+			return cmd.executeSubmit(factory, commsFlagSetValues)
 		},
 	}
 
@@ -140,7 +140,7 @@ func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 
 func (cmd *RunsSubmitCommand) executeSubmit(
 	factory spi.Factory,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
@@ -148,10 +148,10 @@ func (cmd *RunsSubmitCommand) executeSubmit(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsFlagSetValues.logFileName)
 	if err == nil {
 
-		commsCmdValues.isCapturingLogs = true
+		commsFlagSetValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Submit tests (Remote)")
 
@@ -159,16 +159,16 @@ func (cmd *RunsSubmitCommand) executeSubmit(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 		if err == nil {
 
-			commsRetrier := api.NewCommsRetrier(commsCmdValues.maxRetries, commsCmdValues.retryBackoffSeconds, factory.GetTimeService())
+			commsRetrier := api.NewCommsRetrier(commsFlagSetValues.maxRetries, commsFlagSetValues.retryBackoffSeconds, factory.GetTimeService())
 
 			// Read the bootstrap properties.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
 			loadBootstrapWithRetriesFunc := func() error {
-				bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+				bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 				return err
 			}
 

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -81,7 +81,7 @@ func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs submit"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeSubmit(factory, runsCommand.Values().(*RunsCmdValues), commsCmdValues)
+			return cmd.executeSubmit(factory, commsCmdValues)
 		},
 	}
 
@@ -140,7 +140,6 @@ func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 
 func (cmd *RunsSubmitCommand) executeSubmit(
 	factory spi.Factory,
-	runsCmdValues *RunsCmdValues,
 	commsCmdValues *CommsCmdValues,
 ) error {
 

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -28,9 +28,9 @@ type RunsSubmitCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors
 // ------------------------------------------------------------------------------------------------
-func NewRunsSubmitCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsSubmitCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(RunsSubmitCommand)
-	err := cmd.init(factory, runsCommand, commsCommand)
+	err := cmd.init(factory, runsCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -53,20 +53,20 @@ func (cmd *RunsSubmitCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsSubmitCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *RunsSubmitCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 	cmd.values = &utils.RunsSubmitCmdValues{}
 	cmd.cobraCommand, err = cmd.createRunsSubmitCobraCmd(
 		factory,
 		runsCommand,
-		commsCommand.Values().(*CommsCmdValues),
+		commsFlagSet.Values().(*CommsFlagSetValues),
 	)
 	return err
 }
 
 func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -140,7 +140,7 @@ func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 
 func (cmd *RunsSubmitCommand) executeSubmit(
 	factory spi.Factory,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/runsSubmit.go
+++ b/pkg/cmd/runsSubmit.go
@@ -28,9 +28,9 @@ type RunsSubmitCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors
 // ------------------------------------------------------------------------------------------------
-func NewRunsSubmitCommand(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsSubmitCommand(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(RunsSubmitCommand)
-	err := cmd.init(factory, runsCommand, rootCommand)
+	err := cmd.init(factory, runsCommand, commsCommand)
 	return cmd, err
 }
 
@@ -53,20 +53,20 @@ func (cmd *RunsSubmitCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsSubmitCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, rootCommand spi.GalasaCommand) error {
+func (cmd *RunsSubmitCommand) init(factory spi.Factory, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 	var err error
 	cmd.values = &utils.RunsSubmitCmdValues{}
 	cmd.cobraCommand, err = cmd.createRunsSubmitCobraCmd(
 		factory,
 		runsCommand,
-		rootCommand.Values().(*RootCmdValues),
+		commsCommand.Values().(*CommsCmdValues),
 	)
 	return err
 }
 
 func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 	runsCommand spi.GalasaCommand,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -81,7 +81,7 @@ func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs submit"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeSubmit(factory, runsCommand.Values().(*RunsCmdValues), rootCmdValues)
+			return cmd.executeSubmit(factory, runsCommand.Values().(*RunsCmdValues), commsCmdValues)
 		},
 	}
 
@@ -141,7 +141,7 @@ func (cmd *RunsSubmitCommand) createRunsSubmitCobraCmd(factory spi.Factory,
 func (cmd *RunsSubmitCommand) executeSubmit(
 	factory spi.Factory,
 	runsCmdValues *RunsCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 
 	var err error
@@ -149,10 +149,10 @@ func (cmd *RunsSubmitCommand) executeSubmit(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 	if err == nil {
 
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Submit tests (Remote)")
 
@@ -160,13 +160,13 @@ func (cmd *RunsSubmitCommand) executeSubmit(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap properties.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, runsCmdValues.bootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				timeService := factory.GetTimeService()

--- a/pkg/cmd/runsSubmitLocal.go
+++ b/pkg/cmd/runsSubmitLocal.go
@@ -36,9 +36,9 @@ type RunsSubmitLocalCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors
 // ------------------------------------------------------------------------------------------------
-func NewRunsSubmitLocalCommand(factory spi.Factory, runsSubmitCommand spi.GalasaCommand, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewRunsSubmitLocalCommand(factory spi.Factory, runsSubmitCommand spi.GalasaCommand, runsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 	cmd := new(RunsSubmitLocalCommand)
-	err := cmd.init(factory, runsSubmitCommand, commsCommand)
+	err := cmd.init(factory, runsSubmitCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -61,7 +61,7 @@ func (cmd *RunsSubmitLocalCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsSubmitLocalCommand) init(factory spi.Factory, runsSubmitCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *RunsSubmitLocalCommand) init(factory spi.Factory, runsSubmitCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 
 	// Allocate storage to capture the parsed values.
@@ -73,7 +73,7 @@ func (cmd *RunsSubmitLocalCommand) init(factory spi.Factory, runsSubmitCommand s
 	cmd.cobraCommand, err = cmd.createRunsSubmitLocalCobraCmd(
 		factory,
 		runsSubmitCommand,
-		commsCommand.Values().(*CommsCmdValues),
+		commsFlagSet.Values().(*CommsFlagSetValues),
 	)
 	return err
 }
@@ -81,7 +81,7 @@ func (cmd *RunsSubmitLocalCommand) init(factory spi.Factory, runsSubmitCommand s
 func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 	factory spi.Factory,
 	runsSubmitCmd spi.GalasaCommand,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 	var err error
 
@@ -158,7 +158,7 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 	factory spi.Factory,
 	runsSubmitCmdValues *utils.RunsSubmitCmdValues,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/runsSubmitLocal.go
+++ b/pkg/cmd/runsSubmitLocal.go
@@ -81,7 +81,7 @@ func (cmd *RunsSubmitLocalCommand) init(factory spi.Factory, runsSubmitCommand s
 func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 	factory spi.Factory,
 	runsSubmitCmd spi.GalasaCommand,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 	var err error
 
@@ -93,9 +93,9 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 		Aliases: []string{"runs submit local"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeSubmitLocal(factory, runsSubmitCmd.Values().(*utils.RunsSubmitCmdValues), commsCmdValues)
+				return cmd.executeSubmitLocal(factory, runsSubmitCmd.Values().(*utils.RunsSubmitCmdValues), commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -158,7 +158,7 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 	factory spi.Factory,
 	runsSubmitCmdValues *utils.RunsSubmitCmdValues,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
@@ -166,7 +166,7 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Submit tests (Local)")
 
@@ -175,13 +175,13 @@ func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 
 	// Work out where galasa home is, only once.
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap properties.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			timeService := utils.NewRealTimeService()

--- a/pkg/cmd/runsSubmitLocal.go
+++ b/pkg/cmd/runsSubmitLocal.go
@@ -38,7 +38,7 @@ type RunsSubmitLocalCommand struct {
 // ------------------------------------------------------------------------------------------------
 func NewRunsSubmitLocalCommand(factory spi.Factory, runsSubmitCommand spi.GalasaCommand, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
 	cmd := new(RunsSubmitLocalCommand)
-	err := cmd.init(factory, runsSubmitCommand, runsCommand, commsCommand)
+	err := cmd.init(factory, runsSubmitCommand, commsCommand)
 	return cmd, err
 }
 
@@ -61,7 +61,7 @@ func (cmd *RunsSubmitLocalCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *RunsSubmitLocalCommand) init(factory spi.Factory, runsSubmitCommand spi.GalasaCommand, runsCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *RunsSubmitLocalCommand) init(factory spi.Factory, runsSubmitCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 	var err error
 
 	// Allocate storage to capture the parsed values.
@@ -73,7 +73,6 @@ func (cmd *RunsSubmitLocalCommand) init(factory spi.Factory, runsSubmitCommand s
 	cmd.cobraCommand, err = cmd.createRunsSubmitLocalCobraCmd(
 		factory,
 		runsSubmitCommand,
-		runsCommand.Values().(*RunsCmdValues),
 		commsCommand.Values().(*CommsCmdValues),
 	)
 	return err
@@ -82,7 +81,6 @@ func (cmd *RunsSubmitLocalCommand) init(factory spi.Factory, runsSubmitCommand s
 func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 	factory spi.Factory,
 	runsSubmitCmd spi.GalasaCommand,
-	runsCmdValues *RunsCmdValues,
 	commsCmdValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 	var err error
@@ -94,7 +92,7 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 		Args:    cobra.NoArgs,
 		Aliases: []string{"runs submit local"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.executeSubmitLocal(factory, runsSubmitCmd.Values().(*utils.RunsSubmitCmdValues), runsCmdValues, commsCmdValues)
+			return cmd.executeSubmitLocal(factory, runsSubmitCmd.Values().(*utils.RunsSubmitCmdValues), commsCmdValues)
 		},
 	}
 
@@ -157,7 +155,6 @@ func (cmd *RunsSubmitLocalCommand) createRunsSubmitLocalCobraCmd(
 func (cmd *RunsSubmitLocalCommand) executeSubmitLocal(
 	factory spi.Factory,
 	runsSubmitCmdValues *utils.RunsSubmitCmdValues,
-	runsCmdValues *RunsCmdValues,
 	commsCmdValues *CommsCmdValues,
 ) error {
 

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -6,8 +6,8 @@
 package cmd
 
 import (
-    "github.com/galasa-dev/cli/pkg/spi"
-    "github.com/spf13/cobra"
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/spf13/cobra"
 )
 
 type SecretsCmdValues struct {
@@ -23,9 +23,9 @@ type SecretsCommand struct {
 // Constructors
 // ------------------------------------------------------------------------------------------------
 
-func NewSecretsCmd(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewSecretsCmd(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
     cmd := new(SecretsCommand)
-    err := cmd.init(rootCommand, commsCommand)
+    err := cmd.init(rootCommand, commsFlagSet)
     return cmd, err
 }
 
@@ -49,17 +49,17 @@ func (cmd *SecretsCommand) Values() interface{} {
 // Private functions
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *SecretsCommand) init(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
+func (cmd *SecretsCommand) init(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
     var err error
 
     cmd.values = &SecretsCmdValues{}
-    cmd.cobraCommand, err = cmd.createCobraCommand(rootCommand, commsCommand)
+    cmd.cobraCommand, err = cmd.createCobraCommand(rootCommand, commsFlagSet)
 
     return err
 }
 
-func (cmd *SecretsCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (*cobra.Command, error) {
+func (cmd *SecretsCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) (*cobra.Command, error) {
 
     var err error
 
@@ -69,7 +69,7 @@ func (cmd *SecretsCommand) createCobraCommand(rootCommand spi.GalasaCommand, com
         Long:  "The parent command for operations to manipulate secrets in the Galasa service's credentials store",
     }
 
-    secretsCobraCmd.PersistentFlags().AddFlagSet(commsCommand.CobraCommand().PersistentFlags())
+    secretsCobraCmd.PersistentFlags().AddFlagSet(commsFlagSet.Flags())
     rootCommand.CobraCommand().AddCommand(secretsCobraCmd)
 
     return secretsCobraCmd, err

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -11,7 +11,6 @@ import (
 )
 
 type SecretsCmdValues struct {
-    bootstrap string
     name string
 }
 
@@ -69,8 +68,6 @@ func (cmd *SecretsCommand) createCobraCommand(rootCommand spi.GalasaCommand, com
         Short: "Manage secrets stored in the Galasa service's credentials store",
         Long:  "The parent command for operations to manipulate secrets in the Galasa service's credentials store",
     }
-
-    addBootstrapFlag(secretsCobraCmd, &cmd.values.bootstrap)
 
     rootCommand.CobraCommand().AddCommand(secretsCobraCmd)
     commsCommand.CobraCommand().AddCommand(secretsCobraCmd)

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -69,8 +69,8 @@ func (cmd *SecretsCommand) createCobraCommand(rootCommand spi.GalasaCommand, com
         Long:  "The parent command for operations to manipulate secrets in the Galasa service's credentials store",
     }
 
+    secretsCobraCmd.PersistentFlags().AddFlagSet(commsCommand.CobraCommand().PersistentFlags())
     rootCommand.CobraCommand().AddCommand(secretsCobraCmd)
-    commsCommand.CobraCommand().AddCommand(secretsCobraCmd)
 
     return secretsCobraCmd, err
 }

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -24,9 +24,9 @@ type SecretsCommand struct {
 // Constructors
 // ------------------------------------------------------------------------------------------------
 
-func NewSecretsCmd(rootCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewSecretsCmd(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (spi.GalasaCommand, error) {
     cmd := new(SecretsCommand)
-    err := cmd.init(rootCommand)
+    err := cmd.init(rootCommand, commsCommand)
     return cmd, err
 }
 
@@ -50,17 +50,17 @@ func (cmd *SecretsCommand) Values() interface{} {
 // Private functions
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *SecretsCommand) init(rootCmd spi.GalasaCommand) error {
+func (cmd *SecretsCommand) init(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) error {
 
     var err error
 
     cmd.values = &SecretsCmdValues{}
-    cmd.cobraCommand, err = cmd.createCobraCommand(rootCmd)
+    cmd.cobraCommand, err = cmd.createCobraCommand(rootCommand, commsCommand)
 
     return err
 }
 
-func (cmd *SecretsCommand) createCobraCommand(rootCommand spi.GalasaCommand) (*cobra.Command, error) {
+func (cmd *SecretsCommand) createCobraCommand(rootCommand spi.GalasaCommand, commsCommand spi.GalasaCommand) (*cobra.Command, error) {
 
     var err error
 
@@ -73,6 +73,7 @@ func (cmd *SecretsCommand) createCobraCommand(rootCommand spi.GalasaCommand) (*c
     addBootstrapFlag(secretsCobraCmd, &cmd.values.bootstrap)
 
     rootCommand.CobraCommand().AddCommand(secretsCobraCmd)
+    commsCommand.CobraCommand().AddCommand(secretsCobraCmd)
 
     return secretsCobraCmd, err
 }

--- a/pkg/cmd/secretsDelete.go
+++ b/pkg/cmd/secretsDelete.go
@@ -26,12 +26,12 @@ type SecretsDeleteCommand struct {
 func NewSecretsDeleteCommand(
     factory spi.Factory,
     secretsDeleteCommand spi.GalasaCommand,
-    commsCmd spi.GalasaCommand,
+    commsFlagSet GalasaFlagSet,
 ) (spi.GalasaCommand, error) {
 
     cmd := new(SecretsDeleteCommand)
 
-    err := cmd.init(factory, secretsDeleteCommand, commsCmd)
+    err := cmd.init(factory, secretsDeleteCommand, commsFlagSet)
     return cmd, err
 }
 
@@ -53,10 +53,10 @@ func (cmd *SecretsDeleteCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *SecretsDeleteCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *SecretsDeleteCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
     var err error
 
-    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, commsCmd.Values().(*CommsCmdValues))
+    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 
     return err
 }
@@ -64,7 +64,7 @@ func (cmd *SecretsDeleteCommand) init(factory spi.Factory, secretsCommand spi.Ga
 func (cmd *SecretsDeleteCommand) createCobraCmd(
     factory spi.Factory,
     secretsCommand spi.GalasaCommand,
-    commsCommandValues *CommsCmdValues,
+    commsCommandValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
     var err error
@@ -93,7 +93,7 @@ func (cmd *SecretsDeleteCommand) createCobraCmd(
 func (cmd *SecretsDeleteCommand) executeSecretsDelete(
     factory spi.Factory,
     secretsCmdValues *SecretsCmdValues,
-    commsCmdValues *CommsCmdValues,
+    commsCmdValues *CommsFlagSetValues,
 ) error {
 
     var err error

--- a/pkg/cmd/secretsDelete.go
+++ b/pkg/cmd/secretsDelete.go
@@ -64,7 +64,7 @@ func (cmd *SecretsDeleteCommand) init(factory spi.Factory, secretsCommand spi.Ga
 func (cmd *SecretsDeleteCommand) createCobraCmd(
     factory spi.Factory,
     secretsCommand spi.GalasaCommand,
-    commsCommandValues *CommsFlagSetValues,
+    commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
     var err error
@@ -77,9 +77,9 @@ func (cmd *SecretsDeleteCommand) createCobraCmd(
         Aliases: []string{COMMAND_NAME_SECRETS_DELETE},
         RunE: func(cobraCommand *cobra.Command, args []string) error {
 			executionFunc := func() error {
-            	return cmd.executeSecretsDelete(factory, secretsCommand.Values().(*SecretsCmdValues), commsCommandValues)
+            	return cmd.executeSecretsDelete(factory, secretsCommand.Values().(*SecretsCmdValues), commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
         },
     }
 
@@ -93,26 +93,26 @@ func (cmd *SecretsDeleteCommand) createCobraCmd(
 func (cmd *SecretsDeleteCommand) executeSecretsDelete(
     factory spi.Factory,
     secretsCmdValues *SecretsCmdValues,
-    commsCmdValues *CommsFlagSetValues,
+    commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
     var err error
     // Operations on the file system will all be relative to the current folder.
     fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Delete a secret from the credentials store")
 
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/secretsDelete.go
+++ b/pkg/cmd/secretsDelete.go
@@ -26,12 +26,12 @@ type SecretsDeleteCommand struct {
 func NewSecretsDeleteCommand(
     factory spi.Factory,
     secretsDeleteCommand spi.GalasaCommand,
-    rootCmd spi.GalasaCommand,
+    commsCmd spi.GalasaCommand,
 ) (spi.GalasaCommand, error) {
 
     cmd := new(SecretsDeleteCommand)
 
-    err := cmd.init(factory, secretsDeleteCommand, rootCmd)
+    err := cmd.init(factory, secretsDeleteCommand, commsCmd)
     return cmd, err
 }
 
@@ -53,10 +53,10 @@ func (cmd *SecretsDeleteCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *SecretsDeleteCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) error {
+func (cmd *SecretsDeleteCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
     var err error
 
-    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, rootCmd.Values().(*RootCmdValues))
+    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, commsCmd.Values().(*CommsCmdValues))
 
     return err
 }
@@ -64,7 +64,7 @@ func (cmd *SecretsDeleteCommand) init(factory spi.Factory, secretsCommand spi.Ga
 func (cmd *SecretsDeleteCommand) createCobraCmd(
     factory spi.Factory,
     secretsCommand spi.GalasaCommand,
-    rootCommandValues *RootCmdValues,
+    commsCommandValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 
     var err error
@@ -76,7 +76,7 @@ func (cmd *SecretsDeleteCommand) createCobraCmd(
         Long:    "Deletes a secret from the credentials store",
         Aliases: []string{COMMAND_NAME_SECRETS_DELETE},
         RunE: func(cobraCommand *cobra.Command, args []string) error {
-            return cmd.executeSecretsDelete(factory, secretsCommand.Values().(*SecretsCmdValues), rootCommandValues)
+            return cmd.executeSecretsDelete(factory, secretsCommand.Values().(*SecretsCmdValues), commsCommandValues)
         },
     }
 
@@ -90,29 +90,29 @@ func (cmd *SecretsDeleteCommand) createCobraCmd(
 func (cmd *SecretsDeleteCommand) executeSecretsDelete(
     factory spi.Factory,
     secretsCmdValues *SecretsCmdValues,
-    rootCmdValues *RootCmdValues,
+    commsCmdValues *CommsCmdValues,
 ) error {
 
     var err error
     // Operations on the file system will all be relative to the current folder.
     fileSystem := factory.GetFileSystem()
 
-    err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+    err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 
     if err == nil {
-        rootCmdValues.isCapturingLogs = true
+        commsCmdValues.isCapturingLogs = true
 
         log.Println("Galasa CLI - Delete a secret from the credentials store")
 
         env := factory.GetEnvironment()
 
         var galasaHome spi.GalasaHome
-        galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+        galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
         if err == nil {
 
             var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
             var bootstrapData *api.BootstrapData
-            bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, secretsCmdValues.bootstrap, urlService)
+            bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
             if err == nil {
 
 				var console = factory.GetStdOutConsole()

--- a/pkg/cmd/secretsGet.go
+++ b/pkg/cmd/secretsGet.go
@@ -82,7 +82,10 @@ func (cmd *SecretsGetCommand) createCobraCmd(
         Long:    "Get a list of secrets or a specific secret from the credentials store",
         Aliases: []string{COMMAND_NAME_SECRETS_GET},
         RunE: func(cobraCommand *cobra.Command, args []string) error {
-            return cmd.executeSecretsGet(factory, secretsCommand.Values().(*SecretsCmdValues), commsCommandValues)
+			executionFunc := func() error {
+            	return cmd.executeSecretsGet(factory, secretsCommand.Values().(*SecretsCmdValues), commsCommandValues)
+			}
+			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
         },
     }
 
@@ -106,45 +109,41 @@ func (cmd *SecretsGetCommand) executeSecretsGet(
     // Operations on the file system will all be relative to the current folder.
     fileSystem := factory.GetFileSystem()
 
-    err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	commsCmdValues.isCapturingLogs = true
 
-    if err == nil {
-        commsCmdValues.isCapturingLogs = true
+	log.Println("Galasa CLI - Get secrets from the ecosystem")
 
-        log.Println("Galasa CLI - Get secrets from the ecosystem")
+	env := factory.GetEnvironment()
 
-        env := factory.GetEnvironment()
+	var galasaHome spi.GalasaHome
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	if err == nil {
 
-        var galasaHome spi.GalasaHome
-        galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
-        if err == nil {
+		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
+		var bootstrapData *api.BootstrapData
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		if err == nil {
 
-            var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
-            var bootstrapData *api.BootstrapData
-            bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
-            if err == nil {
+			var console = factory.GetStdOutConsole()
 
-                var console = factory.GetStdOutConsole()
+			apiServerUrl := bootstrapData.ApiServerURL
+			log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-                apiServerUrl := bootstrapData.ApiServerURL
-                log.Printf("The API server is at '%s'\n", apiServerUrl)
+			authenticator := factory.GetAuthenticator(
+				apiServerUrl,
+				galasaHome,
+			)
 
-                authenticator := factory.GetAuthenticator(
-                    apiServerUrl,
-                    galasaHome,
-                )
+			var apiClient *galasaapi.APIClient
+			apiClient, err = authenticator.GetAuthenticatedAPIClient()
 
-                var apiClient *galasaapi.APIClient
-                apiClient, err = authenticator.GetAuthenticatedAPIClient()
+			byteReader := factory.GetByteReader()
 
-				byteReader := factory.GetByteReader()
-
-                if err == nil {
-                    err = secrets.GetSecrets(secretsCmdValues.name, cmd.values.outputFormat, console, apiClient, byteReader)
-                }
-            }
-        }
-    }
+			if err == nil {
+				err = secrets.GetSecrets(secretsCmdValues.name, cmd.values.outputFormat, console, apiClient, byteReader)
+			}
+		}
+	}
 
     return err
 }

--- a/pkg/cmd/secretsGet.go
+++ b/pkg/cmd/secretsGet.go
@@ -31,12 +31,12 @@ type SecretsGetCommand struct {
 func NewSecretsGetCommand(
     factory spi.Factory,
     secretsGetCommand spi.GalasaCommand,
-    rootCmd spi.GalasaCommand,
+    commsCmd spi.GalasaCommand,
 ) (spi.GalasaCommand, error) {
 
     cmd := new(SecretsGetCommand)
 
-    err := cmd.init(factory, secretsGetCommand, rootCmd)
+    err := cmd.init(factory, secretsGetCommand, commsCmd)
     return cmd, err
 }
 
@@ -58,11 +58,11 @@ func (cmd *SecretsGetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *SecretsGetCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) error {
+func (cmd *SecretsGetCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
     var err error
 
 	cmd.values = &SecretsGetCmdValues{}
-    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, rootCmd.Values().(*RootCmdValues))
+    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, commsCmd.Values().(*CommsCmdValues))
 
     return err
 }
@@ -70,7 +70,7 @@ func (cmd *SecretsGetCommand) init(factory spi.Factory, secretsCommand spi.Galas
 func (cmd *SecretsGetCommand) createCobraCmd(
     factory spi.Factory,
     secretsCommand spi.GalasaCommand,
-    rootCommandValues *RootCmdValues,
+    commsCommandValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 
     var err error
@@ -82,7 +82,7 @@ func (cmd *SecretsGetCommand) createCobraCmd(
         Long:    "Get a list of secrets or a specific secret from the credentials store",
         Aliases: []string{COMMAND_NAME_SECRETS_GET},
         RunE: func(cobraCommand *cobra.Command, args []string) error {
-            return cmd.executeSecretsGet(factory, secretsCommand.Values().(*SecretsCmdValues), rootCommandValues)
+            return cmd.executeSecretsGet(factory, secretsCommand.Values().(*SecretsCmdValues), commsCommandValues)
         },
     }
 
@@ -99,29 +99,29 @@ func (cmd *SecretsGetCommand) createCobraCmd(
 func (cmd *SecretsGetCommand) executeSecretsGet(
     factory spi.Factory,
     secretsCmdValues *SecretsCmdValues,
-    rootCmdValues *RootCmdValues,
+    commsCmdValues *CommsCmdValues,
 ) error {
 
     var err error
     // Operations on the file system will all be relative to the current folder.
     fileSystem := factory.GetFileSystem()
 
-    err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+    err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 
     if err == nil {
-        rootCmdValues.isCapturingLogs = true
+        commsCmdValues.isCapturingLogs = true
 
         log.Println("Galasa CLI - Get secrets from the ecosystem")
 
         env := factory.GetEnvironment()
 
         var galasaHome spi.GalasaHome
-        galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+        galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
         if err == nil {
 
             var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
             var bootstrapData *api.BootstrapData
-            bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, secretsCmdValues.bootstrap, urlService)
+            bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
             if err == nil {
 
                 var console = factory.GetStdOutConsole()

--- a/pkg/cmd/secretsGet.go
+++ b/pkg/cmd/secretsGet.go
@@ -31,12 +31,12 @@ type SecretsGetCommand struct {
 func NewSecretsGetCommand(
     factory spi.Factory,
     secretsGetCommand spi.GalasaCommand,
-    commsCmd spi.GalasaCommand,
+    commsFlagSet GalasaFlagSet,
 ) (spi.GalasaCommand, error) {
 
     cmd := new(SecretsGetCommand)
 
-    err := cmd.init(factory, secretsGetCommand, commsCmd)
+    err := cmd.init(factory, secretsGetCommand, commsFlagSet)
     return cmd, err
 }
 
@@ -58,11 +58,11 @@ func (cmd *SecretsGetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *SecretsGetCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *SecretsGetCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
     var err error
 
 	cmd.values = &SecretsGetCmdValues{}
-    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, commsCmd.Values().(*CommsCmdValues))
+    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 
     return err
 }
@@ -70,7 +70,7 @@ func (cmd *SecretsGetCommand) init(factory spi.Factory, secretsCommand spi.Galas
 func (cmd *SecretsGetCommand) createCobraCmd(
     factory spi.Factory,
     secretsCommand spi.GalasaCommand,
-    commsCommandValues *CommsCmdValues,
+    commsCommandValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
     var err error
@@ -102,7 +102,7 @@ func (cmd *SecretsGetCommand) createCobraCmd(
 func (cmd *SecretsGetCommand) executeSecretsGet(
     factory spi.Factory,
     secretsCmdValues *SecretsCmdValues,
-    commsCmdValues *CommsCmdValues,
+    commsCmdValues *CommsFlagSetValues,
 ) error {
 
     var err error

--- a/pkg/cmd/secretsGet.go
+++ b/pkg/cmd/secretsGet.go
@@ -70,7 +70,7 @@ func (cmd *SecretsGetCommand) init(factory spi.Factory, secretsCommand spi.Galas
 func (cmd *SecretsGetCommand) createCobraCmd(
     factory spi.Factory,
     secretsCommand spi.GalasaCommand,
-    commsCommandValues *CommsFlagSetValues,
+    commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
     var err error
@@ -83,9 +83,9 @@ func (cmd *SecretsGetCommand) createCobraCmd(
         Aliases: []string{COMMAND_NAME_SECRETS_GET},
         RunE: func(cobraCommand *cobra.Command, args []string) error {
 			executionFunc := func() error {
-            	return cmd.executeSecretsGet(factory, secretsCommand.Values().(*SecretsCmdValues), commsCommandValues)
+            	return cmd.executeSecretsGet(factory, secretsCommand.Values().(*SecretsCmdValues), commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
         },
     }
 
@@ -102,26 +102,26 @@ func (cmd *SecretsGetCommand) createCobraCmd(
 func (cmd *SecretsGetCommand) executeSecretsGet(
     factory spi.Factory,
     secretsCmdValues *SecretsCmdValues,
-    commsCmdValues *CommsFlagSetValues,
+    commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
     var err error
     // Operations on the file system will all be relative to the current folder.
     fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Get secrets from the ecosystem")
 
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/secretsSet.go
+++ b/pkg/cmd/secretsSet.go
@@ -78,7 +78,7 @@ func (cmd *SecretsSetCommand) init(factory spi.Factory, secretsCommand spi.Galas
 func (cmd *SecretsSetCommand) createCobraCmd(
     factory spi.Factory,
     secretsCommand spi.GalasaCommand,
-    commsCommandValues *CommsFlagSetValues,
+    commsFlagSetValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
     var err error
@@ -91,9 +91,9 @@ func (cmd *SecretsSetCommand) createCobraCmd(
         Aliases: []string{COMMAND_NAME_SECRETS_SET},
         RunE: func(cobraCommand *cobra.Command, args []string) error {
 			executionFunc := func() error {
-            	return cmd.executeSecretsSet(factory, secretsCommand.Values().(*SecretsCmdValues), commsCommandValues)
+            	return cmd.executeSecretsSet(factory, secretsCommand.Values().(*SecretsCmdValues), commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
         },
     }
 
@@ -144,26 +144,26 @@ func (cmd *SecretsSetCommand) createCobraCmd(
 func (cmd *SecretsSetCommand) executeSecretsSet(
     factory spi.Factory,
     secretsCmdValues *SecretsCmdValues,
-    commsCmdValues *CommsFlagSetValues,
+    commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
     var err error
     // Operations on the file system will all be relative to the current folder.
     fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Set secrets from the ecosystem")
 
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/secretsSet.go
+++ b/pkg/cmd/secretsSet.go
@@ -6,15 +6,15 @@
 package cmd
 
 import (
-    "fmt"
-    "log"
+	"fmt"
+	"log"
 
-    "github.com/galasa-dev/cli/pkg/api"
-    "github.com/galasa-dev/cli/pkg/galasaapi"
-    "github.com/galasa-dev/cli/pkg/secrets"
-    "github.com/galasa-dev/cli/pkg/spi"
-    "github.com/galasa-dev/cli/pkg/utils"
-    "github.com/spf13/cobra"
+	"github.com/galasa-dev/cli/pkg/api"
+	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/galasa-dev/cli/pkg/secrets"
+	"github.com/galasa-dev/cli/pkg/spi"
+	"github.com/galasa-dev/cli/pkg/utils"
+	"github.com/spf13/cobra"
 )
 
 type SecretsSetCmdValues struct {
@@ -39,12 +39,12 @@ type SecretsSetCommand struct {
 func NewSecretsSetCommand(
     factory spi.Factory,
     secretsSetCommand spi.GalasaCommand,
-    commsCmd spi.GalasaCommand,
+    commsFlagSet GalasaFlagSet,
 ) (spi.GalasaCommand, error) {
 
     cmd := new(SecretsSetCommand)
 
-    err := cmd.init(factory, secretsSetCommand, commsCmd)
+    err := cmd.init(factory, secretsSetCommand, commsFlagSet)
     return cmd, err
 }
 
@@ -66,11 +66,11 @@ func (cmd *SecretsSetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *SecretsSetCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *SecretsSetCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
     var err error
 
     cmd.values = &SecretsSetCmdValues{}
-    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, commsCmd.Values().(*CommsCmdValues))
+    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, commsFlagSet.Values().(*CommsFlagSetValues))
 
     return err
 }
@@ -78,7 +78,7 @@ func (cmd *SecretsSetCommand) init(factory spi.Factory, secretsCommand spi.Galas
 func (cmd *SecretsSetCommand) createCobraCmd(
     factory spi.Factory,
     secretsCommand spi.GalasaCommand,
-    commsCommandValues *CommsCmdValues,
+    commsCommandValues *CommsFlagSetValues,
 ) (*cobra.Command, error) {
 
     var err error
@@ -144,7 +144,7 @@ func (cmd *SecretsSetCommand) createCobraCmd(
 func (cmd *SecretsSetCommand) executeSecretsSet(
     factory spi.Factory,
     secretsCmdValues *SecretsCmdValues,
-    commsCmdValues *CommsCmdValues,
+    commsCmdValues *CommsFlagSetValues,
 ) error {
 
     var err error

--- a/pkg/cmd/secretsSet.go
+++ b/pkg/cmd/secretsSet.go
@@ -39,12 +39,12 @@ type SecretsSetCommand struct {
 func NewSecretsSetCommand(
     factory spi.Factory,
     secretsSetCommand spi.GalasaCommand,
-    rootCmd spi.GalasaCommand,
+    commsCmd spi.GalasaCommand,
 ) (spi.GalasaCommand, error) {
 
     cmd := new(SecretsSetCommand)
 
-    err := cmd.init(factory, secretsSetCommand, rootCmd)
+    err := cmd.init(factory, secretsSetCommand, commsCmd)
     return cmd, err
 }
 
@@ -66,11 +66,11 @@ func (cmd *SecretsSetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *SecretsSetCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) error {
+func (cmd *SecretsSetCommand) init(factory spi.Factory, secretsCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
     var err error
 
     cmd.values = &SecretsSetCmdValues{}
-    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, rootCmd.Values().(*RootCmdValues))
+    cmd.cobraCommand, err = cmd.createCobraCmd(factory, secretsCommand, commsCmd.Values().(*CommsCmdValues))
 
     return err
 }
@@ -78,7 +78,7 @@ func (cmd *SecretsSetCommand) init(factory spi.Factory, secretsCommand spi.Galas
 func (cmd *SecretsSetCommand) createCobraCmd(
     factory spi.Factory,
     secretsCommand spi.GalasaCommand,
-    rootCommandValues *RootCmdValues,
+    commsCommandValues *CommsCmdValues,
 ) (*cobra.Command, error) {
 
     var err error
@@ -90,7 +90,7 @@ func (cmd *SecretsSetCommand) createCobraCmd(
         Long:    "Creates or updates a secret in the credentials store",
         Aliases: []string{COMMAND_NAME_SECRETS_SET},
         RunE: func(cobraCommand *cobra.Command, args []string) error {
-            return cmd.executeSecretsSet(factory, secretsCommand.Values().(*SecretsCmdValues), rootCommandValues)
+            return cmd.executeSecretsSet(factory, secretsCommand.Values().(*SecretsCmdValues), commsCommandValues)
         },
     }
 
@@ -141,29 +141,29 @@ func (cmd *SecretsSetCommand) createCobraCmd(
 func (cmd *SecretsSetCommand) executeSecretsSet(
     factory spi.Factory,
     secretsCmdValues *SecretsCmdValues,
-    rootCmdValues *RootCmdValues,
+    commsCmdValues *CommsCmdValues,
 ) error {
 
     var err error
     // Operations on the file system will all be relative to the current folder.
     fileSystem := factory.GetFileSystem()
 
-    err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+    err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 
     if err == nil {
-        rootCmdValues.isCapturingLogs = true
+        commsCmdValues.isCapturingLogs = true
 
         log.Println("Galasa CLI - Set secrets from the ecosystem")
 
         env := factory.GetEnvironment()
 
         var galasaHome spi.GalasaHome
-        galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+        galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
         if err == nil {
 
             var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
             var bootstrapData *api.BootstrapData
-            bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, secretsCmdValues.bootstrap, urlService)
+            bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
             if err == nil {
 
                 var console = factory.GetStdOutConsole()

--- a/pkg/cmd/secretsSet.go
+++ b/pkg/cmd/secretsSet.go
@@ -90,7 +90,10 @@ func (cmd *SecretsSetCommand) createCobraCmd(
         Long:    "Creates or updates a secret in the credentials store",
         Aliases: []string{COMMAND_NAME_SECRETS_SET},
         RunE: func(cobraCommand *cobra.Command, args []string) error {
-            return cmd.executeSecretsSet(factory, secretsCommand.Values().(*SecretsCmdValues), commsCommandValues)
+			executionFunc := func() error {
+            	return cmd.executeSecretsSet(factory, secretsCommand.Values().(*SecretsCmdValues), commsCommandValues)
+			}
+			return executeCommandWithRetries(factory, commsCommandValues, executionFunc)
         },
     }
 
@@ -148,58 +151,54 @@ func (cmd *SecretsSetCommand) executeSecretsSet(
     // Operations on the file system will all be relative to the current folder.
     fileSystem := factory.GetFileSystem()
 
-    err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	commsCmdValues.isCapturingLogs = true
 
-    if err == nil {
-        commsCmdValues.isCapturingLogs = true
+	log.Println("Galasa CLI - Set secrets from the ecosystem")
 
-        log.Println("Galasa CLI - Set secrets from the ecosystem")
+	env := factory.GetEnvironment()
 
-        env := factory.GetEnvironment()
+	var galasaHome spi.GalasaHome
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	if err == nil {
 
-        var galasaHome spi.GalasaHome
-        galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
-        if err == nil {
+		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
+		var bootstrapData *api.BootstrapData
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		if err == nil {
 
-            var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
-            var bootstrapData *api.BootstrapData
-            bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
-            if err == nil {
+			var console = factory.GetStdOutConsole()
 
-                var console = factory.GetStdOutConsole()
+			apiServerUrl := bootstrapData.ApiServerURL
+			log.Printf("The API server is at '%s'\n", apiServerUrl)
 
-                apiServerUrl := bootstrapData.ApiServerURL
-                log.Printf("The API server is at '%s'\n", apiServerUrl)
+			authenticator := factory.GetAuthenticator(
+				apiServerUrl,
+				galasaHome,
+			)
 
-                authenticator := factory.GetAuthenticator(
-                    apiServerUrl,
-                    galasaHome,
-                )
+			var apiClient *galasaapi.APIClient
+			apiClient, err = authenticator.GetAuthenticatedAPIClient()
 
-                var apiClient *galasaapi.APIClient
-                apiClient, err = authenticator.GetAuthenticatedAPIClient()
+			byteReader := factory.GetByteReader()
 
-                byteReader := factory.GetByteReader()
-
-                if err == nil {
-                    err = secrets.SetSecret(
-                        secretsCmdValues.name,
-                        cmd.values.username,
-                        cmd.values.password,
-                        cmd.values.token,
-                        cmd.values.base64Username,
-                        cmd.values.base64Password,
-                        cmd.values.base64Token,
-                        cmd.values.secretType,
-						cmd.values.description,
-                        console,
-                        apiClient,
-                        byteReader,
-                    )
-                }
-            }
-        }
-    }
+			if err == nil {
+				err = secrets.SetSecret(
+					secretsCmdValues.name,
+					cmd.values.username,
+					cmd.values.password,
+					cmd.values.token,
+					cmd.values.base64Username,
+					cmd.values.base64Password,
+					cmd.values.base64Token,
+					cmd.values.secretType,
+					cmd.values.description,
+					console,
+					apiClient,
+					byteReader,
+				)
+			}
+		}
+	}
 
     return err
 }

--- a/pkg/cmd/users.go
+++ b/pkg/cmd/users.go
@@ -23,10 +23,10 @@ type UsersCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewUsersCommand(rootCmd spi.GalasaCommand, commsCmd spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewUsersCommand(rootCmd spi.GalasaCommand, commsFlagSet GalasaFlagSet) (spi.GalasaCommand, error) {
 
 	cmd := new(UsersCommand)
-	err := cmd.init(rootCmd, commsCmd)
+	err := cmd.init(rootCmd, commsFlagSet)
 	return cmd, err
 }
 
@@ -49,19 +49,19 @@ func (cmd *UsersCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *UsersCommand) init(rootCmd spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *UsersCommand) init(rootCmd spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 
 	var err error
 
 	cmd.values = &UsersCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(rootCmd, commsCmd)
+	cmd.cobraCommand = cmd.createCobraCommand(rootCmd, commsFlagSet)
 
 	return err
 }
 
 func (cmd *UsersCommand) createCobraCommand(
 	rootCommand spi.GalasaCommand,
-	commsCommand spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) *cobra.Command {
 
 	usersCobraCmd := &cobra.Command{
@@ -70,7 +70,7 @@ func (cmd *UsersCommand) createCobraCommand(
 		Long:  "Allows interaction with the user servlet to return information about users.",
 	}
 
-	usersCobraCmd.PersistentFlags().AddFlagSet(commsCommand.CobraCommand().PersistentFlags())
+	usersCobraCmd.PersistentFlags().AddFlagSet(commsFlagSet.Flags())
 	rootCommand.CobraCommand().AddCommand(usersCobraCmd)
 
 	return usersCobraCmd

--- a/pkg/cmd/users.go
+++ b/pkg/cmd/users.go
@@ -24,10 +24,10 @@ type UsersCommand struct {
 // ------------------------------------------------------------------------------------------------
 // Constructors methods
 // ------------------------------------------------------------------------------------------------
-func NewUsersCommand(rootCmd spi.GalasaCommand) (spi.GalasaCommand, error) {
+func NewUsersCommand(rootCmd spi.GalasaCommand, commsCmd spi.GalasaCommand) (spi.GalasaCommand, error) {
 
 	cmd := new(UsersCommand)
-	err := cmd.init(rootCmd)
+	err := cmd.init(rootCmd, commsCmd)
 	return cmd, err
 }
 
@@ -50,18 +50,19 @@ func (cmd *UsersCommand) Values() interface{} {
 // Private methods
 // ------------------------------------------------------------------------------------------------
 
-func (cmd *UsersCommand) init(rootCmd spi.GalasaCommand) error {
+func (cmd *UsersCommand) init(rootCmd spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
 
 	var err error
 
 	cmd.values = &UsersCmdValues{}
-	cmd.cobraCommand = cmd.createCobraCommand(rootCmd)
+	cmd.cobraCommand = cmd.createCobraCommand(rootCmd, commsCmd)
 
 	return err
 }
 
 func (cmd *UsersCommand) createCobraCommand(
 	rootCommand spi.GalasaCommand,
+	commsCommand spi.GalasaCommand,
 ) *cobra.Command {
 
 	usersCobraCmd := &cobra.Command{
@@ -73,6 +74,7 @@ func (cmd *UsersCommand) createCobraCommand(
 	addBootstrapFlag(usersCobraCmd, &cmd.values.ecosystemBootstrap)
 
 	rootCommand.CobraCommand().AddCommand(usersCobraCmd)
+	commsCommand.CobraCommand().AddCommand(usersCobraCmd)
 
 	return usersCobraCmd
 }

--- a/pkg/cmd/users.go
+++ b/pkg/cmd/users.go
@@ -12,7 +12,6 @@ import (
 )
 
 type UsersCmdValues struct {
-	ecosystemBootstrap string
 	name               string
 }
 
@@ -70,8 +69,6 @@ func (cmd *UsersCommand) createCobraCommand(
 		Short: "Manages users in an ecosystem",
 		Long:  "Allows interaction with the user servlet to return information about users.",
 	}
-
-	addBootstrapFlag(usersCobraCmd, &cmd.values.ecosystemBootstrap)
 
 	rootCommand.CobraCommand().AddCommand(usersCobraCmd)
 	commsCommand.CobraCommand().AddCommand(usersCobraCmd)

--- a/pkg/cmd/users.go
+++ b/pkg/cmd/users.go
@@ -70,8 +70,8 @@ func (cmd *UsersCommand) createCobraCommand(
 		Long:  "Allows interaction with the user servlet to return information about users.",
 	}
 
+	usersCobraCmd.PersistentFlags().AddFlagSet(commsCommand.CobraCommand().PersistentFlags())
 	rootCommand.CobraCommand().AddCommand(usersCobraCmd)
-	commsCommand.CobraCommand().AddCommand(usersCobraCmd)
 
 	return usersCobraCmd
 }

--- a/pkg/cmd/usersDelete.go
+++ b/pkg/cmd/usersDelete.go
@@ -73,7 +73,7 @@ func (cmd *UsersDeleteCommand) createCobraCmd(
 
 	var err error
 
-	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
+	commsFlagSetValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	userCommandValues := usersCommand.Values().(*UsersCmdValues)
 	usersDeleteCobraCmd := &cobra.Command{
@@ -83,9 +83,9 @@ func (cmd *UsersDeleteCommand) createCobraCmd(
 		Aliases: []string{COMMAND_NAME_USERS_DELETE},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeUsersDelete(factory, usersCommand.Values().(*UsersCmdValues), commsCmdValues)
+				return cmd.executeUsersDelete(factory, usersCommand.Values().(*UsersCmdValues), commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -99,7 +99,7 @@ func (cmd *UsersDeleteCommand) createCobraCmd(
 func (cmd *UsersDeleteCommand) executeUsersDelete(
 	factory spi.Factory,
 	userCmdValues *UsersCmdValues,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
@@ -107,7 +107,7 @@ func (cmd *UsersDeleteCommand) executeUsersDelete(
 	fileSystem := factory.GetFileSystem()
 	byteReader := factory.GetByteReader()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Delete user from the ecosystem")
 
@@ -115,13 +115,13 @@ func (cmd *UsersDeleteCommand) executeUsersDelete(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap users.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			apiServerUrl := bootstrapData.ApiServerURL

--- a/pkg/cmd/usersDelete.go
+++ b/pkg/cmd/usersDelete.go
@@ -29,12 +29,12 @@ type UsersDeleteCommand struct {
 func NewUsersDeleteCommand(
 	factory spi.Factory,
 	usersDeleteCommand spi.GalasaCommand,
-	commsCmd spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (spi.GalasaCommand, error) {
 
 	cmd := new(UsersDeleteCommand)
 
-	err := cmd.init(factory, usersDeleteCommand, commsCmd)
+	err := cmd.init(factory, usersDeleteCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -57,23 +57,23 @@ func (cmd *UsersDeleteCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *UsersDeleteCommand) init(factory spi.Factory, usersCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *UsersDeleteCommand) init(factory spi.Factory, usersCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 
-	cmd.cobraCommand, err = cmd.createCobraCmd(factory, usersCommand, commsCmd)
+	cmd.cobraCommand, err = cmd.createCobraCmd(factory, usersCommand, commsFlagSet)
 
 	return err
 }
 
 func (cmd *UsersDeleteCommand) createCobraCmd(
 	factory spi.Factory,
-	usersCommand,
-	commsCmd spi.GalasaCommand,
+	usersCommand spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (*cobra.Command, error) {
 
 	var err error
 
-	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
+	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	userCommandValues := usersCommand.Values().(*UsersCmdValues)
 	usersDeleteCobraCmd := &cobra.Command{
@@ -99,7 +99,7 @@ func (cmd *UsersDeleteCommand) createCobraCmd(
 func (cmd *UsersDeleteCommand) executeUsersDelete(
 	factory spi.Factory,
 	userCmdValues *UsersCmdValues,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/usersDelete.go
+++ b/pkg/cmd/usersDelete.go
@@ -73,6 +73,8 @@ func (cmd *UsersDeleteCommand) createCobraCmd(
 
 	var err error
 
+	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
+
 	userCommandValues := usersCommand.Values().(*UsersCmdValues)
 	usersDeleteCobraCmd := &cobra.Command{
 		Use:     "delete",
@@ -80,7 +82,10 @@ func (cmd *UsersDeleteCommand) createCobraCmd(
 		Long:    "Deletes a single user by their login ID from the ecosystem",
 		Aliases: []string{COMMAND_NAME_USERS_DELETE},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
-			return cmd.executeUsersDelete(factory, usersCommand.Values().(*UsersCmdValues), commsCmd.Values().(*CommsCmdValues))
+			executionFunc := func() error {
+				return cmd.executeUsersDelete(factory, usersCommand.Values().(*UsersCmdValues), commsCmdValues)
+			}
+			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
 		},
 	}
 
@@ -102,41 +107,37 @@ func (cmd *UsersDeleteCommand) executeUsersDelete(
 	fileSystem := factory.GetFileSystem()
 	byteReader := factory.GetByteReader()
 
-	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
+	commsCmdValues.isCapturingLogs = true
 
+	log.Println("Galasa CLI - Delete user from the ecosystem")
+
+	// Get the ability to query environment variables.
+	env := factory.GetEnvironment()
+
+	var galasaHome spi.GalasaHome
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 	if err == nil {
-		commsCmdValues.isCapturingLogs = true
 
-		log.Println("Galasa CLI - Delete user from the ecosystem")
-
-		// Get the ability to query environment variables.
-		env := factory.GetEnvironment()
-
-		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+		// Read the bootstrap users.
+		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
+		var bootstrapData *api.BootstrapData
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 		if err == nil {
 
-			// Read the bootstrap users.
-			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
-			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+			apiServerUrl := bootstrapData.ApiServerURL
+			log.Printf("The API server is at '%s'\n", apiServerUrl)
+
+			authenticator := factory.GetAuthenticator(
+				apiServerUrl,
+				galasaHome,
+			)
+
+			var apiClient *galasaapi.APIClient
+			apiClient, err = authenticator.GetAuthenticatedAPIClient()
+
 			if err == nil {
-
-				apiServerUrl := bootstrapData.ApiServerURL
-				log.Printf("The API server is at '%s'\n", apiServerUrl)
-
-				authenticator := factory.GetAuthenticator(
-					apiServerUrl,
-					galasaHome,
-				)
-
-				var apiClient *galasaapi.APIClient
-				apiClient, err = authenticator.GetAuthenticatedAPIClient()
-
-				if err == nil {
-					// Call to process the command in a unit-testable way.
-					err = users.DeleteUser(userCmdValues.name, apiClient, byteReader)
-				}
+				// Call to process the command in a unit-testable way.
+				err = users.DeleteUser(userCmdValues.name, apiClient, byteReader)
 			}
 		}
 	}

--- a/pkg/cmd/usersDelete.go
+++ b/pkg/cmd/usersDelete.go
@@ -29,12 +29,12 @@ type UsersDeleteCommand struct {
 func NewUsersDeleteCommand(
 	factory spi.Factory,
 	usersDeleteCommand spi.GalasaCommand,
-	rootCmd spi.GalasaCommand,
+	commsCmd spi.GalasaCommand,
 ) (spi.GalasaCommand, error) {
 
 	cmd := new(UsersDeleteCommand)
 
-	err := cmd.init(factory, usersDeleteCommand, rootCmd)
+	err := cmd.init(factory, usersDeleteCommand, commsCmd)
 	return cmd, err
 }
 
@@ -57,10 +57,10 @@ func (cmd *UsersDeleteCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *UsersDeleteCommand) init(factory spi.Factory, usersCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) error {
+func (cmd *UsersDeleteCommand) init(factory spi.Factory, usersCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
 	var err error
 
-	cmd.cobraCommand, err = cmd.createCobraCmd(factory, usersCommand, rootCmd)
+	cmd.cobraCommand, err = cmd.createCobraCmd(factory, usersCommand, commsCmd)
 
 	return err
 }
@@ -68,7 +68,7 @@ func (cmd *UsersDeleteCommand) init(factory spi.Factory, usersCommand spi.Galasa
 func (cmd *UsersDeleteCommand) createCobraCmd(
 	factory spi.Factory,
 	usersCommand,
-	rootCmd spi.GalasaCommand,
+	commsCmd spi.GalasaCommand,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -80,7 +80,7 @@ func (cmd *UsersDeleteCommand) createCobraCmd(
 		Long:    "Deletes a single user by their login ID from the ecosystem",
 		Aliases: []string{COMMAND_NAME_USERS_DELETE},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
-			return cmd.executeUsersDelete(factory, usersCommand.Values().(*UsersCmdValues), rootCmd.Values().(*RootCmdValues))
+			return cmd.executeUsersDelete(factory, usersCommand.Values().(*UsersCmdValues), commsCmd.Values().(*CommsCmdValues))
 		},
 	}
 
@@ -94,7 +94,7 @@ func (cmd *UsersDeleteCommand) createCobraCmd(
 func (cmd *UsersDeleteCommand) executeUsersDelete(
 	factory spi.Factory,
 	userCmdValues *UsersCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 
 	var err error
@@ -102,10 +102,10 @@ func (cmd *UsersDeleteCommand) executeUsersDelete(
 	fileSystem := factory.GetFileSystem()
 	byteReader := factory.GetByteReader()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 
 	if err == nil {
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Delete user from the ecosystem")
 
@@ -113,13 +113,13 @@ func (cmd *UsersDeleteCommand) executeUsersDelete(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap users.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, userCmdValues.ecosystemBootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				apiServerUrl := bootstrapData.ApiServerURL

--- a/pkg/cmd/usersGet.go
+++ b/pkg/cmd/usersGet.go
@@ -73,7 +73,7 @@ func (cmd *UsersGetCommand) createCobraCmd(
 
 	var err error
 
-	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
+	commsFlagSetValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	userCommandValues := usersCommand.Values().(*UsersCmdValues)
 	usersGetCobraCmd := &cobra.Command{
@@ -83,9 +83,9 @@ func (cmd *UsersGetCommand) createCobraCmd(
 		Aliases: []string{COMMAND_NAME_USERS_GET},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
 			executionFunc := func() error {
-				return cmd.executeUsersGet(factory, usersCommand.Values().(*UsersCmdValues), commsCmdValues)
+				return cmd.executeUsersGet(factory, usersCommand.Values().(*UsersCmdValues), commsFlagSetValues)
 			}
-			return executeCommandWithRetries(factory, commsCmdValues, executionFunc)
+			return executeCommandWithRetries(factory, commsFlagSetValues, executionFunc)
 		},
 	}
 
@@ -99,14 +99,14 @@ func (cmd *UsersGetCommand) createCobraCmd(
 func (cmd *UsersGetCommand) executeUsersGet(
 	factory spi.Factory,
 	userCmdValues *UsersCmdValues,
-	commsCmdValues *CommsFlagSetValues,
+	commsFlagSetValues *CommsFlagSetValues,
 ) error {
 
 	var err error
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	commsCmdValues.isCapturingLogs = true
+	commsFlagSetValues.isCapturingLogs = true
 
 	log.Println("Galasa CLI - Get users from the ecosystem")
 
@@ -114,13 +114,13 @@ func (cmd *UsersGetCommand) executeUsersGet(
 	env := factory.GetEnvironment()
 
 	var galasaHome spi.GalasaHome
-	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
+	galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsFlagSetValues.CmdParamGalasaHomePath)
 	if err == nil {
 
 		// Read the bootstrap users.
 		var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 		var bootstrapData *api.BootstrapData
-		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
+		bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsFlagSetValues.bootstrap, urlService)
 		if err == nil {
 
 			var console = factory.GetStdOutConsole()

--- a/pkg/cmd/usersGet.go
+++ b/pkg/cmd/usersGet.go
@@ -29,12 +29,12 @@ type UsersGetCommand struct {
 func NewUsersGetCommand(
 	factory spi.Factory,
 	usersGetCommand spi.GalasaCommand,
-	commsCmd spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (spi.GalasaCommand, error) {
 
 	cmd := new(UsersGetCommand)
 
-	err := cmd.init(factory, usersGetCommand, commsCmd)
+	err := cmd.init(factory, usersGetCommand, commsFlagSet)
 	return cmd, err
 }
 
@@ -57,23 +57,23 @@ func (cmd *UsersGetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *UsersGetCommand) init(factory spi.Factory, usersCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
+func (cmd *UsersGetCommand) init(factory spi.Factory, usersCommand spi.GalasaCommand, commsFlagSet GalasaFlagSet) error {
 	var err error
 
-	cmd.cobraCommand, err = cmd.createCobraCmd(factory, usersCommand, commsCmd)
+	cmd.cobraCommand, err = cmd.createCobraCmd(factory, usersCommand, commsFlagSet)
 
 	return err
 }
 
 func (cmd *UsersGetCommand) createCobraCmd(
 	factory spi.Factory,
-	usersCommand,
-	commsCmd spi.GalasaCommand,
+	usersCommand spi.GalasaCommand,
+	commsFlagSet GalasaFlagSet,
 ) (*cobra.Command, error) {
 
 	var err error
 
-	commsCmdValues := commsCmd.Values().(*CommsCmdValues)
+	commsCmdValues := commsFlagSet.Values().(*CommsFlagSetValues)
 
 	userCommandValues := usersCommand.Values().(*UsersCmdValues)
 	usersGetCobraCmd := &cobra.Command{
@@ -99,7 +99,7 @@ func (cmd *UsersGetCommand) createCobraCmd(
 func (cmd *UsersGetCommand) executeUsersGet(
 	factory spi.Factory,
 	userCmdValues *UsersCmdValues,
-	commsCmdValues *CommsCmdValues,
+	commsCmdValues *CommsFlagSetValues,
 ) error {
 
 	var err error

--- a/pkg/cmd/usersGet.go
+++ b/pkg/cmd/usersGet.go
@@ -29,12 +29,12 @@ type UsersGetCommand struct {
 func NewUsersGetCommand(
 	factory spi.Factory,
 	usersGetCommand spi.GalasaCommand,
-	rootCmd spi.GalasaCommand,
+	commsCmd spi.GalasaCommand,
 ) (spi.GalasaCommand, error) {
 
 	cmd := new(UsersGetCommand)
 
-	err := cmd.init(factory, usersGetCommand, rootCmd)
+	err := cmd.init(factory, usersGetCommand, commsCmd)
 	return cmd, err
 }
 
@@ -57,10 +57,10 @@ func (cmd *UsersGetCommand) Values() interface{} {
 // ------------------------------------------------------------------------------------------------
 // Private methods
 // ------------------------------------------------------------------------------------------------
-func (cmd *UsersGetCommand) init(factory spi.Factory, usersCommand spi.GalasaCommand, rootCmd spi.GalasaCommand) error {
+func (cmd *UsersGetCommand) init(factory spi.Factory, usersCommand spi.GalasaCommand, commsCmd spi.GalasaCommand) error {
 	var err error
 
-	cmd.cobraCommand, err = cmd.createCobraCmd(factory, usersCommand, rootCmd)
+	cmd.cobraCommand, err = cmd.createCobraCmd(factory, usersCommand, commsCmd)
 
 	return err
 }
@@ -68,7 +68,7 @@ func (cmd *UsersGetCommand) init(factory spi.Factory, usersCommand spi.GalasaCom
 func (cmd *UsersGetCommand) createCobraCmd(
 	factory spi.Factory,
 	usersCommand,
-	rootCmd spi.GalasaCommand,
+	commsCmd spi.GalasaCommand,
 ) (*cobra.Command, error) {
 
 	var err error
@@ -80,7 +80,7 @@ func (cmd *UsersGetCommand) createCobraCmd(
 		Long:    "Get a list of users stored in the Galasa API server",
 		Aliases: []string{COMMAND_NAME_USERS_GET},
 		RunE: func(cobraCommand *cobra.Command, args []string) error {
-			return cmd.executeUsersGet(factory, usersCommand.Values().(*UsersCmdValues), rootCmd.Values().(*RootCmdValues))
+			return cmd.executeUsersGet(factory, usersCommand.Values().(*UsersCmdValues), commsCmd.Values().(*CommsCmdValues))
 		},
 	}
 
@@ -94,17 +94,17 @@ func (cmd *UsersGetCommand) createCobraCmd(
 func (cmd *UsersGetCommand) executeUsersGet(
 	factory spi.Factory,
 	userCmdValues *UsersCmdValues,
-	rootCmdValues *RootCmdValues,
+	commsCmdValues *CommsCmdValues,
 ) error {
 
 	var err error
 	// Operations on the file system will all be relative to the current folder.
 	fileSystem := factory.GetFileSystem()
 
-	err = utils.CaptureLog(fileSystem, rootCmdValues.logFileName)
+	err = utils.CaptureLog(fileSystem, commsCmdValues.logFileName)
 
 	if err == nil {
-		rootCmdValues.isCapturingLogs = true
+		commsCmdValues.isCapturingLogs = true
 
 		log.Println("Galasa CLI - Get users from the ecosystem")
 
@@ -112,13 +112,13 @@ func (cmd *UsersGetCommand) executeUsersGet(
 		env := factory.GetEnvironment()
 
 		var galasaHome spi.GalasaHome
-		galasaHome, err = utils.NewGalasaHome(fileSystem, env, rootCmdValues.CmdParamGalasaHomePath)
+		galasaHome, err = utils.NewGalasaHome(fileSystem, env, commsCmdValues.CmdParamGalasaHomePath)
 		if err == nil {
 
 			// Read the bootstrap users.
 			var urlService *api.RealUrlResolutionService = new(api.RealUrlResolutionService)
 			var bootstrapData *api.BootstrapData
-			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, userCmdValues.ecosystemBootstrap, urlService)
+			bootstrapData, err = api.LoadBootstrap(galasaHome, fileSystem, env, commsCmdValues.bootstrap, urlService)
 			if err == nil {
 
 				var console = factory.GetStdOutConsole()

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -66,6 +66,10 @@ type GalasaError struct {
 	cause error
 }
 
+type GalasaCommsError interface {
+	IsRetryRequired() bool
+}
+
 func (err *GalasaError) GetMessageType() *MessageType {
 	return err.msgType
 }

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -121,6 +121,11 @@ func (err *GalasaError) Error() string {
 	return err.message
 }
 
+func (err *GalasaError) isRetryRequired() bool {
+	isRetryRequired := true 
+	return isRetryRequired 
+}
+
 const (
 	STACK_TRACE_WANTED     = true
 	STACK_TRACE_NOT_WANTED = false

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -8,7 +8,6 @@ package errors
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"strconv"
 	"strings"
 )

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -8,6 +8,7 @@ package errors
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
 )

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -121,11 +121,6 @@ func (err *GalasaError) Error() string {
 	return err.message
 }
 
-func (err *GalasaError) isRetryRequired() bool {
-	isRetryRequired := true 
-	return isRetryRequired 
-}
-
 const (
 	STACK_TRACE_WANTED     = true
 	STACK_TRACE_NOT_WANTED = false

--- a/pkg/errors/galasaAPIError.go
+++ b/pkg/errors/galasaAPIError.go
@@ -14,6 +14,22 @@ import (
 	"github.com/galasa-dev/cli/pkg/spi"
 )
 
+type WrappedGalasaError struct {
+	HttpStatusCode int
+	GalasaError error
+}
+
+func NewWrappedGalasaError(httpStatusCode int, galasaError error) *WrappedGalasaError {
+	return &WrappedGalasaError{
+		HttpStatusCode: httpStatusCode,
+		GalasaError: galasaError,
+	}
+}
+
+func (err *WrappedGalasaError) Error() string {
+	return err.GalasaError.Error()
+}
+
 type GalasaAPIError struct {
 	Code    int    `json:"error_code"`
 	Message string `json:"error_message"`

--- a/pkg/errors/galasaAPIError.go
+++ b/pkg/errors/galasaAPIError.go
@@ -14,22 +14,6 @@ import (
 	"github.com/galasa-dev/cli/pkg/spi"
 )
 
-type WrappedGalasaError struct {
-	HttpStatusCode int
-	GalasaError error
-}
-
-func NewWrappedGalasaError(httpStatusCode int, galasaError error) *WrappedGalasaError {
-	return &WrappedGalasaError{
-		HttpStatusCode: httpStatusCode,
-		GalasaError: galasaError,
-	}
-}
-
-func (err *WrappedGalasaError) Error() string {
-	return err.GalasaError.Error()
-}
-
 type GalasaAPIError struct {
 	Code    int    `json:"error_code"`
 	Message string `json:"error_message"`

--- a/pkg/launcher/remoteLauncher.go
+++ b/pkg/launcher/remoteLauncher.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/embedded"
 	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
 	"github.com/galasa-dev/cli/pkg/galasaapi"
@@ -21,6 +22,7 @@ import (
 // RemoteLauncher A launcher, which launches and monitors tests on a remote ecosystem via HTTP/HTTPS.
 type RemoteLauncher struct {
 	apiClient *galasaapi.APIClient
+	commsRetrier api.CommsRetrier
 }
 
 //----------------------------------------------------------------------------------
@@ -28,13 +30,15 @@ type RemoteLauncher struct {
 //----------------------------------------------------------------------------------
 
 // NewRemoteLauncher create a remote launcher.
-func NewRemoteLauncher(apiServerUrl string, apiClient *galasaapi.APIClient) *RemoteLauncher {
+func NewRemoteLauncher(apiServerUrl string, apiClient *galasaapi.APIClient, commsRetrier api.CommsRetrier) *RemoteLauncher {
 	log.Printf("NewRemoteLauncher(%s) entered.", apiServerUrl)
 
 	launcher := new(RemoteLauncher)
 
 	// An HTTP client which can communicate with the api server in an ecosystem.
 	launcher.apiClient = apiClient
+
+	launcher.commsRetrier = commsRetrier
 
 	return launcher
 }
@@ -94,10 +98,12 @@ func (launcher *RemoteLauncher) SubmitTestRun(
 	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 
 	if err == nil {
-		var httpResponse *http.Response
-		resultGroup, httpResponse, err = launcher.apiClient.RunsAPIApi.PostSubmitTestRuns(context.TODO(), groupName).TestRunRequest(*testRunRequest).ClientApiVersion(restApiVersion).Execute()
+		err = launcher.commsRetrier.ExecuteCommandWithRateLimitRetries(func() error {
+			var httpResponse *http.Response
+			resultGroup, httpResponse, err = launcher.apiClient.RunsAPIApi.PostSubmitTestRuns(context.TODO(), groupName).TestRunRequest(*testRunRequest).ClientApiVersion(restApiVersion).Execute()
 
-		err = galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
+			return galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
+		})
 	}
 	return resultGroup, err
 }
@@ -110,10 +116,12 @@ func (launcher *RemoteLauncher) GetRunsById(runId string) (*galasaapi.Run, error
 	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 
 	if err == nil {
-		var httpResponse *http.Response
-		rasRun, _, err = launcher.apiClient.ResultArchiveStoreAPIApi.GetRasRunById(context.TODO(), runId).ClientApiVersion(restApiVersion).Execute()
+		err = launcher.commsRetrier.ExecuteCommandWithRateLimitRetries(func() error {
+			var httpResponse *http.Response
+			rasRun, _, err = launcher.apiClient.ResultArchiveStoreAPIApi.GetRasRunById(context.TODO(), runId).ClientApiVersion(restApiVersion).Execute()
 
-		err = galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
+			return galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
+		})
 	}
 	return rasRun, err
 }
@@ -129,11 +137,13 @@ func (launcher *RemoteLauncher) GetStreams() ([]string, error) {
 
 	if err == nil {
 		var properties []galasaapi.GalasaProperty
-		var httpResponse *http.Response
-		properties, httpResponse, err = launcher.apiClient.ConfigurationPropertyStoreAPIApi.
-			QueryCpsNamespaceProperties(context.TODO(), "framework").Prefix("test.stream").Suffix("repo").ClientApiVersion(restApiVersion).Execute()
+		err = launcher.commsRetrier.ExecuteCommandWithRateLimitRetries(func() error {
+			var httpResponse *http.Response
+			properties, httpResponse, err = launcher.apiClient.ConfigurationPropertyStoreAPIApi.
+				QueryCpsNamespaceProperties(context.TODO(), "framework").Prefix("test.stream").Suffix("repo").ClientApiVersion(restApiVersion).Execute()
 
-		err = galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
+			return galasaErrors.GetGalasaErrorFromCommsResponse(httpResponse, err)
+		})
 		if err == nil {
 
 			streams, err = getStreamNamesFromProperties(properties)
@@ -169,19 +179,23 @@ func (launcher *RemoteLauncher) GetTestCatalog(stream string) (TestCatalog, erro
 
 	if err == nil {
 		var cpsResponse *http.Response
-		cpsProperty, cpsResponse, err = launcher.apiClient.ConfigurationPropertyStoreAPIApi.QueryCpsNamespaceProperties(context.TODO(), "framework").Prefix("test.stream."+stream).Suffix("location").ClientApiVersion(restApiVersion).Execute()
+		err = launcher.commsRetrier.ExecuteCommandWithRateLimitRetries(func() error {
+			cpsProperty, cpsResponse, err = launcher.apiClient.ConfigurationPropertyStoreAPIApi.QueryCpsNamespaceProperties(context.TODO(), "framework").Prefix("test.stream."+stream).Suffix("location").ClientApiVersion(restApiVersion).Execute()
+	
+			var statusCode int
+			if cpsResponse != nil {
+				defer cpsResponse.Body.Close()
+				statusCode = cpsResponse.StatusCode
+			}
+	
+			if err != nil {
+				err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_PROPERTY_GET_FAILED, stream, err)
+			} else if len(cpsProperty) < 1 {
+				err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_CATALOG_NOT_FOUND, stream)
+			}
+			return err
+		})
 
-		var statusCode int
-		if cpsResponse != nil {
-			defer cpsResponse.Body.Close()
-			statusCode = cpsResponse.StatusCode
-		}
-
-		if err != nil {
-			err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_PROPERTY_GET_FAILED, stream, err)
-		} else if len(cpsProperty) < 1 {
-			err = galasaErrors.NewGalasaErrorWithHttpStatusCode(statusCode, galasaErrors.GALASA_ERROR_CATALOG_NOT_FOUND, stream)
-		}
 		if err == nil {
 			streamLocation :=cpsProperty[0].Data.Value
 			catalogString := new(strings.Builder)

--- a/pkg/launcher/remoteLauncher_test.go
+++ b/pkg/launcher/remoteLauncher_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/galasaapi"
+	"github.com/galasa-dev/cli/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -90,8 +91,9 @@ func TestGetTestCatalogHttpErrorGetsReported(t *testing.T) {
 
 	apiServerUrl := server.URL
 	apiClient := api.InitialiseAPI(apiServerUrl)
+	commsRetrier := api.NewCommsRetrier(0, 0, utils.NewMockTimeService())
 
-	launcher := NewRemoteLauncher(apiServerUrl, apiClient)
+	launcher := NewRemoteLauncher(apiServerUrl, apiClient, commsRetrier)
 
 	_, err := launcher.GetTestCatalog("myStream")
 

--- a/pkg/spi/timeService.go
+++ b/pkg/spi/timeService.go
@@ -9,5 +9,4 @@ import "time"
 
 type TimeService interface {
 	Now() time.Time
-	Sleep(duration time.Duration)
 }

--- a/pkg/spi/timeService.go
+++ b/pkg/spi/timeService.go
@@ -9,4 +9,5 @@ import "time"
 
 type TimeService interface {
 	Now() time.Time
+	Sleep(duration time.Duration)
 }

--- a/pkg/utils/logRedirector.go
+++ b/pkg/utils/logRedirector.go
@@ -13,6 +13,17 @@ import (
 	"github.com/galasa-dev/cli/pkg/spi"
 )
 
+// CaptureExecutionLogs captures the logs for a given execution function to a file or stderr.
+func CaptureExecutionLogs(factory spi.Factory, logFileName string, executionFunc func() error) error {
+	var err error
+	fileSystem := factory.GetFileSystem()
+	err = CaptureLog(fileSystem, logFileName)
+	if err == nil {
+		err = executionFunc()
+	}
+	return err
+}
+
 /*
  * CaptureLog(logFileName) decides whether to re-direct the log information to the
  * specified file, or if the file name is "-" or empty, the log information won't be

--- a/pkg/utils/logRedirector_test.go
+++ b/pkg/utils/logRedirector_test.go
@@ -6,6 +6,7 @@
 package utils
 
 import (
+	"log"
 	"testing"
 
 	"github.com/galasa-dev/cli/pkg/files"
@@ -25,4 +26,31 @@ func TestLogRedirectorFailsWhenLogFileIsAFolder(t *testing.T) {
 	err = CaptureLog(fileSystem, logFileName)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "GAL1069")
+}
+
+func TestLogRedirectorCapturesFunctionLogsToAFileOk(t *testing.T) {
+
+	var err error
+
+	factory := NewMockFactory()
+	fileSystem := factory.GetFileSystem()
+
+	expectedLogFileContent := "Hello, world!"
+	executionFunc := func() error {
+		log.Println(expectedLogFileContent)
+		return nil
+	}
+
+	logFileName := "test-log.log"
+
+	err = CaptureExecutionLogs(factory, logFileName, executionFunc)
+	assert.Nil(t, err)
+
+	logFileExists, _ := fileSystem.Exists(logFileName)
+	assert.True(t, logFileExists)
+
+	// The actual content will be prefixed with a timestamp (e.g. "2024/12/23 13:33:35"),
+	// we just want to see if our message was written to the file
+	logFileContent, _ := fileSystem.ReadTextFile(logFileName)
+	assert.Contains(t, logFileContent, expectedLogFileContent)
 }

--- a/pkg/utils/timeService.go
+++ b/pkg/utils/timeService.go
@@ -30,3 +30,8 @@ func NewRealTimeService() spi.TimeService {
 func (ts *timeService) Now() time.Time {
 	return time.Now().UTC()
 }
+
+// Sleeps for a given duration
+func (ts *timeService) Sleep(duration time.Duration) {
+	time.Sleep(duration)
+}

--- a/pkg/utils/timeServiceMock.go
+++ b/pkg/utils/timeServiceMock.go
@@ -28,9 +28,13 @@ func NewOverridableMockTimeService(now time.Time) spi.TimeService {
 }
 
 func (ts *MockTimeService) AdvanceClock(duration time.Duration) {
-	ts.MockNow.Add(duration)
+	ts.MockNow = ts.MockNow.Add(duration)
 }
 
 func (ts *MockTimeService) Now() time.Time {
 	return ts.MockNow
+}
+
+func (ts *MockTimeService) Sleep(duration time.Duration) {
+	ts.AdvanceClock(duration)
 }


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2072
Builds on changes in https://github.com/galasa-dev/cli/pull/322

## Changes
- Added `--rate-limit-retries` flag to configure the maximum number of retries to attempt when rate limit errors are encountered
- Added `--rate-limit-retry-backoff` flag to configure the amount of time in seconds between retry attempts
- Replaced duplicate `bootstrap` value in commands with a comms command structure containing flags that are commonly-used in commands that talk to the API server