### PR TITLE
CLI displays user roles when users are shown

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -251,7 +251,7 @@
         "hashed_secret": "0c60ced8eef0402874353606d68af16aa72869a8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 88,
+        "line_number": 160,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/pkg/users/usersGet.go
+++ b/pkg/users/usersGet.go
@@ -54,14 +54,14 @@ func getUserDataFromRestApi(
 
 	restApiVersion, err = embedded.GetGalasactlRestApiVersion()
 
-	apiCall := apiClient.UsersAPIApi.GetUserByLoginId(context)
+	apiCall := apiClient.UsersAPIApi.GetUserByLoginId(context).ClientApiVersion(restApiVersion)
 
 	if loginId != "" {
 
 		loginId, err = validateLoginIdFlag(loginId)
 
 		if err == nil {
-			apiCall = apiCall.LoginId(loginId).ClientApiVersion(restApiVersion)
+			apiCall = apiCall.LoginId(loginId)
 		}
 	}
 

--- a/pkg/usersformatter/summaryFormatter.go
+++ b/pkg/usersformatter/summaryFormatter.go
@@ -42,7 +42,7 @@ func (*UserSummaryFormatter) FormatUsers(users []galasaapi.UserData) (string, er
 	if totalUsers > 0 {
 		var table [][]string
 
-		var headers = []string{HEADER_USER_LOGIN_ID, HEADER_WEBUI_LAST_LOGIN, HEADER_RESTAPI_LAST_LOGIN}
+		var headers = []string{HEADER_USER_LOGIN_ID, HEADER_USER_ROLE, HEADER_WEBUI_LAST_LOGIN, HEADER_RESTAPI_LAST_LOGIN}
 
 		table = append(table, headers)
 		for _, user := range users {
@@ -63,7 +63,9 @@ func (*UserSummaryFormatter) FormatUsers(users []galasaapi.UserData) (string, er
 				}
 			}
 
-			line = append(line, loginId, webLastLogin, restLastLogin)
+			userRole := user.Synthetic.GetRole().Metadata.GetName()
+
+			line = append(line, loginId, userRole, webLastLogin, restLastLogin)
 			table = append(table, line)
 		}
 

--- a/pkg/usersformatter/summaryFormatter_test.go
+++ b/pkg/usersformatter/summaryFormatter_test.go
@@ -37,6 +37,19 @@ func CreateMockUser(loginId string, clientName string, lastLogin string) *galasa
 	user.SetLoginId(loginId)
 	user.SetClients([]galasaapi.FrontEndClient{*client, *client2})
 
+	role := galasaapi.NewRBACRole()
+	roleMetadata := galasaapi.NewRBACRoleMetadata()
+	role.Metadata = roleMetadata
+	role.Metadata.SetId("2")
+	role.Metadata.SetName("admin")
+	role.Metadata.SetUrl("http://myhost/api/roles/2")
+	role.Metadata.SetDescription("A test role")
+
+	synthetic := galasaapi.NewUserSynthetics()
+	synthetic.SetRole(*role)
+	synthetic.Role.SetApiVersion("myVersion")
+	user.SetSynthetic(*synthetic)
+
 	return user
 }
 
@@ -58,7 +71,7 @@ func TestUserSummaryFormatterNoDataReturnsTotalCountAllZeros(t *testing.T) {
 func TestTokenSummaryFormatterSingleDataReturnsCorrectly(t *testing.T) {
 	// Given...
 	formatter := NewUserSummaryFormatter()
-	// No data to format...
+	// No data to format...x
 	users := make([]galasaapi.UserData, 0)
 	user1 := CreateMockUser("test-user", "web-ui", "2023-12-03T18:25:43.511Z")
 	users = append(users, *user1)
@@ -69,8 +82,8 @@ func TestTokenSummaryFormatterSingleDataReturnsCorrectly(t *testing.T) {
 	// Then...
 	assert.Nil(t, err)
 	expectedFormattedOutput :=
-		`login-id  web-last-login(UTC) rest-api-last-login(UTC)
-test-user 2023-12-03 18:25    2023-12-03 18:25
+		`login-id  role  web-last-login(UTC) rest-api-last-login(UTC)
+test-user admin 2023-12-03 18:25    2023-12-03 18:25
 
 Total:1
 `
@@ -93,10 +106,10 @@ func TestTokenSummaryFormatterMultipleDataSeperatesWithNewLine(t *testing.T) {
 	// Then...
 	assert.Nil(t, err)
 	expectedFormattedOutput :=
-		`login-id    web-last-login(UTC) rest-api-last-login(UTC)
-test-user   2023-12-03 18:25    2023-12-03 18:25
-test-user-2 2023-12-03 18:25    2023-12-03 18:25
-test-user-3 2023-12-03 18:25    2023-12-03 18:25
+		`login-id    role  web-last-login(UTC) rest-api-last-login(UTC)
+test-user   admin 2023-12-03 18:25    2023-12-03 18:25
+test-user-2 admin 2023-12-03 18:25    2023-12-03 18:25
+test-user-3 admin 2023-12-03 18:25    2023-12-03 18:25
 
 Total:3
 `

--- a/pkg/usersformatter/usersformatter.go
+++ b/pkg/usersformatter/usersformatter.go
@@ -22,6 +22,7 @@ import (
 // and turn them into a string for display to the user.
 const (
 	HEADER_USER_LOGIN_ID      = "login-id"
+	HEADER_USER_ROLE          = "role"
 	HEADER_WEBUI_LAST_LOGIN   = "web-last-login(UTC)"
 	HEADER_RESTAPI_LAST_LOGIN = "rest-api-last-login(UTC)"
 )


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
See issue https://github.com/galasa-dev/projectmanagement/issues/2071

- [x] `galasactl users get` now displays roles in summary view. Only summary view supported so far. Leaves a blank if there is no role.
- [x] Some unit test improved. 81.7% now
