### PR TITLE
better handling of 'galasactl users set' failures.

### DIFF
--- a/docs/generated/errors-list.md
+++ b/docs/generated/errors-list.md
@@ -194,11 +194,11 @@ The `galasactl` tool can generate the following errors:
 - GAL1195E: Failed to delete user from database by user number.
 - GAL1196E: The user could not be deleted by login ID because it was not found by the Galasa service. Try listing users using 'galasactl users get' to identify the one you wish to delete
 - GAL1197E: An attempt to delete a user failed. Sending the delete request to the Galasa service failed. Cause is {}
-- GAL1198E: An attempt to delete a user numbered '{}' failed. Unexpected http status code {} received from the server.
-- GAL1199E: An attempt to delete a user numbered '{}' failed. Unexpected http status code {} received from the server. Error details from the server could not be read. Cause: {}
-- GAL1200E: An attempt to delete a user numbered '{}' failed. Unexpected http status code {} received from the server. Error details from the server are not in a valid json format. Cause: '{}'
-- GAL1201E: An attempt to delete a user numbered '{}' failed. Unexpected http status code {} received from the server. Error details from the server are: '{}'
-- GAL1202E: An attempt to delete a user numbered '{}' failed. Unexpected http status code {} received from the server. Error details from the server are not in the json format.
+- GAL1198E: An attempt to delete a user '{}' failed. Unexpected http status code {} received from the server.
+- GAL1199E: An attempt to delete a user '{}' failed. Unexpected http status code {} received from the server. Error details from the server could not be read. Cause: {}
+- GAL1200E: An attempt to delete a user '{}' failed. Unexpected http status code {} received from the server. Error details from the server are not in a valid json format. Cause: '{}'
+- GAL1201E: An attempt to delete a user '{}' failed. Unexpected http status code {} received from the server. Error details from the server are: '{}'
+- GAL1202E: An attempt to delete a user '{}' failed. Unexpected http status code {} received from the server. Error details from the server are not in the json format.
 - GAL1203E: Failed to get roles. Sending the get request to the Galasa service failed. Cause is {}
 - GAL1204E: Failed to get roles. Unexpected http status code {} received from the server.
 - GAL1205E: Failed to get roles. Unexpected http status code {} received from the server. Error details from the server could not be read. Cause: {}
@@ -209,6 +209,11 @@ The `galasactl` tool can generate the following errors:
 - GAL1210E: Role name {} is not known on the Galasa service.
 - GAL1211E: User with login id {} is not known on the Galasa service.
 - GAL1212E: Failed to update user record on the Galasa service.
+- GAL1213E: An attempt to update a user '{}' failed. Unexpected http status code {} received from the server.
+- GAL1214E: An attempt to update a user '{}' failed. Unexpected http status code {} received from the server. Error details from the server could not be read. Cause: {}
+- GAL1215E: An attempt to update a user '{}' failed. Unexpected http status code {} received from the server. Error details from the server are not in a valid json format. Cause: '{}'
+- GAL1216E: An attempt to update a user '{}' failed. Unexpected http status code {} received from the server. Error details from the server are: '{}'
+- GAL1217E: An attempt to update a user '{}' failed. Unexpected http status code {} received from the server. Error details from the server are not in the json format.
 - GAL1225E: Failed to open file '{}' cause: {}. Check that this file exists, and that you have read permissions.
 - GAL1226E: Internal failure. Contents of gzip could be read, but not decoded. New gzip reader failed: file: {} error: {}
 - GAL1227E: Internal failure. Contents of gzip could not be decoded. {} error: {}

--- a/pkg/cmd/usersSet.go
+++ b/pkg/cmd/usersSet.go
@@ -151,7 +151,8 @@ func (cmd *UsersSetCommand) executeUsersSet(
 
 			if err == nil {
 				// Call to process the command in a unit-testable way.
-				err = users.SetUsers(userCmdValues.name, cmd.values.role, apiClient, console)
+				byteReader := factory.GetByteReader()
+				err = users.SetUsers(userCmdValues.name, cmd.values.role, apiClient, console, byteReader)
 			}
 		}
 	}

--- a/pkg/errors/errorMessage.go
+++ b/pkg/errors/errorMessage.go
@@ -376,11 +376,11 @@ var (
 	GALASA_ERROR_FAILED_TO_DELETE_USER                   = NewMessageType("GAL1195E: Failed to delete user from database by user number.", 1195, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_SERVER_DELETE_USER_NOT_FOUND            = NewMessageType("GAL1196E: The user could not be deleted by login ID because it was not found by the Galasa service. Try listing users using 'galasactl users get' to identify the one you wish to delete", 1196, STACK_TRACE_NOT_WANTED)
 	GALASA_ERROR_SERVER_DELETE_USER_FAILED               = NewMessageType("GAL1197E: An attempt to delete a user failed. Sending the delete request to the Galasa service failed. Cause is %v", 1197, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_DELETE_USER_NO_RESPONSE_CONTENT         = NewMessageType("GAL1198E: An attempt to delete a user numbered '%s' failed. Unexpected http status code %v received from the server.", 1198, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_DELETE_USER_RESPONSE_PAYLOAD_UNREADABLE = NewMessageType("GAL1199E: An attempt to delete a user numbered '%s' failed. Unexpected http status code %v received from the server. Error details from the server could not be read. Cause: %s", 1199, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_DELETE_USER_UNPARSEABLE_CONTENT         = NewMessageType("GAL1200E: An attempt to delete a user numbered '%s' failed. Unexpected http status code %v received from the server. Error details from the server are not in a valid json format. Cause: '%s'", 1200, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_DELETE_USER_SERVER_REPORTED_ERROR       = NewMessageType("GAL1201E: An attempt to delete a user numbered '%s' failed. Unexpected http status code %v received from the server. Error details from the server are: '%s'", 1201, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_DELETE_USER_EXPLANATION_NOT_JSON        = NewMessageType("GAL1202E: An attempt to delete a user numbered '%s' failed. Unexpected http status code %v received from the server. Error details from the server are not in the json format.", 1202, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_USER_NO_RESPONSE_CONTENT         = NewMessageType("GAL1198E: An attempt to delete a user '%s' failed. Unexpected http status code %v received from the server.", 1198, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_USER_RESPONSE_PAYLOAD_UNREADABLE = NewMessageType("GAL1199E: An attempt to delete a user '%s' failed. Unexpected http status code %v received from the server. Error details from the server could not be read. Cause: %s", 1199, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_USER_UNPARSEABLE_CONTENT         = NewMessageType("GAL1200E: An attempt to delete a user '%s' failed. Unexpected http status code %v received from the server. Error details from the server are not in a valid json format. Cause: '%s'", 1200, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_USER_SERVER_REPORTED_ERROR       = NewMessageType("GAL1201E: An attempt to delete a user '%s' failed. Unexpected http status code %v received from the server. Error details from the server are: '%s'", 1201, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_DELETE_USER_EXPLANATION_NOT_JSON        = NewMessageType("GAL1202E: An attempt to delete a user '%s' failed. Unexpected http status code %v received from the server. Error details from the server are not in the json format.", 1202, STACK_TRACE_NOT_WANTED)
 
 	// When getting multiple roles...
 	GALASA_ERROR_GET_ROLES_REQUEST_FAILED           = NewMessageType("GAL1203E: Failed to get roles. Sending the get request to the Galasa service failed. Cause is %v", 1203, STACK_TRACE_NOT_WANTED)
@@ -395,8 +395,13 @@ var (
 	GALASA_ERROR_ROLE_NAME_NOT_FOUND = NewMessageType("GAL1210E: Role name %v is not known on the Galasa service.", 1210, STACK_TRACE_NOT_WANTED)
 
 	// When updating a user
-	GALASA_ERROR_SERVER_USER_NOT_FOUND = NewMessageType("GAL1211E: User with login id %v is not known on the Galasa service.", 1211, STACK_TRACE_NOT_WANTED)
-	GALASA_ERROR_UPDATING_USER_RECORD  = NewMessageType("GAL1212E: Failed to update user record on the Galasa service.", 1212, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_SERVER_USER_NOT_FOUND                   = NewMessageType("GAL1211E: User with login id %v is not known on the Galasa service.", 1211, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_UPDATING_USER_RECORD                    = NewMessageType("GAL1212E: Failed to update user record on the Galasa service.", 1212, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_UPDATE_USER_NO_RESPONSE_CONTENT         = NewMessageType("GAL1213E: An attempt to update a user '%s' failed. Unexpected http status code %v received from the server.", 1213, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_UPDATE_USER_RESPONSE_PAYLOAD_UNREADABLE = NewMessageType("GAL1214E: An attempt to update a user '%s' failed. Unexpected http status code %v received from the server. Error details from the server could not be read. Cause: %s", 1214, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_UPDATE_USER_UNPARSEABLE_CONTENT         = NewMessageType("GAL1215E: An attempt to update a user '%s' failed. Unexpected http status code %v received from the server. Error details from the server are not in a valid json format. Cause: '%s'", 1215, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_UPDATE_USER_SERVER_REPORTED_ERROR       = NewMessageType("GAL1216E: An attempt to update a user '%s' failed. Unexpected http status code %v received from the server. Error details from the server are: '%s'", 1216, STACK_TRACE_NOT_WANTED)
+	GALASA_ERROR_UPDATE_USER_EXPLANATION_NOT_JSON        = NewMessageType("GAL1217E: An attempt to update a user '%s' failed. Unexpected http status code %v received from the server. Error details from the server are not in the json format.", 1217, STACK_TRACE_NOT_WANTED)
 
 	// Warnings...
 	GALASA_WARNING_MAVEN_NO_GALASA_OBR_REPO = NewMessageType("GAL2000W: Warning: Maven configuration file settings.xml should contain a reference to a Galasa repository so that the galasa OBR can be resolved. The official release repository is '%s', and 'pre-release' repository is '%s'", 2000, STACK_TRACE_WANTED)

--- a/pkg/users/usersDelete.go
+++ b/pkg/users/usersDelete.go
@@ -58,9 +58,11 @@ func deleteUserFromRestApi(
 			if resp == nil {
 				err = galasaErrors.NewGalasaError(galasaErrors.GALASA_ERROR_SERVER_DELETE_USER_FAILED, err.Error())
 			} else {
+				// Report errors to the user using the user-id rather than the user number, as the
+				// user number means nothing to them.
 				err = galasaErrors.HttpResponseToGalasaError(
 					resp,
-					userNumber,
+					user.GetLoginId(),
 					byteReader,
 					galasaErrors.GALASA_ERROR_DELETE_USER_NO_RESPONSE_CONTENT,
 					galasaErrors.GALASA_ERROR_DELETE_USER_RESPONSE_PAYLOAD_UNREADABLE,

--- a/pkg/users/usersDelete_test.go
+++ b/pkg/users/usersDelete_test.go
@@ -140,7 +140,7 @@ func TestUserDeleteAUserThrowsAnUnexpectedError(t *testing.T) {
 	assert.NotNil(t, err, "DeleteUser returned an unexpected error")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusInternalServerError))
 	assert.Contains(t, err.Error(), "GAL1201E")
-	assert.Contains(t, err.Error(), "An attempt to delete a user numbered 'dummy-doc-id' failed")
+	assert.Contains(t, err.Error(), "An attempt to delete a user", loginId)
 }
 
 func TestUserDeleteAUserNotFoundThrowsError(t *testing.T) {

--- a/pkg/users/usersSet_test.go
+++ b/pkg/users/usersSet_test.go
@@ -65,8 +65,10 @@ func TestSendUpdateOfUserGoodPath(t *testing.T) {
 
 	apiClient := api.InitialiseAPI(server.Server.URL)
 
+	mockByteReader := utils.NewMockByteReader()
+
 	//When
-	updatedUser, err := sendUserUpdateToRestApi("usernumber201", "2", apiClient)
+	updatedUser, err := sendUserUpdateToRestApi("usernumber201", "2", apiClient, "user201loginId", mockByteReader)
 
 	//Then
 	assert.Nil(t, err)


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
After doing more ad-hoc testing of the galasactl tool, I noted that the errors didn't have much detail inside.

Added code to decode the failures, reading and parsing the json and showing that to the user.

eg: `Instead of Could not update user 'mike' because you don't have permissions.` To something more like `Instead of Could not update user 'mike' because you don't have permissions. Http code from the server was 403. Error message from the server was: GAL5140E: Failed to update the role of a user record. The requestor is not allowed to change their own user role.`... not exact wording but that's the sort of thing which changes here.
