### PR TITLE
login-id flag is now mandatory where it needs to be.

### DIFF
--- a/pkg/cmd/users.go
+++ b/pkg/cmd/users.go
@@ -89,4 +89,8 @@ func addLoginIdFlag(cmd *cobra.Command, isMandatory bool, userCmdValues *UsersCm
 
 	cmd.Flags().StringVar(&userCmdValues.name, flagName, "", description)
 
+	if isMandatory {
+		cmd.MarkFlagRequired(flagName)
+	}
+
 }

--- a/pkg/cmd/usersDelete.go
+++ b/pkg/cmd/usersDelete.go
@@ -89,7 +89,7 @@ func (cmd *UsersDeleteCommand) createCobraCmd(
 		},
 	}
 
-	addLoginIdFlag(usersDeleteCobraCmd, true, userCommandValues)
+	addLoginIdFlag(usersDeleteCobraCmd, MANDATORY_FLAG, userCommandValues)
 
 	usersCommand.CobraCommand().AddCommand(usersDeleteCobraCmd)
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Solves bug [galasactl users delete with no login id specified deleted a user ! #2118](https://github.com/galasa-dev/projectmanagement/issues/2118)