### PR TITLE
Fix incorrect addgroup and adduser inside CLI docker image

### DIFF
--- a/dockerfiles/dockerfile.galasactl
+++ b/dockerfiles/dockerfile.galasactl
@@ -5,8 +5,10 @@ RUN apt-get update \
 
 ARG platform
 
-RUN addgroup galasa && \ 
-    adduser -D -G galasa -h /galasa -s /bin/sh galasa 
+RUN groupadd -r galasa && \
+    useradd -r -g galasa -d /galasa -s /bin/bash galasa && \
+    mkdir -p /galasa && \
+    chown galasa:galasa /galasa
 
 COPY bin/galasactl-${platform} /bin/galasactl
 RUN chmod +x /bin/galasactl


### PR DESCRIPTION
## Why?

As part of another story, to give the `galasactl-x86_64` image access to bash, the `FROM` image of the image was updated from Alpine to Ubuntu. Since then this has broken the command to add a user and group of `galasa` as the syntax used in the Dockerfile is for Alpine Linux, not Ubuntu. In Ubuntu, adduser works differently, and `useradd` and `groupadd` should be used instead.