### PR TITLE
Iss1888 - Reference images in GHCR "docker proxy" instead of Harbor & fix broken adduser/addgroup for 'galasa'

### DIFF
--- a/dockerfiles/dockerfile.galasactl
+++ b/dockerfiles/dockerfile.galasactl
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/ubuntu:20.04
+FROM ghcr.io/galasa-dev/ubuntu:20.04
 
 RUN apt-get update \
     && apt-get install -y ca-certificates

--- a/dockerfiles/dockerfile.galasactl
+++ b/dockerfiles/dockerfile.galasactl
@@ -5,8 +5,10 @@ RUN apt-get update \
 
 ARG platform
 
-RUN addgroup galasa && \ 
-    adduser -D -G galasa -h /galasa -s /bin/sh galasa 
+RUN groupadd -r galasa && \
+    useradd -r -g galasa -d /galasa -s /bin/bash galasa && \
+    mkdir -p /galasa && \
+    chown galasa:galasa /galasa
 
 COPY bin/galasactl-${platform} /bin/galasactl
 RUN chmod +x /bin/galasactl

--- a/dockerfiles/dockerfile.galasactl-executables
+++ b/dockerfiles/dockerfile.galasactl-executables
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:alpine
+FROM ghcr.io/galasa-dev/httpd:alpine
 
 RUN rm -v /usr/local/apache2/htdocs/*
 COPY dockerfiles/httpdconf/base-httpd.conf /usr/local/apache2/conf/httpd.conf


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/1888

Replacing references to images stored in Harbor with GHCR now they have been moved over to our "docker proxy cache". Harbor has been experiencing unexplained issues so pulling/pushing images there has been failing, and so PR builds have been failing sporadically all day. Moving our regularly used based images to GHCR removes the chance for these outages which affect our delivery.

&

As part of another story, to give the galasactl-x86_64 image access to bash, the FROM image of the image was updated from Alpine to Ubuntu. Since then this has broken the command to add a user and group of galasa as the syntax used in the Dockerfile is for Alpine Linux, not Ubuntu. In Ubuntu, adduser works differently, and useradd and groupadd should be used instead.

This fix has been tested by running the image within my fork (see workflow run [here](https://github.com/jadecarino/automation/actions/runs/13269465006/job/37045967779) which is failing for another reason but is correctly being run with the galasa user, compared to a previous workflow run [here](https://github.com/jadecarino/automation/actions/runs/13269245770/job/37044520120) where the user galasa wasn't found).