### PR TITLE
embedded file paths must always use forward-slash separator, even on windows.

### DIFF
--- a/pkg/embedded/embeddedFileSystem.go
+++ b/pkg/embedded/embeddedFileSystem.go
@@ -15,6 +15,7 @@ import (
 type ReadOnlyFileSystem interface {
 	ReadFile(filePath string) ([]byte, error)
 	ReadDir(directoryPath string) ([]fs.DirEntry, error)
+	GetFileSeparator() string
 }
 
 type EmbeddedFileSystem struct {
@@ -28,9 +29,12 @@ func NewReadOnlyFileSystem() ReadOnlyFileSystem {
 	return &result
 }
 
-//------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------
 // Interface methods...
-//------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------
+func (fs *EmbeddedFileSystem) GetFileSeparator() string {
+	return "/"
+}
 
 // The only thing which this class actually supports.
 func (fs *EmbeddedFileSystem) ReadFile(filePath string) ([]byte, error) {

--- a/pkg/embedded/embeddedFileSystemMock.go
+++ b/pkg/embedded/embeddedFileSystemMock.go
@@ -13,12 +13,12 @@ import (
 )
 
 type MockDirEntry struct {
-    os.DirEntry
-    DirName string
+	os.DirEntry
+	DirName string
 }
 
 func (mockDirEntry MockDirEntry) Name() string {
-    return mockDirEntry.DirName
+	return mockDirEntry.DirName
 }
 
 type MockReadOnlyFileSystem struct {
@@ -38,17 +38,21 @@ func (fs *MockReadOnlyFileSystem) WriteFile(filePath string, content string) {
 	fs.files[filePath] = content
 }
 
+func (fs *MockReadOnlyFileSystem) GetFileSeparator() string {
+	return "/"
+}
+
 func (fs *MockReadOnlyFileSystem) ReadFile(filePath string) ([]byte, error) {
 	content := fs.files[filePath]
 	return []byte(content), nil
 }
 
 func (fs *MockReadOnlyFileSystem) ReadDir(directoryPath string) ([]fs.DirEntry, error) {
-    dirEntries := make([]os.DirEntry, 0)
-    for key := range fs.files {
-        if strings.HasPrefix(key, directoryPath) && key != directoryPath {
-            dirEntries = append(dirEntries, MockDirEntry{DirName: filepath.Base(key)})
-        }
-    }
-    return dirEntries, nil
+	dirEntries := make([]os.DirEntry, 0)
+	for key := range fs.files {
+		if strings.HasPrefix(key, directoryPath) && key != directoryPath {
+			dirEntries = append(dirEntries, MockDirEntry{DirName: filepath.Base(key)})
+		}
+	}
+	return dirEntries, nil
 }

--- a/pkg/embedded/embeddedFileSystem_test.go
+++ b/pkg/embedded/embeddedFileSystem_test.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package embedded
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileSeparatorIsASlash(t *testing.T) {
+	fs := NewReadOnlyFileSystem()
+
+	separator := fs.GetFileSeparator()
+
+	assert.Equal(t, "/", separator)
+}

--- a/pkg/embedded/embedded_test.go
+++ b/pkg/embedded/embedded_test.go
@@ -43,9 +43,9 @@ func TestDoesntReReadVersionsFromEmbeddedFSWhenAlreadyKnowAnswers(t *testing.T) 
 	fs.WriteFile(propsFileName, content)
 
 	alreadyKnownVersions := &versions{
-		galasaFrameworkVersion: "myFrameworkVersion",
-		galasaBootJarVersion:   "myBootJarVersion",
-		galasactlVersion:       "myGalasaCtlVersion",
+		galasaFrameworkVersion:  "myFrameworkVersion",
+		galasaBootJarVersion:    "myBootJarVersion",
+		galasactlVersion:        "myGalasaCtlVersion",
 		galasactlRestApiVersion: "myRestApiVersion",
 	}
 

--- a/pkg/images/FallbackFontFace.go
+++ b/pkg/images/FallbackFontFace.go
@@ -8,7 +8,6 @@ package images
 import (
 	"image"
 	"io/fs"
-	"path/filepath"
 
 	"github.com/galasa-dev/cli/pkg/embedded"
 	"golang.org/x/image/font"
@@ -50,7 +49,10 @@ func loadFontsFromDirectory(fileSystem embedded.ReadOnlyFileSystem, fontDirector
 		for _, fontFile := range fontFiles {
 			var fontFace font.Face
 
-			fontFilePath := filepath.Join(fontDirectoryPath, fontFile.Name())
+			// Don't use filepath.Join to build path, as that uses the OS file separator, and
+			// we need to use the file separator from the file system, which may be different.
+			// eg: The embedded file system in golang uses '/' even when on Windows...
+			fontFilePath := fontDirectoryPath + fileSystem.GetFileSeparator() + fontFile.Name()
 			fontFace, err = loadFont(fileSystem, fontFilePath)
 			if err == nil {
 				fonts = append(fonts, fontFace)


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
