### PR TITLE
json test structure didn't contain group information. May be making intermittent failures

### DIFF
--- a/pkg/launcher/jvmLauncher_test.go
+++ b/pkg/launcher/jvmLauncher_test.go
@@ -316,6 +316,7 @@ func TestCanGetRunGroupStatus(t *testing.T) {
 		"requestor": "unknown",
 		"status": "finished",
 		"result": "Passed",
+		"group": "none",
 		"queued": "2023-02-17T16:24:52.041118Z",
 		"startTime": "2023-02-17T16:24:52.068591Z",
 		"endTime": "2023-02-17T16:24:52.268396Z",


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Intermittent test failures spotted. See issue [Intermittent CLI Build failure #2146](https://github.com/galasa-dev/projectmanagement/issues/2146)

Not 100% sure why it failed, but it seemed to be in the json->object serialisation inflation code in the client... when it expected a group to be present.

Adding it to the static test data in the hope that it fixes it. If not we'll have to raise it again.