### PR TITLE
Move CLI testing to ecosystem1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,7 @@ jobs:
         env:
           GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
         run : |
+          export GALASA_TOKEN="${GALASA_TOKEN}"
           ./test-galasactl-ecosystem.sh --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap
 
       - name: Login to Github Container Registry
@@ -233,7 +234,6 @@ jobs:
             GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
         run: |
           gh workflow run build.yaml --repo https://github.com/galasa-dev/isolated --ref ${{ env.BRANCH }}
-
 
   report-failure:
     # Skip this job for forks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,17 +127,35 @@ jobs:
         run : |
           ./test-galasactl-local.sh --buildTool gradle
 
-      - name: Chmod ecosystem test script
-        run : |
-          chmod +x test-galasactl-ecosystem.sh
+      # Skip testing of Galasa service related commands if the
+      # GALASA_TOKEN_ECOSYSTEM1 secret is not set as the test
+      # script will not be able to authenticate to ecosystem1.
+      - name: Check if secret GALASA_TOKEN_ECOSYSTEM1 exists
+        continue-on-error: true
+        env:
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+        run: |
+          if [ -z "${GALASA_TOKEN_ECOSYSTEM1}" ] || [ "${GALASA_TOKEN_ECOSYSTEM1}" = "" ]; then
+            echo "GALASA_TOKEN_ECOSYSTEM1 is not set. Skipping tests where the CLI interacts with the Galasa service."
+            exit 1
+          else
+            echo "GALASA_TOKEN_ECOSYSTEM1 is set. Proceeding with tests where the CLI interacts with the Galasa service."
+          fi
+        id: check-galasa-token
 
-      - name: Run ecosystem test script
+      - name: Set environment variables
+        if: ${{ steps.check-galasa-token.outcome == 'success' }}
         env:
           GALASA_HOME: /home/runner/galasa
           GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
         run : |
-          export GALASA_HOME="${GALASA_HOME}"
-          export GALASA_TOKEN="${GALASA_TOKEN}"
+          echo "GALASA_HOME=${{ env.GALASA_HOME }}" >> $GITHUB_ENV
+          echo "GALASA_TOKEN=${{ env.GALASA_TOKEN }}" >> $GITHUB_ENV
+
+      - name: Run ecosystem test script
+        if: ${{ steps.check-galasa-token.outcome == 'success' }}
+        run : |
+          chmod +x test-galasactl-ecosystem.sh
           ./test-galasactl-ecosystem.sh --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap
 
       - name: Login to Github Container Registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,14 +127,15 @@ jobs:
         run : |
           ./test-galasactl-local.sh --buildTool gradle
 
-      # Commenting out for now as we cannot reach the prod1 ecosystem from GitHub Actions.
-      # - name: Chmod ecosystem test script
-      #   run : |
-      #     chmod +x test-galasactl-ecosystem.sh
+      - name: Chmod ecosystem test script
+        run : |
+          chmod +x test-galasactl-ecosystem.sh
 
-      # - name: Run ecosystem test script
-      #   run : |
-      #     ./test-galasactl-ecosystem.sh --bootstrap https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
+      - name: Run ecosystem test script
+        env:
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+        run : |
+          ./test-galasactl-ecosystem.sh --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap
 
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
@@ -219,55 +220,27 @@ jobs:
           ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.BRANCH }}-cli \
           --resource apps:Deployment:cli-${{ env.BRANCH }} --health --server argocd.galasa.dev
 
-  build-galasactl-ibm-testing-image-and-trigger-tekton-pipeline:
+  trigger-next-workflow:
     # Skip this job for forks
     if: ${{ github.repository_owner == 'galasa-dev' }}
-    name: Build image containing galasactl, OpenJDK and Gradle for testing
+    name: Trigger next workflow in the build chain
+    needs: [log-github-ref, build-cli]
     runs-on: ubuntu-latest
-    needs: build-cli
 
     steps:
-      - name: Checkout CLI
-        uses: actions/checkout@v4
-
-      - name: Login to Github Container Registry
-        uses: docker/login-action@v3
+      - name: Triggering isolated build
         env:
-          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
-          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
+            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/isolated --ref ${{ env.BRANCH }}
 
-      - name: Extract metadata for galasactl-ibm-testing image
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasactl-ibm-x86_64-testing
-
-      - name: Build galasactl-ibm-testing image
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: dockerfiles/dockerfile.galasactl-ibm-testing
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            branch=${{ env.BRANCH }}
-
-      - name: Attempt to trigger test-cli-ecosystem-commands Tekton pipeline
-        run: | 
-          echo "The Tekton pipeline test-cli-ecosystem-commands should be triggered in the next 2-minutes - check the Tekton dashboard"
 
   report-failure:
     # Skip this job for forks
     if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
     name: Report failure in workflow
     runs-on: ubuntu-latest
-    needs: [log-github-ref, build-cli, build-galasactl-ibm-testing-image-and-trigger-tekton-pipeline]
+    needs: [log-github-ref, build-cli]
 
     steps:
       - name: Report failure in workflow to Slack

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,8 +133,10 @@ jobs:
 
       - name: Run ecosystem test script
         env:
+          GALASA_HOME: /home/runner/galasa
           GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
         run : |
+          export GALASA_HOME="${GALASA_HOME}"
           export GALASA_TOKEN="${GALASA_TOKEN}"
           ./test-galasactl-ecosystem.sh --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -104,8 +104,10 @@ jobs:
 
       - name: Run ecosystem test script
         env:
+          GALASA_HOME: /home/runner/galasa
           GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
         run : |
+          export GALASA_HOME="${GALASA_HOME}"
           export GALASA_TOKEN="${GALASA_TOKEN}"
           ./test-galasactl-ecosystem.sh --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -106,6 +106,7 @@ jobs:
         env:
           GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
         run : |
+          export GALASA_TOKEN="${GALASA_TOKEN}"
           ./test-galasactl-ecosystem.sh --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap
 
       - name: Build Docker image with galasactl executable

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -98,14 +98,15 @@ jobs:
         run : |
           ./test-galasactl-local.sh --buildTool gradle
 
-      # Commenting out for now as we cannot reach the prod1 ecosystem from GitHub Actions.
-      # - name: Chmod ecosystem test script
-      #   run : |
-      #     chmod +x test-galasactl-ecosystem.sh
+      - name: Chmod ecosystem test script
+        run : |
+          chmod +x test-galasactl-ecosystem.sh
 
-      # - name: Run ecosystem test script
-      #   run : |
-      #     ./test-galasactl-ecosystem.sh --bootstrap https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
+      - name: Run ecosystem test script
+        env:
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+        run : |
+          ./test-galasactl-ecosystem.sh --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap
 
       - name: Build Docker image with galasactl executable
         uses: docker/build-push-action@v5

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -98,17 +98,35 @@ jobs:
         run : |
           ./test-galasactl-local.sh --buildTool gradle
 
-      - name: Chmod ecosystem test script
-        run : |
-          chmod +x test-galasactl-ecosystem.sh
+      # Skip testing of Galasa service related commands if the
+      # GALASA_TOKEN_ECOSYSTEM1 secret is not set as the test
+      # script will not be able to authenticate to ecosystem1.
+      - name: Check if secret GALASA_TOKEN_ECOSYSTEM1 exists
+        continue-on-error: true
+        env:
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+        run: |
+          if [ -z "${GALASA_TOKEN_ECOSYSTEM1}" ] || [ "${GALASA_TOKEN_ECOSYSTEM1}" = "" ]; then
+            echo "GALASA_TOKEN_ECOSYSTEM1 is not set. Skipping tests where the CLI interacts with the Galasa service."
+            exit 1
+          else
+            echo "GALASA_TOKEN_ECOSYSTEM1 is set. Proceeding with tests where the CLI interacts with the Galasa service."
+          fi
+        id: check-galasa-token
 
-      - name: Run ecosystem test script
+      - name: Set environment variables
+        if: ${{ steps.check-galasa-token.outcome == 'success' }}
         env:
           GALASA_HOME: /home/runner/galasa
           GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
         run : |
-          export GALASA_HOME="${GALASA_HOME}"
-          export GALASA_TOKEN="${GALASA_TOKEN}"
+          echo "GALASA_HOME=${{ env.GALASA_HOME }}" >> $GITHUB_ENV
+          echo "GALASA_TOKEN=${{ env.GALASA_TOKEN }}" >> $GITHUB_ENV
+
+      - name: Run ecosystem test script
+        if: ${{ steps.check-galasa-token.outcome == 'success' }}
+        run : |
+          chmod +x test-galasactl-ecosystem.sh
           ./test-galasactl-ecosystem.sh --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap
 
       - name: Build Docker image with galasactl executable

--- a/test-galasactl-ecosystem.sh
+++ b/test-galasactl-ecosystem.sh
@@ -83,7 +83,7 @@ done
 
 # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
 if [[ "${bootstrap}" == "" ]]; then
-    export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+    export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
     info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
 fi
 
@@ -92,8 +92,8 @@ info "Running tests against ecosystem bootstrap ${bootstrap}"
 #-----------------------------------------------------------------------------------------
 # Constants
 #-----------------------------------------------------------------------------------------
-export GALASA_TEST_NAME_SHORT="local.CoreLocalJava11Ubuntu"   
-export GALASA_TEST_NAME_LONG="dev.galasa.inttests.core.${GALASA_TEST_NAME_SHORT}" 
+export GALASA_TEST_NAME_SHORT="core.CoreManagerIVT"   
+export GALASA_TEST_NAME_LONG="dev.galasa.ivts/dev.galasa.ivts.${GALASA_TEST_NAME_SHORT}" 
 export GALASA_TEST_RUN_GET_EXPECTED_SUMMARY_LINE_COUNT="4"
 export GALASA_TEST_RUN_GET_EXPECTED_DETAILS_LINE_COUNT="14"
 export GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT="11"

--- a/test-scripts/auth-tests.sh
+++ b/test-scripts/auth-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+        export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 
@@ -114,7 +114,7 @@ function auth_tokens_get_all_tokens_without_loginId {
 function auth_tokens_get_all_tokens_by_loginId {
 
     h2 "Performing auth tokens get with loginId: get..."
-    loginId="Galasadelivery@ibm.com"
+    loginId="galasa-team"
 
     set -o pipefail # Fail everything if anything in the pipeline fails. Else we are just checking the 'tee' return code.
 

--- a/test-scripts/calculate-galasactl-executables.sh
+++ b/test-scripts/calculate-galasactl-executables.sh
@@ -64,7 +64,7 @@ done
 
 # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
 if [[ "${bootstrap}" == "" ]]; then
-    export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+    export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
     info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
 fi
 

--- a/test-scripts/gherkin-runs-tests.sh
+++ b/test-scripts/gherkin-runs-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+        export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 

--- a/test-scripts/properties-tests.sh
+++ b/test-scripts/properties-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+        export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 

--- a/test-scripts/resources-tests.sh
+++ b/test-scripts/resources-tests.sh
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-echo "Running script resourrces-tests.sh"
+echo "Running script resources-tests.sh"
 # This script can be ran locally or executed in a pipeline to test the various built binaries of galasactl
 # This script tests the 'galasactl resources' command against a namespace that is in our ecosystem's cps namespaces already
 # Pre-requesite: the CLI must have been built first so the binaries are present in the /bin directory
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+        export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 

--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+        export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 
@@ -78,8 +78,8 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
     #-----------------------------------------------------------------------------------------
     # Constants
     #-----------------------------------------------------------------------------------------
-    export GALASA_TEST_NAME_SHORT="local.CoreLocalJava11Ubuntu"
-    export GALASA_TEST_NAME_LONG="dev.galasa.inttests.core.${GALASA_TEST_NAME_SHORT}"
+    export GALASA_TEST_NAME_SHORT="core.CoreManagerIVT"   
+    export GALASA_TEST_NAME_LONG="dev.galasa.ivts/dev.galasa.ivts.${GALASA_TEST_NAME_SHORT}" 
     export GALASA_TEST_RUN_GET_EXPECTED_SUMMARY_LINE_COUNT="4"
     export GALASA_TEST_RUN_GET_EXPECTED_DETAILS_LINE_COUNT="14"
     export GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT="11"
@@ -836,7 +836,7 @@ function runs_get_check_raw_format_output_with_older_to_than_from_age {
 
 #--------------------------------------------------------------------------
 function runs_get_check_requestor_parameter {
-    requestor="Galasadelivery@ibm.com"
+    requestor="galasa-team"
     h2 "Performing runs get with details format providing a from age and requestor as $requestor..."
 
     cd ${BASEDIR}/temp


### PR DESCRIPTION
## Why?

We temporarily need to stop testing on the prod1 service.

This set of changes points the CLI testing scripts at the ecosystem1 service instead of prod1. This is now possible since we have replicated the CoreManagerIVT and made it available on ecosystem1 with a new test stream.

However, there is no need to move back to prod1 even once we are told we can. This has removed the need to call into Tekton then come back to GH Actions again.