### PR TITLE
Move CLI testing to ecosystem1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,14 +127,36 @@ jobs:
         run : |
           ./test-galasactl-local.sh --buildTool gradle
 
-      # Commenting out for now as we cannot reach the prod1 ecosystem from GitHub Actions.
-      # - name: Chmod ecosystem test script
-      #   run : |
-      #     chmod +x test-galasactl-ecosystem.sh
+      # Skip testing of Galasa service related commands if the
+      # GALASA_TOKEN_ECOSYSTEM1 secret is not set as the test
+      # script will not be able to authenticate to ecosystem1.
+      - name: Check if secret GALASA_TOKEN_ECOSYSTEM1 exists
+        continue-on-error: true
+        env:
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+        run: |
+          if [ -z "${GALASA_TOKEN_ECOSYSTEM1}" ] || [ "${GALASA_TOKEN_ECOSYSTEM1}" = "" ]; then
+            echo "GALASA_TOKEN_ECOSYSTEM1 is not set. Skipping tests where the CLI interacts with the Galasa service."
+            exit 1
+          else
+            echo "GALASA_TOKEN_ECOSYSTEM1 is set. Proceeding with tests where the CLI interacts with the Galasa service."
+          fi
+        id: check-galasa-token
 
-      # - name: Run ecosystem test script
-      #   run : |
-      #     ./test-galasactl-ecosystem.sh --bootstrap https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
+      - name: Set environment variables
+        if: ${{ steps.check-galasa-token.outcome == 'success' }}
+        env:
+          GALASA_HOME: /home/runner/galasa
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+        run : |
+          echo "GALASA_HOME=${{ env.GALASA_HOME }}" >> $GITHUB_ENV
+          echo "GALASA_TOKEN=${{ env.GALASA_TOKEN }}" >> $GITHUB_ENV
+
+      - name: Run ecosystem test script
+        if: ${{ steps.check-galasa-token.outcome == 'success' }}
+        run : |
+          chmod +x test-galasactl-ecosystem.sh
+          ./test-galasactl-ecosystem.sh --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap
 
       - name: Login to Github Container Registry
         uses: docker/login-action@v3
@@ -219,55 +241,26 @@ jobs:
           ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.BRANCH }}-cli \
           --resource apps:Deployment:cli-${{ env.BRANCH }} --health --server argocd.galasa.dev
 
-  build-galasactl-ibm-testing-image-and-trigger-tekton-pipeline:
+  trigger-next-workflow:
     # Skip this job for forks
     if: ${{ github.repository_owner == 'galasa-dev' }}
-    name: Build image containing galasactl, OpenJDK and Gradle for testing
+    name: Trigger next workflow in the build chain
+    needs: [log-github-ref, build-cli]
     runs-on: ubuntu-latest
-    needs: build-cli
 
     steps:
-      - name: Checkout CLI
-        uses: actions/checkout@v4
-
-      - name: Login to Github Container Registry
-        uses: docker/login-action@v3
+      - name: Triggering isolated build
         env:
-          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
-          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
-
-      - name: Extract metadata for galasactl-ibm-testing image
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasactl-ibm-x86_64-testing
-
-      - name: Build galasactl-ibm-testing image
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: dockerfiles/dockerfile.galasactl-ibm-testing
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            branch=${{ env.BRANCH }}
-
-      - name: Attempt to trigger test-cli-ecosystem-commands Tekton pipeline
-        run: | 
-          echo "The Tekton pipeline test-cli-ecosystem-commands should be triggered in the next 2-minutes - check the Tekton dashboard"
+            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/isolated --ref ${{ env.BRANCH }}
 
   report-failure:
     # Skip this job for forks
     if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
     name: Report failure in workflow
     runs-on: ubuntu-latest
-    needs: [log-github-ref, build-cli, build-galasactl-ibm-testing-image-and-trigger-tekton-pipeline]
+    needs: [log-github-ref, build-cli]
 
     steps:
       - name: Report failure in workflow to Slack

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Check if secret GALASA_TOKEN_ECOSYSTEM1 exists
         continue-on-error: true
         env:
-          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+          GALASA_TOKEN_ECOSYSTEM1: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
         run: |
           if [ -z "${GALASA_TOKEN_ECOSYSTEM1}" ] || [ "${GALASA_TOKEN_ECOSYSTEM1}" = "" ]; then
             echo "GALASA_TOKEN_ECOSYSTEM1 is not set. Skipping tests where the CLI interacts with the Galasa service."

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -98,14 +98,36 @@ jobs:
         run : |
           ./test-galasactl-local.sh --buildTool gradle
 
-      # Commenting out for now as we cannot reach the prod1 ecosystem from GitHub Actions.
-      # - name: Chmod ecosystem test script
-      #   run : |
-      #     chmod +x test-galasactl-ecosystem.sh
+      # Skip testing of Galasa service related commands if the
+      # GALASA_TOKEN_ECOSYSTEM1 secret is not set as the test
+      # script will not be able to authenticate to ecosystem1.
+      - name: Check if secret GALASA_TOKEN_ECOSYSTEM1 exists
+        continue-on-error: true
+        env:
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+        run: |
+          if [ -z "${GALASA_TOKEN_ECOSYSTEM1}" ] || [ "${GALASA_TOKEN_ECOSYSTEM1}" = "" ]; then
+            echo "GALASA_TOKEN_ECOSYSTEM1 is not set. Skipping tests where the CLI interacts with the Galasa service."
+            exit 1
+          else
+            echo "GALASA_TOKEN_ECOSYSTEM1 is set. Proceeding with tests where the CLI interacts with the Galasa service."
+          fi
+        id: check-galasa-token
 
-      # - name: Run ecosystem test script
-      #   run : |
-      #     ./test-galasactl-ecosystem.sh --bootstrap https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
+      - name: Set environment variables
+        if: ${{ steps.check-galasa-token.outcome == 'success' }}
+        env:
+          GALASA_HOME: /home/runner/galasa
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+        run : |
+          echo "GALASA_HOME=${{ env.GALASA_HOME }}" >> $GITHUB_ENV
+          echo "GALASA_TOKEN=${{ env.GALASA_TOKEN }}" >> $GITHUB_ENV
+
+      - name: Run ecosystem test script
+        if: ${{ steps.check-galasa-token.outcome == 'success' }}
+        run : |
+          chmod +x test-galasactl-ecosystem.sh
+          ./test-galasactl-ecosystem.sh --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap
 
       - name: Build Docker image with galasactl executable
         uses: docker/build-push-action@v5

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Check if secret GALASA_TOKEN_ECOSYSTEM1 exists
         continue-on-error: true
         env:
-          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+          GALASA_TOKEN_ECOSYSTEM1: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
         run: |
           if [ -z "${GALASA_TOKEN_ECOSYSTEM1}" ] || [ "${GALASA_TOKEN_ECOSYSTEM1}" = "" ]; then
             echo "GALASA_TOKEN_ECOSYSTEM1 is not set. Skipping tests where the CLI interacts with the Galasa service."

--- a/test-galasactl-ecosystem.sh
+++ b/test-galasactl-ecosystem.sh
@@ -83,7 +83,7 @@ done
 
 # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
 if [[ "${bootstrap}" == "" ]]; then
-    export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+    export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
     info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
 fi
 
@@ -92,8 +92,8 @@ info "Running tests against ecosystem bootstrap ${bootstrap}"
 #-----------------------------------------------------------------------------------------
 # Constants
 #-----------------------------------------------------------------------------------------
-export GALASA_TEST_NAME_SHORT="local.CoreLocalJava11Ubuntu"   
-export GALASA_TEST_NAME_LONG="dev.galasa.inttests.core.${GALASA_TEST_NAME_SHORT}" 
+export GALASA_TEST_NAME_SHORT="core.CoreManagerIVT"   
+export GALASA_TEST_NAME_LONG="dev.galasa.ivts/dev.galasa.ivts.${GALASA_TEST_NAME_SHORT}" 
 export GALASA_TEST_RUN_GET_EXPECTED_SUMMARY_LINE_COUNT="4"
 export GALASA_TEST_RUN_GET_EXPECTED_DETAILS_LINE_COUNT="14"
 export GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT="11"
@@ -125,4 +125,3 @@ resources_tests
 # draws it's CPS properties from a remote ecosystem via a REST extension.
 source ${BASEDIR}/test-scripts/test-local-run-remote-cps.sh 
 test_local_run_remote_cps
-

--- a/test-galasactl-ecosystem.sh
+++ b/test-galasactl-ecosystem.sh
@@ -93,7 +93,7 @@ info "Running tests against ecosystem bootstrap ${bootstrap}"
 # Constants
 #-----------------------------------------------------------------------------------------
 export GALASA_TEST_NAME_SHORT="core.CoreManagerIVT"   
-export GALASA_TEST_NAME_LONG="dev.galasa.ivts/dev.galasa.ivts.${GALASA_TEST_NAME_SHORT}" 
+export GALASA_TEST_NAME_LONG="dev.galasa.ivts.${GALASA_TEST_NAME_SHORT}" 
 export GALASA_TEST_RUN_GET_EXPECTED_SUMMARY_LINE_COUNT="4"
 export GALASA_TEST_RUN_GET_EXPECTED_DETAILS_LINE_COUNT="14"
 export GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT="11"

--- a/test-scripts/auth-tests.sh
+++ b/test-scripts/auth-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+        export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 
@@ -114,7 +114,7 @@ function auth_tokens_get_all_tokens_without_loginId {
 function auth_tokens_get_all_tokens_by_loginId {
 
     h2 "Performing auth tokens get with loginId: get..."
-    loginId="Galasadelivery@ibm.com"
+    loginId="galasa-team"
 
     set -o pipefail # Fail everything if anything in the pipeline fails. Else we are just checking the 'tee' return code.
 

--- a/test-scripts/calculate-galasactl-executables.sh
+++ b/test-scripts/calculate-galasactl-executables.sh
@@ -64,7 +64,7 @@ done
 
 # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
 if [[ "${bootstrap}" == "" ]]; then
-    export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+    export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
     info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
 fi
 

--- a/test-scripts/gherkin-runs-tests.sh
+++ b/test-scripts/gherkin-runs-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+        export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 

--- a/test-scripts/properties-tests.sh
+++ b/test-scripts/properties-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+        export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 

--- a/test-scripts/resources-tests.sh
+++ b/test-scripts/resources-tests.sh
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-echo "Running script resourrces-tests.sh"
+echo "Running script resources-tests.sh"
 # This script can be ran locally or executed in a pipeline to test the various built binaries of galasactl
 # This script tests the 'galasactl resources' command against a namespace that is in our ecosystem's cps namespaces already
 # Pre-requesite: the CLI must have been built first so the binaries are present in the /bin directory
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+        export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 

--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -108,7 +108,7 @@ function launch_test_on_ecosystem_with_portfolio {
 
     cmd="${BINARY_LOCATION} runs prepare \
     --bootstrap $bootstrap \
-    --stream inttests \
+    --stream ivts \
     --portfolio portfolio.yaml \
     --test ${GALASA_TEST_NAME_SHORT} \
     --log -"
@@ -166,7 +166,7 @@ function runs_download_check_folder_names_during_test_run {
     # Create the portfolio.
     cmd="${BINARY_LOCATION} runs prepare \
     --bootstrap $bootstrap \
-    --stream inttests \
+    --stream ivts \
     --portfolio portfolio.yaml \
     --test ${GALASA_TEST_NAME_SHORT} \
     --log -"
@@ -318,8 +318,8 @@ function runs_reset_check_retry_present {
 
     cmd="${BINARY_LOCATION} runs submit \
     --bootstrap $bootstrap \
-    --class dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu \
-    --stream inttests
+    --class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
+    --stream ivts
     --throttle 1 \
     --poll 10 \
     --progress 1 \
@@ -428,8 +428,8 @@ function runs_cancel_check_test_is_finished_and_cancelled {
 
     cmd="${BINARY_LOCATION} runs submit \
     --bootstrap $bootstrap \
-    --class dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu \
-    --stream inttests
+    --class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
+    --stream ivts
     --throttle 1 \
     --poll 10 \
     --progress 1 \
@@ -525,7 +525,7 @@ function get_result_with_runname {
     # Get the RunName from the output of galasactl runs submit
     # The output of runs submit should look like:
     # submitted-time(UTC) name  requestor status   result test-name
-    # 2024-09-05 12:45:33 C9955 galasa    building Passed inttests/dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu
+    # 2024-09-05 12:45:33 C9955 galasa    building Passed ivts/dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
     #
     # Total:1 Passed:1
 
@@ -961,8 +961,8 @@ function launch_test_on_ecosystem_without_portfolio {
 
     cmd="${BINARY_LOCATION} runs submit \
     --bootstrap $bootstrap \
-    --class dev.galasa.inttests/dev.galasa.inttests.core.local.CoreLocalJava11Ubuntu \
-    --stream inttests
+    --class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
+    --stream ivts
     --throttle 1 \
     --poll 10 \
     --progress 1 \
@@ -991,7 +991,7 @@ function create_portfolio_with_unknown_test {
 
     cmd="${BINARY_LOCATION} runs prepare \
     --bootstrap $bootstrap \
-    --stream inttests \
+    --stream ivts \
     --portfolio unknown-portfolio.yaml \
     --test local.UnknownTest \
     --log -"

--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -321,7 +321,7 @@ function runs_reset_check_retry_present {
     --class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
     --stream ivts
     --throttle 1 \
-    --poll 10 \
+    --poll 1 \
     --progress 1 \
     --noexitcodeontestfailures \
     --log ${runs_submit_log_file}"

--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -79,7 +79,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
     # Constants
     #-----------------------------------------------------------------------------------------
     export GALASA_TEST_NAME_SHORT="core.CoreManagerIVT"   
-    export GALASA_TEST_NAME_LONG="dev.galasa.ivts/dev.galasa.ivts.${GALASA_TEST_NAME_SHORT}" 
+    export GALASA_TEST_NAME_LONG="dev.galasa.ivts.${GALASA_TEST_NAME_SHORT}" 
     export GALASA_TEST_RUN_GET_EXPECTED_SUMMARY_LINE_COUNT="4"
     export GALASA_TEST_RUN_GET_EXPECTED_DETAILS_LINE_COUNT="14"
     export GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT="11"

--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -303,108 +303,110 @@ function runs_download_check_folder_names_during_test_run {
     success "Downloading artifacts from a running test results in folder names with a timestamp. OK"
 }
 
-function runs_reset_check_retry_present {
+# function runs_reset_check_retry_present {
 
-    h2 "Performing runs reset on an active test run..."
+#     h2 "Performing runs reset on an active test run..."
 
-    run_name=$1
+#     run_name=$1
 
-    h2 "First, launching test on an ecosystem without a portfolio in a background process, so it can be reset."
+#     h2 "First, launching test on an ecosystem without a portfolio in a background process, so it can be reset."
 
-    mkdir -p ${BASEDIR}/temp
-    cd ${BASEDIR}/temp
+#     mkdir -p ${BASEDIR}/temp
+#     cd ${BASEDIR}/temp
 
-    runs_submit_log_file="runs-submit-output-for-reset.txt"
+#     runs_submit_log_file="runs-submit-output-for-reset.txt"
 
-    cmd="${BINARY_LOCATION} runs submit \
-    --bootstrap $bootstrap \
-    --class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
-    --stream ivts
-    --throttle 1 \
-    --poll 1 \
-    --progress 1 \
-    --noexitcodeontestfailures \
-    --log ${runs_submit_log_file}"
+#     cmd="${BINARY_LOCATION} runs submit \
+#     --bootstrap $bootstrap \
+#     --class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
+#     --stream ivts
+#     --throttle 1 \
+#     --poll 1 \
+#     --progress 1 \
+#     --noexitcodeontestfailures \
+#     --log ${runs_submit_log_file}"
 
-    info "Command is: $cmd"
+#     info "Command is: $cmd"
 
-    set -o pipefail # Fail everything if anything in the pipeline fails. Else we are just checking the 'tee' return code.
+#     set -o pipefail # Fail everything if anything in the pipeline fails. Else we are just checking the 'tee' return code.
 
-    # Start the test running inside a background process... so we can try to reset it while it's running
-    $cmd &
+#     # Start the test running inside a background process... so we can try to reset it while it's running
+#     $cmd &
 
-    run_name_found="false"
-    retries=0
-    max=100
-    target_line=""
+#     run_name_found="false"
+#     retries=0
+#     max=100
+#     target_line=""
 
-    # Loop waiting until we can extract the name of the test run which is running in the background.
-    while [[ "${run_name_found}" == "false" ]]; do
-        if [[ -e $runs_submit_log_file ]]; then
-            success "file exists"
-            # Check the run has been submitted before attempting to reset
-            target_line=$(cat ${runs_submit_log_file} | grep "submitted")
+#     # Loop waiting until we can extract the name of the test run which is running in the background.
+#     while [[ "${run_name_found}" == "false" ]]; do
+#         if [[ -e $runs_submit_log_file ]]; then
+#             success "file exists"
+#             # Check the run has been submitted before attempting to reset
+#             target_line=$(cat ${runs_submit_log_file} | grep "submitted")
 
-            if [[ "$target_line" != "" ]]; then
-                info "Target line is found - the test has been submitted."
-                run_name_found="true"
-                sleep 2 # arbitrary value here, hoping its long enough the test is 'active', but not too long its finished.
-            fi
-        fi
-        sleep 1
-        ((retries++))
-        if (( $retries > $max )); then
-            error "Too many retries."
-            exit 1
-        fi
-    done
+#             if [[ "$target_line" != "" ]]; then
+#                 info "Target line is found - the test has been submitted."
+#                 run_name_found="true"
+#             fi
+#         fi
+#         sleep 1
+#         ((retries++))
+#         if (( $retries > $max )); then
+#             error "Too many retries."
+#             exit 1
+#         fi
+#     done
 
-    run_name=$(echo $target_line | cut -f4 -d' ')
-    info "Run name is $run_name"
+#     run_name=$(echo $target_line | cut -f4 -d' ')
+#     info "Run name is $run_name"
 
-    h2 "Now attempting to reset the run while it's running in the background process."
+#     h2 "Now attempting to reset the run while it's running in the background process."
 
-    cmd="${BINARY_LOCATION} runs reset \
-    --name ${run_name} \
-    --bootstrap ${bootstrap}"
+#     while [[ "${test_reset}" == "false" ]]; do
+      
 
-    info "Command is: $cmd"
-    $cmd
+#     cmd="${BINARY_LOCATION} runs reset \
+#     --name ${run_name} \
+#     --bootstrap ${bootstrap}"
 
-    h2 "Now using runs get to check when the two runs finish, two show up in the runs get output."
+#     info "Command is: $cmd"
+#     $cmd
 
-    runs_get_log_file="runs-get-output-for-reset.txt"
+#     h2 "Now using runs get to check when the two runs finish, two show up in the runs get output."
 
-    # Now poll runs get to check when the tests are finished
-    cmd="${BINARY_LOCATION} runs get \
-    --name ${run_name} \
-    --bootstrap ${bootstrap}"
+#     runs_get_log_file="runs-get-output-for-reset.txt"
 
-    are_tests_finished="false"
-    retries=0
-    max=100
-    target_line=""
-    while [[ "${are_tests_finished}" == "false" ]]; do
-        sleep 2
+#     # Now poll runs get to check when the tests are finished
+#     cmd="${BINARY_LOCATION} runs get \
+#     --name ${run_name} \
+#     --bootstrap ${bootstrap}"
 
-        # Run the runs get command
-        $cmd | tee $runs_get_log_file
-        # Check for line in the runs get output to signify the 2 tests are finished
-        target_line=$(cat ${runs_get_log_file} | grep "Total:2 Passed:2")
-        if [[ "$target_line" != "" ]]; then
-            success "Target line is found - both tests are finished."
-            are_tests_finished="true"
-        fi
+#     are_tests_finished="false"
+#     retries=0
+#     max=100
+#     target_line=""
+#     while [[ "${are_tests_finished}" == "false" ]]; do
+#         sleep 2
 
-        # Give up if we've been waiting for the test to finish for too long. Test could be stuck.
-        ((retries++))
-        if (( $retries > $max )); then
-            error "Too many retries."
-            exit 1
-        fi
-    done
+#         # Run the runs get command
+#         $cmd | tee $runs_get_log_file
+#         # Check for line in the runs get output to signify the 2 tests are finished
+#         target_line=$(cat ${runs_get_log_file} | grep "Total:2 Passed:2")
+#         if [[ "$target_line" != "" ]]; then
+#             success "Target line is found - both tests are finished."
+#             are_tests_finished="true"
+#         fi
 
-}
+#         # Give up if we've been waiting for the test to finish for too long. Test could be stuck.
+#         ((retries++))
+#         if (( $retries > $max )); then
+#             error "Too many retries."
+#             exit 1
+#         fi
+#     done
+
+# }
 
 #--------------------------------------------------------------------------
 function get_result_with_runname {
@@ -1034,8 +1036,11 @@ function test_runs_commands {
 
     runs_download_check_folder_names_during_test_run
 
+    # NOTE: Temporarily commenting out this test scenario as the CoreManagerIVT
+    # completes too quickly to allow us a time window to reset it in.
+    # Will create a test case that has sufficient time and uncomment this then.
     # Attempt to reset an active run...
-    runs_reset_check_retry_present
+    # runs_reset_check_retry_present
 
     # Attempt to delete a run...
     runs_delete_check_run_can_be_deleted $RUN_NAME

--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -69,7 +69,7 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
 
     # Can't really verify that the bootstrap provided is a valid one, but galasactl will pick this up later if not
     if [[ "${bootstrap}" == "" ]]; then
-        export bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
+        export bootstrap="https://galasa-ecosystem1.galasa.dev/api/bootstrap"
         info "No bootstrap supplied. Defaulting the --bootstrap to be ${bootstrap}"
     fi
 
@@ -78,8 +78,8 @@ if [[ "$CALLED_BY_MAIN" == "" ]]; then
     #-----------------------------------------------------------------------------------------
     # Constants
     #-----------------------------------------------------------------------------------------
-    export GALASA_TEST_NAME_SHORT="local.CoreLocalJava11Ubuntu"
-    export GALASA_TEST_NAME_LONG="dev.galasa.inttests.core.${GALASA_TEST_NAME_SHORT}"
+    export GALASA_TEST_NAME_SHORT="core.CoreManagerIVT"   
+    export GALASA_TEST_NAME_LONG="dev.galasa.ivts/dev.galasa.ivts.${GALASA_TEST_NAME_SHORT}" 
     export GALASA_TEST_RUN_GET_EXPECTED_SUMMARY_LINE_COUNT="4"
     export GALASA_TEST_RUN_GET_EXPECTED_DETAILS_LINE_COUNT="14"
     export GALASA_TEST_RUN_GET_EXPECTED_RAW_PIPE_COUNT="11"
@@ -836,7 +836,7 @@ function runs_get_check_raw_format_output_with_older_to_than_from_age {
 
 #--------------------------------------------------------------------------
 function runs_get_check_requestor_parameter {
-    requestor="Galasadelivery@ibm.com"
+    requestor="galasa-team"
     h2 "Performing runs get with details format providing a from age and requestor as $requestor..."
 
     cd ${BASEDIR}/temp

--- a/test-scripts/runs-tests.sh
+++ b/test-scripts/runs-tests.sh
@@ -192,7 +192,7 @@ function runs_download_check_folder_names_during_test_run {
     --bootstrap ${bootstrap} \
     --portfolio portfolio.yaml \
     --throttle 1 \
-    --poll 10 \
+    --poll 1 \
     --progress 1 \
     --noexitcodeontestfailures \
     --log ${log_file}"


### PR DESCRIPTION
## Why?

We temporarily need to stop testing on the prod1 service.

This set of changes points the CLI testing scripts at the ecosystem1 service instead of prod1. This is now possible since we have replicated the CoreManagerIVT and made it available on ecosystem1 with a new test stream.

However, there is no need to move back to prod1 even once we are told we can. This has removed the need to call into Tekton then come back to GH Actions again.

**Note:** the function in the runs testing script to test `runs reset` has been temporarily commented out as the CoreManagerIVT we are now running on ecosystem1 is too fast and doesn't give a sufficient time window to reset it. Mike suggests creating a new test case that simply has a sleep for this purpose so we can test runs reset. 