### PR TITLE
Add initial workaround to find lost runs in the RAS before marking them as lost

### DIFF
--- a/pkg/runs/runTypes.go
+++ b/pkg/runs/runTypes.go
@@ -20,6 +20,7 @@ type TestRun struct {
 	GherkinUrl     string            `yaml:"gherkin"`
 	GherkinFeature string            `yaml:"feature"`
 	Group          string            `yaml:"group" json:"group"`
+	RunId          string            `yaml:"runId,omitempty" json:"runId,omitempty"`
 }
 
 type TestMethod struct {

--- a/pkg/runs/submitter.go
+++ b/pkg/runs/submitter.go
@@ -364,7 +364,7 @@ func (submitter *Submitter) submitRun(
 	return readyRuns, err
 }
 
-func updateSubmittedRunIds(
+func (submitter *Submitter) updateSubmittedRunIds(
 	submittedRuns map[string]*TestRun,
 	launchedRuns *galasaapi.TestRuns,
 ) {
@@ -394,7 +394,7 @@ func (submitter *Submitter) runsFetchCurrentStatus(
 	}
 
 	// Launched runs will now have run IDs, so record the run IDs for the submitted runs
-	updateSubmittedRunIds(submittedRuns, currentGroup)
+	submitter.updateSubmittedRunIds(submittedRuns, currentGroup)
 
 	// a copy to find lost runs
 	checkRuns := DeepClone(submittedRuns)


### PR DESCRIPTION
## Why?
See story https://github.com/galasa-dev/projectmanagement/issues/2167