### PR TITLE
galasactl can launch tests on old service without a submission id being set.

### DIFF
--- a/pkg/runs/submitter.go
+++ b/pkg/runs/submitter.go
@@ -348,7 +348,9 @@ func (submitter *Submitter) submitRun(
 			if err == nil {
 				submittedRun := resultGroup.GetRuns()[0]
 				nextRun.Group = *submittedRun.Group
-				nextRun.SubmissionId = *submittedRun.SubmissionId
+				if submittedRun.SubmissionId != nil {
+					nextRun.SubmissionId = *submittedRun.SubmissionId
+				}
 				nextRun.Name = *submittedRun.Name
 
 				submittedRuns[nextRun.Name] = &nextRun


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Try running the latest galasactl against a system which doesn't set the submission id, or return it in the response payload to the launch request over REST.

It panics with a null pointer exception. Because the submission ID wasn't set.

Added an 'if' so that it's more tolerant. This would be the case if someone uses the galasactl tool to launch tests on an older non-0.40.0 system.

