### PR TITLE
galasactl should not set submission id - it should come from the server or remain blank

### DIFF
--- a/pkg/launcher/jvmLauncher.go
+++ b/pkg/launcher/jvmLauncher.go
@@ -12,8 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/uuid"
-
 	"github.com/galasa-dev/cli/pkg/api"
 	"github.com/galasa-dev/cli/pkg/embedded"
 	galasaErrors "github.com/galasa-dev/cli/pkg/errors"
@@ -303,7 +301,8 @@ func (launcher *JvmLauncher) SubmitTestRun(
 								localTest.testRun.SetTrace(isTraceEnabled)
 								localTest.testRun.SetType(requestType)
 								localTest.testRun.SetName(localTest.runId)
-								localTest.testRun.SetSubmissionId(uuid.New().String())
+
+								localTest.testRun.SetSubmissionId("")
 
 								// The test run we started can be returned to the submitter.
 								testRuns.Runs = append(testRuns.Runs, *localTest.testRun)


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Galasa client should not set the submission id itself, but should only get one from a server-side response.